### PR TITLE
Add missing ExecStatusType enum values for pipeline mode

### DIFF
--- a/psycopg_c/psycopg_c/pq/libpq.pxd
+++ b/psycopg_c/psycopg_c/pq/libpq.pxd
@@ -95,6 +95,8 @@ cdef extern from "libpq-fe.h":
         PGRES_FATAL_ERROR
         PGRES_COPY_BOTH
         PGRES_SINGLE_TUPLE
+        PGRES_PIPELINE_SYNC
+        PGRES_PIPELINE_ABORT
 
     # 33.1. Database Connection Control Functions
     PGconn *PQconnectdb(const char *conninfo)


### PR DESCRIPTION
Follow-up 515e246b5f933ba93fdde93a03287c6940dbf85b; these values were
only added for the Python definition of the enum.

Related to #74. 