### PR TITLE
Adjust test on PGconn.tty for libpq 14

### DIFF
--- a/tests/pq/test_pgconn.py
+++ b/tests/pq/test_pgconn.py
@@ -224,12 +224,19 @@ def test_port(pgconn):
         pgconn.port
 
 
+@pytest.mark.libpq("< 14")
 def test_tty(pgconn):
     tty = [o.val for o in pgconn.info if o.keyword == b"tty"][0]
     assert pgconn.tty == tty
     pgconn.finish()
     with pytest.raises(psycopg.OperationalError):
         pgconn.tty
+
+
+@pytest.mark.libpq(">= 14")
+def test_tty_noop(pgconn):
+    assert not any(o.val for o in pgconn.info if o.keyword == b"tty")
+    assert pgconn.tty == b""
 
 
 def test_transaction_status(pgconn):


### PR DESCRIPTION
Quoting https://www.postgresql.org/docs/14/libpq-status.html:

>  [PQtty] no longer does anything, but it remains for backwards
>  compatibility. The function always return an empty string.

Or perhaps we should drop 'tty' property (and binding), since this is at
least obsolete since PostgreSQL 7.4?