### PR TITLE
Explicitly disallow some mypy checks for tests/ (to improve developer experience)

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -13,3 +13,7 @@ ignore_missing_imports = True
 
 [mypy-shapely.*]
 ignore_missing_imports = True
+
+[mypy-tests.*]
+disallow_untyped_defs = False
+disallow_untyped_calls = False


### PR DESCRIPTION
When running mypy on the tests/ directory, the top-level mypy
configuration is used and strict mode is thus enforced whereas tests
code is not typed. As mypy might be run in people editors by default,
the current situation makes this uncomfortable.

By disabling obvious checks, we get a nicer developer experience. A more
straightforward option would be to set 'check_untyped_defs = False', but
this would prevent valid code to be checked, so the current proposal is
a trade-off.