### PR TITLE
Pipeline mode

### DIFF
--- a/docs/api/connections.rst
+++ b/docs/api/connections.rst
@@ -264,6 +264,8 @@ The `!Connection` class
 
     .. automethod:: fileno
 
+    .. automethod:: pipeline
+
 
 The `!AsyncConnection` class
 ----------------------------
@@ -328,6 +330,15 @@ The `!AsyncConnection` class
     .. automethod:: set_isolation_level
     .. automethod:: set_read_only
     .. automethod:: set_deferrable
+
+    .. automethod:: pipeline
+
+        .. note::
+
+            It must be called as::
+
+                async with conn.pipeline() as pipeline:
+                    ...
 
 
 Connection support objects
@@ -474,3 +485,11 @@ Connection support objects
       the `Transaction` *tx* (returned by a statement such as :samp:`with
       conn.transaction() as {tx}:` and all the blocks nested within. The
       program will continue after the *tx* block.
+
+.. autoclass:: Pipeline
+
+   .. automethod:: sync
+
+.. autoclass:: AsyncPipeline
+
+   .. automethod:: sync

--- a/psycopg/psycopg/__init__.py
+++ b/psycopg/psycopg/__init__.py
@@ -17,11 +17,11 @@ from .errors import DataError, OperationalError, IntegrityError
 from .errors import InternalError, ProgrammingError, NotSupportedError
 from ._column import Column
 from .conninfo import ConnectionInfo
-from .connection import BaseConnection, Connection, Notify
+from .connection import BaseConnection, Connection, Notify, Pipeline
 from .transaction import Rollback, Transaction, AsyncTransaction
 from .cursor_async import AsyncCursor
 from .server_cursor import AsyncServerCursor, ServerCursor
-from .connection_async import AsyncConnection
+from .connection_async import AsyncConnection, AsyncPipeline
 
 from . import dbapi20
 from .dbapi20 import BINARY, DATETIME, NUMBER, ROWID, STRING
@@ -61,6 +61,7 @@ __all__ = [
     "AsyncConnection",
     "AsyncCopy",
     "AsyncCursor",
+    "AsyncPipeline",
     "AsyncServerCursor",
     "AsyncTransaction",
     "BaseConnection",
@@ -70,6 +71,7 @@ __all__ = [
     "Cursor",
     "IsolationLevel",
     "Notify",
+    "Pipeline",
     "Rollback",
     "ServerCursor",
     "Transaction",

--- a/psycopg/psycopg/connection.py
+++ b/psycopg/psycopg/connection.py
@@ -52,6 +52,7 @@ if _psycopg:
     connect = _psycopg.connect
     execute = _psycopg.execute
     send = _psycopg.send
+    fetch_many = _psycopg.fetch_many
 
 else:
     from . import generators
@@ -59,6 +60,7 @@ else:
     connect = generators.connect
     execute = generators.execute
     send = generators.send
+    fetch_many = generators.fetch_many
 
 
 class Notify(NamedTuple):
@@ -528,6 +530,11 @@ class BaseConnection(Generic[Row]):
         cmd = self._prepared.clear()
         if cmd:
             yield from self._exec_command(cmd)
+
+    def _fetch_many_gen(self) -> PQGen[List["PGresult"]]:
+        """Return results of one query from the database."""
+        results = yield from fetch_many(self.pgconn)
+        return results
 
 
 class Connection(BaseConnection[Row]):

--- a/psycopg/psycopg/errors.py
+++ b/psycopg/psycopg/errors.py
@@ -298,6 +298,8 @@ def _class_for_state(sqlstate: str) -> Type[Error]:
 
 
 def get_base_exception(sqlstate: str) -> Type[Error]:
+    if not sqlstate:
+        return DatabaseError
     return (
         _base_exc_map.get(sqlstate[:2])
         or _base_exc_map.get(sqlstate[0])

--- a/psycopg/psycopg/generators.py
+++ b/psycopg/psycopg/generators.py
@@ -116,6 +116,14 @@ def fetch_many(pgconn: PGconn) -> PQGen[List[PGresult]]:
             break
 
         results.append(res)
+
+        if res.status == ExecStatus.PIPELINE_SYNC:
+            # Return any PIPELINE_SYNC result separately, as they are not
+            # followed by a NULL in contrast with other kind of results.
+            # Though, such a result should come first while fetching.
+            assert len(results) == 1
+            break
+
         if res.status in _copy_statuses:
             # After entering copy mode the libpq will create a phony result
             # for every request so let's break the endless loop.

--- a/psycopg/psycopg/generators.py
+++ b/psycopg/psycopg/generators.py
@@ -103,10 +103,11 @@ def fetch_many(pgconn: PGconn) -> PQGen[List[PGresult]]:
     Generator retrieving results from the database without blocking.
 
     The query must have already been sent to the server, so pgconn.flush() has
-    already returned 0.
+    already returned 0 or pgconn.pipeline_sync() been successfully called.
 
     Return the list of results returned by the database (whether success
-    or error).
+    or error); this includes PIPELINE_SYNC results, when the connection is in
+    pipeline mode.
     """
     results: List[PGresult] = []
     while 1:
@@ -128,7 +129,7 @@ def fetch(pgconn: PGconn) -> PQGen[Optional[PGresult]]:
     Generator retrieving a single result from the database without blocking.
 
     The query must have already been sent to the server, so pgconn.flush() has
-    already returned 0.
+    already returned 0 or pgconn.pipeline_sync() been successfully called.
 
     Return a result from the database (whether success or error).
     """

--- a/psycopg/psycopg/server_cursor.py
+++ b/psycopg/psycopg/server_cursor.py
@@ -108,6 +108,7 @@ class ServerCursorHelper(Generic[ConnectionType, Row]):
                 "SELECT 1 FROM pg_catalog.pg_cursors WHERE name = {}"
             ).format(sql.Literal(self.name))
             res = yield from cur._conn._exec_command(query)
+            assert res is not None, "pipeline mode not supported"  # TODO
             if res.ntuples == 0:
                 return
 
@@ -133,6 +134,7 @@ class ServerCursorHelper(Generic[ConnectionType, Row]):
         res = yield from cur._conn._exec_command(
             query, result_format=self.format
         )
+        assert res is not None, "pipeline mode not supported"  # TODO
 
         cur.pgresult = res
         cur._tx.set_pgresult(res, set_loaders=False)

--- a/psycopg/psycopg/transaction.py
+++ b/psycopg/psycopg/transaction.py
@@ -78,7 +78,7 @@ class BaseTransaction(Generic[ConnectionType]):
         sp = f"{self.savepoint_name!r} " if self.savepoint_name else ""
         return f"<{cls} {sp}({status}) {info} at 0x{id(self):x}>"
 
-    def _enter_gen(self) -> PQGen[PGresult]:
+    def _enter_gen(self) -> PQGen[Optional[PGresult]]:
         if self._entered:
             raise TypeError("transaction blocks can be used only once")
         self._entered = True
@@ -124,7 +124,7 @@ class BaseTransaction(Generic[ConnectionType]):
         else:
             return (yield from self._rollback_gen(exc_val))
 
-    def _commit_gen(self) -> PQGen[PGresult]:
+    def _commit_gen(self) -> PQGen[Optional[PGresult]]:
         assert self._conn._savepoints[-1] == self._savepoint_name
         self._conn._savepoints.pop()
         self._exited = True

--- a/psycopg_c/psycopg_c/_psycopg/generators.pyx
+++ b/psycopg_c/psycopg_c/_psycopg/generators.pyx
@@ -124,6 +124,14 @@ def fetch_many(pq.PGconn pgconn) -> PQGen[List[PGresult]]:
         pgres = result._pgresult_ptr
 
         status = libpq.PQresultStatus(pgres)
+
+        if status == libpq.PGRES_PIPELINE_SYNC:
+            # Return any PIPELINE_SYNC result separately, as they are not
+            # followed by a NULL in contrast with other kind of results.
+            # Though, such a result should come first while fetching.
+            assert len(results) == 1
+            break
+
         if status in (libpq.PGRES_COPY_IN, libpq.PGRES_COPY_OUT, libpq.PGRES_COPY_BOTH):
             # After entering copy mode the libpq will create a phony result
             # for every request so let's break the endless loop.

--- a/psycopg_c/psycopg_c/_psycopg/generators.pyx
+++ b/psycopg_c/psycopg_c/_psycopg/generators.pyx
@@ -106,7 +106,7 @@ def fetch_many(pq.PGconn pgconn) -> PQGen[List[PGresult]]:
     Generator retrieving results from the database without blocking.
 
     The query must have already been sent to the server, so pgconn.flush() has
-    already returned 0.
+    already returned 0 or pgconn.pipeline_sync() been successfully called.
 
     Return the list of results returned by the database (whether success
     or error).
@@ -137,7 +137,7 @@ def fetch(pq.PGconn pgconn) -> PQGen[Optional[PGresult]]:
     Generator retrieving a single result from the database without blocking.
 
     The query must have already been sent to the server, so pgconn.flush() has
-    already returned 0.
+    already returned 0 or pgconn.pipeline_sync() been successfully called.
 
     Return a result from the database (whether success or error).
     """

--- a/psycopg_c/psycopg_c/pq/libpq.pxd
+++ b/psycopg_c/psycopg_c/pq/libpq.pxd
@@ -294,6 +294,8 @@ cdef extern from *:
 #endif
 
 #if PG_VERSION_NUM < 140000
+int PGRES_PIPELINE_SYNC = 10;
+int PGRES_PIPELINE_ABORTED = 11;
 typedef enum {
     PQ_PIPELINE_OFF,
     PQ_PIPELINE_ON,

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,7 +1,16 @@
+import logging
+
 import pytest
 
 import psycopg
 from psycopg import pq
+from psycopg.errors import UndefinedTable
+
+
+@pytest.fixture(autouse=True)
+def debug_logs(caplog):
+    caplog.set_level(logging.DEBUG, logger="psycopg")
+
 
 pytestmark = pytest.mark.libpq(">=14")
 
@@ -13,8 +22,8 @@ def test_pipeline_status(conn):
         assert conn._pipeline_mode
         p.sync()
 
-        (r,) = conn.wait(conn._fetch_many_gen())
-        assert r.status == pq.ExecStatus.PIPELINE_SYNC
+        # PQpipelineSync
+        assert len(p) == 1
 
     assert p.status() == pq.PipelineStatus.OFF
     assert not conn._pipeline_mode
@@ -22,10 +31,14 @@ def test_pipeline_status(conn):
 
 def test_pipeline_busy(conn):
     with pytest.raises(
-        psycopg.OperationalError, match="cannot exit pipeline mode while busy"
+        psycopg.ProgrammingError, match="has unfetched results in the pipeline"
     ):
-        with conn.cursor() as cur, conn.pipeline():
+        with conn.cursor() as cur, conn.pipeline() as pipeline:
             cur.execute("select 1")
+            pipeline.sync()
+
+            # PQsendQuery[BEGIN], PQsendQuery, PQpipelineSync
+            assert len(pipeline) == 3
 
 
 def test_pipeline(conn):
@@ -34,25 +47,25 @@ def test_pipeline(conn):
         c2 = conn.cursor()
         c1.execute("select 1")
         pipeline.sync()
+        c1.execute("select 11")
         c2.execute("select 2")
         pipeline.sync()
 
-        (r,) = conn.wait(conn._fetch_many_gen())
-        assert r.status == pq.ExecStatus.COMMAND_OK  # BEGIN
+        # PQsendQuery[BEGIN], PQsendQuery(3), PQpipelineSync(2)
+        assert len(pipeline) == 6
 
-        (r,) = conn.wait(conn._fetch_many_gen())
-        assert r.status == pq.ExecStatus.TUPLES_OK
-        assert r.get_value(0, 0) == b"1"
+        (r1,) = c1.fetchone()
+        assert r1 == 1
+        assert len(pipeline) == 4  # -COMMAND_OK, -TUPLES_OK
 
-        (r,) = conn.wait(conn._fetch_many_gen())
-        assert r.status == pq.ExecStatus.PIPELINE_SYNC
+        (r2,) = c2.fetchone()
+        assert r2 == 2
+        assert len(pipeline) == 1  # -PIPELINE_SYNC, -TUPLES_OK(2)
 
-        (r,) = conn.wait(conn._fetch_many_gen())
-        assert r.status == pq.ExecStatus.TUPLES_OK
-        assert r.get_value(0, 0) == b"2"
-
-        (r,) = conn.wait(conn._fetch_many_gen())
-        assert r.status == pq.ExecStatus.PIPELINE_SYNC
+        (r11,) = c1.fetchone()
+        assert r11 == 11
+        # Same as before, since results have already been fetched.
+        assert len(pipeline) == 1
 
 
 def test_autocommit(conn):
@@ -61,12 +74,11 @@ def test_autocommit(conn):
         c.execute("select 1")
         pipeline.sync()
 
-        (r,) = conn.wait(conn._fetch_many_gen())
-        assert r.status == pq.ExecStatus.TUPLES_OK
-        assert r.get_value(0, 0) == b"1"
+        # PQsendQuery, PQpipelineSync
+        assert len(pipeline) == 2
 
-        (r,) = conn.wait(conn._fetch_many_gen())
-        assert r.status == pq.ExecStatus.PIPELINE_SYNC
+        (r,) = c.fetchone()
+        assert r == 1
 
 
 def test_pipeline_aborted(conn):
@@ -80,33 +92,28 @@ def test_pipeline_aborted(conn):
         c.execute("select 2")
         pipeline.sync()
 
-        (r,) = conn.wait(conn._fetch_many_gen())
-        assert r.status == pq.ExecStatus.TUPLES_OK
-        assert r.get_value(0, 0) == b"1"
+        # PQsendQuery(4), PQpipelineSync(3)
+        assert len(pipeline) == 7
 
-        (r,) = conn.wait(conn._fetch_many_gen())
-        assert r.status == pq.ExecStatus.PIPELINE_SYNC
+        (r,) = c.fetchone()
+        assert r == 1
+        assert len(pipeline) == 6
 
-        (r,) = conn.wait(conn._fetch_many_gen())
-        assert r.status == pq.ExecStatus.FATAL_ERROR
-
+        with pytest.raises(UndefinedTable):
+            c.fetchone()
         assert pipeline.status() == pq.PipelineStatus.ABORTED
+        assert len(pipeline) == 4  # -PIPELINE_SYNC, -TUPLES_OK
 
-        (r,) = conn.wait(conn._fetch_many_gen())
-        assert r.status == pq.ExecStatus.PIPELINE_ABORTED
-
+        with pytest.raises(psycopg.OperationalError, match="pipeline aborted"):
+            c.fetchone()
         assert pipeline.status() == pq.PipelineStatus.ABORTED
+        assert len(pipeline) == 3  # -TUPLES_OK
 
-        (r,) = conn.wait(conn._fetch_many_gen())
-        assert r.status == pq.ExecStatus.PIPELINE_SYNC
+        (r,) = c.fetchone()
+        assert r == 2
 
-        (r,) = conn.wait(conn._fetch_many_gen())
+        assert len(pipeline) == 1  # -PIPELINE_SYNC, -TUPLES_OK
         assert pipeline.status() == pq.PipelineStatus.ON
-        assert r.status == pq.ExecStatus.TUPLES_OK
-        assert r.get_value(0, 0) == b"2"
-
-        (r,) = conn.wait(conn._fetch_many_gen())
-        assert r.status == pq.ExecStatus.PIPELINE_SYNC
 
 
 def test_prepared(conn):
@@ -116,19 +123,16 @@ def test_prepared(conn):
         c.execute("select count(*) from pg_prepared_statements")
         pipeline.sync()
 
-        (r,) = conn.wait(conn._fetch_many_gen())
-        assert r.status == pq.ExecStatus.COMMAND_OK  # PREPARE
+        # PQsendPrepare, PQsendQuery(2), PQpipelineSync
+        assert len(pipeline) == 4
 
-        (r,) = conn.wait(conn._fetch_many_gen())
-        assert r.status == pq.ExecStatus.TUPLES_OK
-        assert r.get_value(0, 0) == b"10"
+        (r,) = c.fetchone()
+        assert r == 10
+        assert len(pipeline) == 2  # -COMMAND_OK, -TUPLES_OK
 
-        (r,) = conn.wait(conn._fetch_many_gen())
-        assert r.status == pq.ExecStatus.TUPLES_OK
-        assert r.get_value(0, 0) == b"1"
-
-        (r,) = conn.wait(conn._fetch_many_gen())
-        assert r.status == pq.ExecStatus.PIPELINE_SYNC
+        (r,) = c.fetchone()
+        assert r == 1
+        assert len(pipeline) == 1  # -TUPLES_OK
 
 
 @pytest.mark.xfail
@@ -136,36 +140,25 @@ def test_auto_prepare(conn):
     # Auto prepare does not work because cache maintainance requires access to
     # results at the moment.
     conn.autocommit = True
-    with conn.pipeline() as pipeline:
+    with conn.pipeline() as pipeline, conn.cursor() as cur:
         for i in range(10):
-            conn.execute("select count(*) from pg_prepared_statements")
+            cur.execute("select count(*) from pg_prepared_statements")
         pipeline.sync()
 
         for v in [0] * 5 + [1] * 5:
-            (r,) = conn.wait(conn._fetch_many_gen())
-            assert r.status == pq.ExecStatus.TUPLES_OK
-            rv = int(r.get_value(0, 0).decode())
-            assert rv == v
-
-        (r,) = conn.wait(conn._fetch_many_gen())
-        assert r.status == pq.ExecStatus.PIPELINE_SYNC
+            (r,) = cur.fetchone()
+            assert r == v
 
 
 def test_transaction(conn):
     with conn.pipeline() as pipeline:
         with conn.transaction():
-            conn.execute("select 'tx'")
+            cur = conn.execute("select 'tx'")
         pipeline.sync()
 
-        (r,) = conn.wait(conn._fetch_many_gen())
-        assert r.status == pq.ExecStatus.COMMAND_OK  # BEGIN
+        # PQsendQuery[BEGIN], PQsendQuery, PQsendQuery[COMMIT], PQpipelineSync
+        assert len(pipeline) == 4
 
-        (r,) = conn.wait(conn._fetch_many_gen())
-        assert r.status == pq.ExecStatus.TUPLES_OK
-        assert r.get_value(0, 0) == b"tx"
-
-        (r,) = conn.wait(conn._fetch_many_gen())
-        assert r.status == pq.ExecStatus.COMMAND_OK  # COMMIT
-
-        (r,) = conn.wait(conn._fetch_many_gen())
-        assert r.status == pq.ExecStatus.PIPELINE_SYNC
+        (r,) = cur.fetchone()
+        assert r == "tx"
+        assert len(pipeline) == 2  # -COMMAND_OK, -TUPLES_OK

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,19 @@
+import pytest
+
+from psycopg import pq
+
+pytestmark = pytest.mark.libpq(">=14")
+
+
+def test_pipeline_status(conn):
+    assert not conn._pipeline_mode
+    with conn.pipeline() as p:
+        assert p.status() == pq.PipelineStatus.ON
+        assert conn._pipeline_mode
+        p.sync()
+        r = conn.pgconn.get_result()
+        assert r.status == pq.ExecStatus.PIPELINE_SYNC
+        r = conn.pgconn.get_result()
+        assert r is None
+    assert p.status() == pq.PipelineStatus.OFF
+    assert not conn._pipeline_mode

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,5 +1,6 @@
 import pytest
 
+import psycopg
 from psycopg import pq
 
 pytestmark = pytest.mark.libpq(">=14")
@@ -17,3 +18,176 @@ def test_pipeline_status(conn):
         assert r is None
     assert p.status() == pq.PipelineStatus.OFF
     assert not conn._pipeline_mode
+
+
+def test_pipeline_busy(conn):
+    with pytest.raises(
+        psycopg.OperationalError, match="cannot exit pipeline mode while busy"
+    ):
+        with conn.cursor() as cur, conn.pipeline():
+            cur.execute("select 1")
+
+
+def test_pipeline(conn):
+    pgconn = conn.pgconn
+    with conn.pipeline() as pipeline:
+        c1 = conn.cursor()
+        c2 = conn.cursor()
+        c1.execute("select 1")
+        pipeline.sync()
+        c2.execute("select 2")
+        pipeline.sync()
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.COMMAND_OK  # BEGIN
+        assert pgconn.get_result() is None
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.TUPLES_OK
+        assert r.get_value(0, 0) == b"1"
+        assert pgconn.get_result() is None
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.PIPELINE_SYNC
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.TUPLES_OK
+        assert r.get_value(0, 0) == b"2"
+        assert pgconn.get_result() is None
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.PIPELINE_SYNC
+
+
+def test_autocommit(conn):
+    conn.autocommit = True
+    pgconn = conn.pgconn
+    with conn.pipeline() as pipeline, conn.cursor() as c:
+        c.execute("select 1")
+        pipeline.sync()
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.TUPLES_OK
+        assert r.get_value(0, 0) == b"1"
+        assert pgconn.get_result() is None
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.PIPELINE_SYNC
+
+
+def test_pipeline_aborted(conn):
+    conn.autocommit = True
+    pgconn = conn.pgconn
+    with conn.pipeline() as pipeline, conn.cursor() as c:
+        c.execute("select 1")
+        pipeline.sync()
+        c.execute("select * from doesnotexist")
+        c.execute("select 'aborted'")
+        pipeline.sync()
+        c.execute("select 2")
+        pipeline.sync()
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.TUPLES_OK
+        assert r.get_value(0, 0) == b"1"
+        assert pgconn.get_result() is None
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.PIPELINE_SYNC
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.FATAL_ERROR
+        assert pgconn.get_result() is None
+
+        assert pipeline.status() == pq.PipelineStatus.ABORTED
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.PIPELINE_ABORTED
+        assert pgconn.get_result() is None
+
+        assert pipeline.status() == pq.PipelineStatus.ABORTED
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.PIPELINE_SYNC
+
+        assert pipeline.status() == pq.PipelineStatus.ON
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.TUPLES_OK
+        assert r.get_value(0, 0) == b"2"
+        assert pgconn.get_result() is None
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.PIPELINE_SYNC
+
+
+def test_prepared(conn):
+    conn.autocommit = True
+    pgconn = conn.pgconn
+    with conn.pipeline() as pipeline, conn.cursor() as c:
+        c.execute("select %s::int", [10], prepare=True)
+        c.execute("select count(*) from pg_prepared_statements")
+        pipeline.sync()
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.COMMAND_OK  # PREPARE
+        assert pgconn.get_result() is None
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.TUPLES_OK
+        assert r.get_value(0, 0) == b"10"
+        assert pgconn.get_result() is None
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.TUPLES_OK
+        assert r.get_value(0, 0) == b"1"
+        assert pgconn.get_result() is None
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.PIPELINE_SYNC
+
+
+@pytest.mark.xfail
+def test_auto_prepare(conn):
+    # Auto prepare does not work because cache maintainance requires access to
+    # results at the moment.
+    conn.autocommit = True
+    pgconn = conn.pgconn
+    with conn.pipeline() as pipeline:
+        for i in range(10):
+            conn.execute("select count(*) from pg_prepared_statements")
+        pipeline.sync()
+
+        for i, v in zip(range(10), [0] * 5 + [1] * 5):
+            r = pgconn.get_result()
+            assert r.status == pq.ExecStatus.TUPLES_OK
+            rv = int(r.get_value(0, 0).decode())
+            assert rv == v
+            assert pgconn.get_result() is None
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.PIPELINE_SYNC
+
+
+def test_transaction(conn):
+    pgconn = conn.pgconn
+    with conn.pipeline() as pipeline:
+        with conn.transaction():
+            conn.execute("select 'tx'")
+        pipeline.sync()
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.COMMAND_OK  # BEGIN
+        assert pgconn.get_result() is None
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.TUPLES_OK
+        assert r.get_value(0, 0) == b"tx"
+        assert pgconn.get_result() is None
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.COMMAND_OK  # COMMIT
+        assert pgconn.get_result() is None
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.PIPELINE_SYNC

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -44,12 +44,12 @@ def test_pipeline(conn):
         assert r.status == pq.ExecStatus.TUPLES_OK
         assert r.get_value(0, 0) == b"1"
 
-        (rs, rto) = conn.wait(conn._fetch_many_gen())
+        (r,) = conn.wait(conn._fetch_many_gen())
+        assert r.status == pq.ExecStatus.PIPELINE_SYNC
 
-        assert rs.status == pq.ExecStatus.PIPELINE_SYNC
-
-        assert rto.status == pq.ExecStatus.TUPLES_OK
-        assert rto.get_value(0, 0) == b"2"
+        (r,) = conn.wait(conn._fetch_many_gen())
+        assert r.status == pq.ExecStatus.TUPLES_OK
+        assert r.get_value(0, 0) == b"2"
 
         (r,) = conn.wait(conn._fetch_many_gen())
         assert r.status == pq.ExecStatus.PIPELINE_SYNC
@@ -84,11 +84,11 @@ def test_pipeline_aborted(conn):
         assert r.status == pq.ExecStatus.TUPLES_OK
         assert r.get_value(0, 0) == b"1"
 
-        (rs, rfe) = conn.wait(conn._fetch_many_gen())
+        (r,) = conn.wait(conn._fetch_many_gen())
+        assert r.status == pq.ExecStatus.PIPELINE_SYNC
 
-        assert rs.status == pq.ExecStatus.PIPELINE_SYNC
-
-        assert rfe.status == pq.ExecStatus.FATAL_ERROR
+        (r,) = conn.wait(conn._fetch_many_gen())
+        assert r.status == pq.ExecStatus.FATAL_ERROR
 
         assert pipeline.status() == pq.PipelineStatus.ABORTED
 
@@ -97,14 +97,13 @@ def test_pipeline_aborted(conn):
 
         assert pipeline.status() == pq.PipelineStatus.ABORTED
 
-        (rs, rto) = conn.wait(conn._fetch_many_gen())
+        (r,) = conn.wait(conn._fetch_many_gen())
+        assert r.status == pq.ExecStatus.PIPELINE_SYNC
 
-        assert rs.status == pq.ExecStatus.PIPELINE_SYNC
-
+        (r,) = conn.wait(conn._fetch_many_gen())
         assert pipeline.status() == pq.PipelineStatus.ON
-
-        assert rto.status == pq.ExecStatus.TUPLES_OK
-        assert rto.get_value(0, 0) == b"2"
+        assert r.status == pq.ExecStatus.TUPLES_OK
+        assert r.get_value(0, 0) == b"2"
 
         (r,) = conn.wait(conn._fetch_many_gen())
         assert r.status == pq.ExecStatus.PIPELINE_SYNC

--- a/tests/test_pipeline_async.py
+++ b/tests/test_pipeline_async.py
@@ -15,10 +15,10 @@ async def test_pipeline_status(aconn):
         assert await p.status() == pq.PipelineStatus.ON
         assert aconn._pipeline_mode
         await p.sync()
-        r = aconn.pgconn.get_result()
+
+        (r,) = await aconn.wait(aconn._fetch_many_gen())
         assert r.status == pq.ExecStatus.PIPELINE_SYNC
-        r = aconn.pgconn.get_result()
-        assert r is None
+
     assert await p.status() == pq.PipelineStatus.OFF
     assert not aconn._pipeline_mode
 
@@ -32,7 +32,6 @@ async def test_pipeline_busy(aconn):
 
 
 async def test_pipeline(aconn):
-    pgconn = aconn.pgconn
     async with aconn.pipeline() as pipeline:
         c1 = aconn.cursor()
         c2 = aconn.cursor()
@@ -41,46 +40,40 @@ async def test_pipeline(aconn):
         await c2.execute("select 2")
         await pipeline.sync()
 
-        r = pgconn.get_result()
+        (r,) = await aconn.wait(aconn._fetch_many_gen())
         assert r.status == pq.ExecStatus.COMMAND_OK  # BEGIN
-        assert pgconn.get_result() is None
 
-        r = pgconn.get_result()
+        (r,) = await aconn.wait(aconn._fetch_many_gen())
         assert r.status == pq.ExecStatus.TUPLES_OK
         assert r.get_value(0, 0) == b"1"
-        assert pgconn.get_result() is None
 
-        r = pgconn.get_result()
-        assert r.status == pq.ExecStatus.PIPELINE_SYNC
+        (rs, rto) = await aconn.wait(aconn._fetch_many_gen())
 
-        r = pgconn.get_result()
-        assert r.status == pq.ExecStatus.TUPLES_OK
-        assert r.get_value(0, 0) == b"2"
-        assert pgconn.get_result() is None
+        assert rs.status == pq.ExecStatus.PIPELINE_SYNC
 
-        r = pgconn.get_result()
+        assert rto.status == pq.ExecStatus.TUPLES_OK
+        assert rto.get_value(0, 0) == b"2"
+
+        (r,) = await aconn.wait(aconn._fetch_many_gen())
         assert r.status == pq.ExecStatus.PIPELINE_SYNC
 
 
 async def test_autocommit(aconn):
     await aconn.set_autocommit(True)
-    pgconn = aconn.pgconn
     async with aconn.pipeline() as pipeline, aconn.cursor() as c:
         await c.execute("select 1")
         await pipeline.sync()
 
-        r = pgconn.get_result()
+        (r,) = await aconn.wait(aconn._fetch_many_gen())
         assert r.status == pq.ExecStatus.TUPLES_OK
         assert r.get_value(0, 0) == b"1"
-        assert pgconn.get_result() is None
 
-        r = pgconn.get_result()
+        (r,) = await aconn.wait(aconn._fetch_many_gen())
         assert r.status == pq.ExecStatus.PIPELINE_SYNC
 
 
 async def test_pipeline_aborted(aconn):
     await aconn.set_autocommit(True)
-    pgconn = aconn.pgconn
     async with aconn.pipeline() as pipeline, aconn.cursor() as c:
         await c.execute("select 1")
         await pipeline.sync()
@@ -90,63 +83,54 @@ async def test_pipeline_aborted(aconn):
         await c.execute("select 2")
         await pipeline.sync()
 
-        r = pgconn.get_result()
+        (r,) = await aconn.wait(aconn._fetch_many_gen())
         assert r.status == pq.ExecStatus.TUPLES_OK
         assert r.get_value(0, 0) == b"1"
-        assert pgconn.get_result() is None
 
-        r = pgconn.get_result()
-        assert r.status == pq.ExecStatus.PIPELINE_SYNC
+        (rs, rfe) = await aconn.wait(aconn._fetch_many_gen())
 
-        r = pgconn.get_result()
-        assert r.status == pq.ExecStatus.FATAL_ERROR
-        assert pgconn.get_result() is None
+        assert rs.status == pq.ExecStatus.PIPELINE_SYNC
+        assert rfe.status == pq.ExecStatus.FATAL_ERROR
 
         assert await pipeline.status() == pq.PipelineStatus.ABORTED
 
-        r = pgconn.get_result()
+        (r,) = await aconn.wait(aconn._fetch_many_gen())
         assert r.status == pq.ExecStatus.PIPELINE_ABORTED
-        assert pgconn.get_result() is None
 
         assert await pipeline.status() == pq.PipelineStatus.ABORTED
 
-        r = pgconn.get_result()
-        assert r.status == pq.ExecStatus.PIPELINE_SYNC
+        (rs, rto) = await aconn.wait(aconn._fetch_many_gen())
+
+        assert rs.status == pq.ExecStatus.PIPELINE_SYNC
 
         assert await pipeline.status() == pq.PipelineStatus.ON
 
-        r = pgconn.get_result()
-        assert r.status == pq.ExecStatus.TUPLES_OK
-        assert r.get_value(0, 0) == b"2"
-        assert pgconn.get_result() is None
+        assert rto.status == pq.ExecStatus.TUPLES_OK
+        assert rto.get_value(0, 0) == b"2"
 
-        r = pgconn.get_result()
+        (r,) = await aconn.wait(aconn._fetch_many_gen())
         assert r.status == pq.ExecStatus.PIPELINE_SYNC
 
 
 async def test_prepared(aconn):
     await aconn.set_autocommit(True)
-    pgconn = aconn.pgconn
     async with aconn.pipeline() as pipeline, aconn.cursor() as c:
         await c.execute("select %s::int", [10], prepare=True)
         await c.execute("select count(*) from pg_prepared_statements")
         await pipeline.sync()
 
-        r = pgconn.get_result()
+        (r,) = await aconn.wait(aconn._fetch_many_gen())
         assert r.status == pq.ExecStatus.COMMAND_OK  # PREPARE
-        assert pgconn.get_result() is None
 
-        r = pgconn.get_result()
+        (r,) = await aconn.wait(aconn._fetch_many_gen())
         assert r.status == pq.ExecStatus.TUPLES_OK
         assert r.get_value(0, 0) == b"10"
-        assert pgconn.get_result() is None
 
-        r = pgconn.get_result()
+        (r,) = await aconn.wait(aconn._fetch_many_gen())
         assert r.status == pq.ExecStatus.TUPLES_OK
         assert r.get_value(0, 0) == b"1"
-        assert pgconn.get_result() is None
 
-        r = pgconn.get_result()
+        (r,) = await aconn.wait(aconn._fetch_many_gen())
         assert r.status == pq.ExecStatus.PIPELINE_SYNC
 
 
@@ -155,42 +139,36 @@ async def test_auto_prepare(aconn):
     # Auto prepare does not work because cache maintainance requires access to
     # results at the moment.
     await aconn.set_autocommit(True)
-    pgconn = aconn.pgconn
     async with aconn.pipeline() as pipeline:
         for i in range(10):
             await aconn.execute("select count(*) from pg_prepared_statements")
         await pipeline.sync()
 
         for i, v in zip(range(10), [0] * 5 + [1] * 5):
-            r = pgconn.get_result()
+            (r,) = await aconn.wait(aconn._fetch_many_gen())
             assert r.status == pq.ExecStatus.TUPLES_OK
             rv = int(r.get_value(0, 0).decode())
             assert rv == v
-            assert pgconn.get_result() is None
 
-        r = pgconn.get_result()
+        (r,) = await aconn.wait(aconn._fetch_many_gen())
         assert r.status == pq.ExecStatus.PIPELINE_SYNC
 
 
 async def test_transaction(aconn):
-    pgconn = aconn.pgconn
     async with aconn.pipeline() as pipeline:
         async with aconn.transaction():
             await aconn.execute("select 'tx'")
         await pipeline.sync()
 
-        r = pgconn.get_result()
+        (r,) = await aconn.wait(aconn._fetch_many_gen())
         assert r.status == pq.ExecStatus.COMMAND_OK  # BEGIN
-        assert pgconn.get_result() is None
 
-        r = pgconn.get_result()
+        (r,) = await aconn.wait(aconn._fetch_many_gen())
         assert r.status == pq.ExecStatus.TUPLES_OK
         assert r.get_value(0, 0) == b"tx"
-        assert pgconn.get_result() is None
 
-        r = pgconn.get_result()
+        (r,) = await aconn.wait(aconn._fetch_many_gen())
         assert r.status == pq.ExecStatus.COMMAND_OK  # COMMIT
-        assert pgconn.get_result() is None
 
-        r = pgconn.get_result()
+        (r,) = await aconn.wait(aconn._fetch_many_gen())
         assert r.status == pq.ExecStatus.PIPELINE_SYNC

--- a/tests/test_pipeline_async.py
+++ b/tests/test_pipeline_async.py
@@ -47,12 +47,12 @@ async def test_pipeline(aconn):
         assert r.status == pq.ExecStatus.TUPLES_OK
         assert r.get_value(0, 0) == b"1"
 
-        (rs, rto) = await aconn.wait(aconn._fetch_many_gen())
+        (r,) = await aconn.wait(aconn._fetch_many_gen())
+        assert r.status == pq.ExecStatus.PIPELINE_SYNC
 
-        assert rs.status == pq.ExecStatus.PIPELINE_SYNC
-
-        assert rto.status == pq.ExecStatus.TUPLES_OK
-        assert rto.get_value(0, 0) == b"2"
+        (r,) = await aconn.wait(aconn._fetch_many_gen())
+        assert r.status == pq.ExecStatus.TUPLES_OK
+        assert r.get_value(0, 0) == b"2"
 
         (r,) = await aconn.wait(aconn._fetch_many_gen())
         assert r.status == pq.ExecStatus.PIPELINE_SYNC
@@ -87,11 +87,11 @@ async def test_pipeline_aborted(aconn):
         assert r.status == pq.ExecStatus.TUPLES_OK
         assert r.get_value(0, 0) == b"1"
 
-        (rs, rfe) = await aconn.wait(aconn._fetch_many_gen())
+        (r,) = await aconn.wait(aconn._fetch_many_gen())
+        assert r.status == pq.ExecStatus.PIPELINE_SYNC
 
-        assert rs.status == pq.ExecStatus.PIPELINE_SYNC
-        assert rfe.status == pq.ExecStatus.FATAL_ERROR
-
+        (r,) = await aconn.wait(aconn._fetch_many_gen())
+        assert r.status == pq.ExecStatus.FATAL_ERROR
         assert await pipeline.status() == pq.PipelineStatus.ABORTED
 
         (r,) = await aconn.wait(aconn._fetch_many_gen())
@@ -99,14 +99,13 @@ async def test_pipeline_aborted(aconn):
 
         assert await pipeline.status() == pq.PipelineStatus.ABORTED
 
-        (rs, rto) = await aconn.wait(aconn._fetch_many_gen())
+        (r,) = await aconn.wait(aconn._fetch_many_gen())
+        assert r.status == pq.ExecStatus.PIPELINE_SYNC
 
-        assert rs.status == pq.ExecStatus.PIPELINE_SYNC
-
+        (r,) = await aconn.wait(aconn._fetch_many_gen())
         assert await pipeline.status() == pq.PipelineStatus.ON
-
-        assert rto.status == pq.ExecStatus.TUPLES_OK
-        assert rto.get_value(0, 0) == b"2"
+        assert r.status == pq.ExecStatus.TUPLES_OK
+        assert r.get_value(0, 0) == b"2"
 
         (r,) = await aconn.wait(aconn._fetch_many_gen())
         assert r.status == pq.ExecStatus.PIPELINE_SYNC

--- a/tests/test_pipeline_async.py
+++ b/tests/test_pipeline_async.py
@@ -1,5 +1,6 @@
 import pytest
 
+import psycopg
 from psycopg import pq
 
 pytestmark = [
@@ -20,3 +21,176 @@ async def test_pipeline_status(aconn):
         assert r is None
     assert await p.status() == pq.PipelineStatus.OFF
     assert not aconn._pipeline_mode
+
+
+async def test_pipeline_busy(aconn):
+    with pytest.raises(
+        psycopg.OperationalError, match="cannot exit pipeline mode while busy"
+    ):
+        async with aconn.cursor() as cur, aconn.pipeline():
+            await cur.execute("select 1")
+
+
+async def test_pipeline(aconn):
+    pgconn = aconn.pgconn
+    async with aconn.pipeline() as pipeline:
+        c1 = aconn.cursor()
+        c2 = aconn.cursor()
+        await c1.execute("select 1")
+        await pipeline.sync()
+        await c2.execute("select 2")
+        await pipeline.sync()
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.COMMAND_OK  # BEGIN
+        assert pgconn.get_result() is None
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.TUPLES_OK
+        assert r.get_value(0, 0) == b"1"
+        assert pgconn.get_result() is None
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.PIPELINE_SYNC
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.TUPLES_OK
+        assert r.get_value(0, 0) == b"2"
+        assert pgconn.get_result() is None
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.PIPELINE_SYNC
+
+
+async def test_autocommit(aconn):
+    await aconn.set_autocommit(True)
+    pgconn = aconn.pgconn
+    async with aconn.pipeline() as pipeline, aconn.cursor() as c:
+        await c.execute("select 1")
+        await pipeline.sync()
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.TUPLES_OK
+        assert r.get_value(0, 0) == b"1"
+        assert pgconn.get_result() is None
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.PIPELINE_SYNC
+
+
+async def test_pipeline_aborted(aconn):
+    await aconn.set_autocommit(True)
+    pgconn = aconn.pgconn
+    async with aconn.pipeline() as pipeline, aconn.cursor() as c:
+        await c.execute("select 1")
+        await pipeline.sync()
+        await c.execute("select * from doesnotexist")
+        await c.execute("select 'aborted'")
+        await pipeline.sync()
+        await c.execute("select 2")
+        await pipeline.sync()
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.TUPLES_OK
+        assert r.get_value(0, 0) == b"1"
+        assert pgconn.get_result() is None
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.PIPELINE_SYNC
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.FATAL_ERROR
+        assert pgconn.get_result() is None
+
+        assert await pipeline.status() == pq.PipelineStatus.ABORTED
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.PIPELINE_ABORTED
+        assert pgconn.get_result() is None
+
+        assert await pipeline.status() == pq.PipelineStatus.ABORTED
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.PIPELINE_SYNC
+
+        assert await pipeline.status() == pq.PipelineStatus.ON
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.TUPLES_OK
+        assert r.get_value(0, 0) == b"2"
+        assert pgconn.get_result() is None
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.PIPELINE_SYNC
+
+
+async def test_prepared(aconn):
+    await aconn.set_autocommit(True)
+    pgconn = aconn.pgconn
+    async with aconn.pipeline() as pipeline, aconn.cursor() as c:
+        await c.execute("select %s::int", [10], prepare=True)
+        await c.execute("select count(*) from pg_prepared_statements")
+        await pipeline.sync()
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.COMMAND_OK  # PREPARE
+        assert pgconn.get_result() is None
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.TUPLES_OK
+        assert r.get_value(0, 0) == b"10"
+        assert pgconn.get_result() is None
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.TUPLES_OK
+        assert r.get_value(0, 0) == b"1"
+        assert pgconn.get_result() is None
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.PIPELINE_SYNC
+
+
+@pytest.mark.xfail
+async def test_auto_prepare(aconn):
+    # Auto prepare does not work because cache maintainance requires access to
+    # results at the moment.
+    await aconn.set_autocommit(True)
+    pgconn = aconn.pgconn
+    async with aconn.pipeline() as pipeline:
+        for i in range(10):
+            await aconn.execute("select count(*) from pg_prepared_statements")
+        await pipeline.sync()
+
+        for i, v in zip(range(10), [0] * 5 + [1] * 5):
+            r = pgconn.get_result()
+            assert r.status == pq.ExecStatus.TUPLES_OK
+            rv = int(r.get_value(0, 0).decode())
+            assert rv == v
+            assert pgconn.get_result() is None
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.PIPELINE_SYNC
+
+
+async def test_transaction(aconn):
+    pgconn = aconn.pgconn
+    async with aconn.pipeline() as pipeline:
+        async with aconn.transaction():
+            await aconn.execute("select 'tx'")
+        await pipeline.sync()
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.COMMAND_OK  # BEGIN
+        assert pgconn.get_result() is None
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.TUPLES_OK
+        assert r.get_value(0, 0) == b"tx"
+        assert pgconn.get_result() is None
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.COMMAND_OK  # COMMIT
+        assert pgconn.get_result() is None
+
+        r = pgconn.get_result()
+        assert r.status == pq.ExecStatus.PIPELINE_SYNC

--- a/tests/test_pipeline_async.py
+++ b/tests/test_pipeline_async.py
@@ -1,0 +1,22 @@
+import pytest
+
+from psycopg import pq
+
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.libpq(">=14"),
+]
+
+
+async def test_pipeline_status(aconn):
+    assert not aconn._pipeline_mode
+    async with aconn.pipeline() as p:
+        assert await p.status() == pq.PipelineStatus.ON
+        assert aconn._pipeline_mode
+        await p.sync()
+        r = aconn.pgconn.get_result()
+        assert r.status == pq.ExecStatus.PIPELINE_SYNC
+        r = aconn.pgconn.get_result()
+        assert r is None
+    assert await p.status() == pq.PipelineStatus.OFF
+    assert not aconn._pipeline_mode


### PR DESCRIPTION
This adds support for connection pipeline mode #74 on Python side.

- the API is to be discussed
- works with sync and async connection/cursor
- at the moment, the user needs to call `PQpipelineSync()` themselves at least once in the pipeline; perhaps we'd want to do this ourselves (e.g. at transaction scope as suggested in postgres doc)
- some things do not work (yet) in this mode, like server-side cursor, `cursor.stream()`, update of query prepare state
- there's propbably some code duplication that can benefit from a refactoring
- I'm not sure yet about `PQflush()` calls (already there) vs. `PQpipelineSync()`, so I need to investigate more about this

Still draft, but happy to get feedback anyways. I'd suggest to review commit-by-commit.