### PR TITLE
Change macOS name in installation documentation

### DIFF
--- a/docs/basic/install.rst
+++ b/docs/basic/install.rst
@@ -30,7 +30,7 @@ some cases though:
 
 - you need a glibc-based Linux distribution: the ``binary`` package doesn't
   work on Alpine Linux for instance;
-- you have a newly released Python or Mac Os X version for which binary
+- you have a newly released Python or macOS version for which binary
   packages are not ready yet.
 
 In these case you should proceed to a :ref:`local installation


### PR DESCRIPTION
See [the wiki](https://en.wikipedia.org/wiki/MacOS). The naming timeline so far: Mac OS X → OS X → macOS.