### PR TITLE
Improve async story in the test on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__/
 /docs/.venv/
 *.html
 /psycopg_binary/
+.vscode

--- a/psycopg/psycopg/connection_async.py
+++ b/psycopg/psycopg/connection_async.py
@@ -6,6 +6,7 @@ psycopg async connection objects
 
 import asyncio
 import logging
+import sys
 from types import TracebackType
 from typing import Any, AsyncIterator, Dict, Optional, Type, Union
 from typing import cast, overload, TYPE_CHECKING
@@ -90,6 +91,18 @@ class AsyncConnection(BaseConnection[Row]):
         row_factory: Optional[AsyncRowFactory[Row]] = None,
         **kwargs: Any,
     ) -> "AsyncConnection[Any]":
+
+        if sys.platform == "win32":
+            loop = asyncio.get_running_loop()
+            if isinstance(loop, asyncio.ProactorEventLoop):
+                raise e.InterfaceError(
+                    "psycopg does not currently support running in async mode "
+                    "on windows on the 'ProactorEventLoop'. "
+                    "Please ensure that a compatible event loop is used, like "
+                    "by setting ``asyncio.set_event_loop_policy`` to "
+                    "WindowsSelectorEventLoopPolicy"
+                )
+
         params = await cls._get_connection_params(conninfo, **kwargs)
         conninfo = make_conninfo(**params)
 

--- a/psycopg/psycopg/connection_async.py
+++ b/psycopg/psycopg/connection_async.py
@@ -93,7 +93,10 @@ class AsyncConnection(BaseConnection[Row]):
     ) -> "AsyncConnection[Any]":
 
         if sys.platform == "win32":
-            loop = asyncio.get_running_loop()
+            if sys.version_info < (3, 7):
+                loop = asyncio.get_event_loop()
+            else:
+                loop = asyncio.get_running_loop()
             if isinstance(loop, asyncio.ProactorEventLoop):
                 raise e.InterfaceError(
                     "psycopg does not currently support running in async mode "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,8 +87,16 @@ def event_loop(request):
     else:
         assert loop == "default"
 
+    loop = None
     if sys.platform == "win32":
-        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-    loop = asyncio.get_event_loop_policy().new_event_loop()
+        if sys.version_info < (3, 7):
+            loop = asyncio.SelectorEventLoop()
+            asyncio.set_event_loop(loop)
+        else:
+            asyncio.set_event_loop_policy(
+                asyncio.WindowsSelectorEventLoopPolicy()
+            )
+    if not loop:
+        loop = asyncio.get_event_loop_policy().new_event_loop()
     yield loop
     loop.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,13 +58,6 @@ def pytest_report_header(config):
     return [f"asyncio loop: {loop}"]
 
 
-def pytest_runtest_setup(item):
-    # Skip asyncio tests on Windows: they just don't seem to work
-    if sys.platform == "win32":
-        for mark in item.iter_markers(name="asyncio"):
-            pytest.skip(f"cannot run asyncio tests on {sys.platform}")
-
-
 @pytest.fixture
 def retries(request):
     """Retry a block in a test a few times before giving up."""
@@ -83,6 +76,8 @@ def retries(request):
 @pytest.fixture
 def event_loop(request):
     """Return the event loop to test asyncio-marked tests."""
+    # pytest-asyncio reset the the loop config after each test, so set
+    # set them each time
 
     loop = request.config.getoption("--loop")
     if loop == "uvloop":
@@ -92,6 +87,8 @@ def event_loop(request):
     else:
         assert loop == "default"
 
+    if sys.platform == "win32":
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
     loop = asyncio.get_event_loop_policy().new_event_loop()
     yield loop
     loop.close()


### PR DESCRIPTION
Make test work under windows, by requiring a compatible event loop.

Also raise an exception when trying to use an async connection with an incompatible event loop on windows.
I'm not sure about what the most appropriate exception is in this case, InterfaceError?

- TODO: test of the error

Fixes #76
