### PR TITLE
Re-export DB-API type constructors and singletons

### DIFF
--- a/psycopg/psycopg/__init__.py
+++ b/psycopg/psycopg/__init__.py
@@ -88,4 +88,17 @@ __all__ = [
     "InternalError",
     "ProgrammingError",
     "NotSupportedError",
+    # DBAPI type constructors and singletons
+    "Date",
+    "Time",
+    "Timestamp",
+    "DateFromTicks",
+    "TimeFromTicks",
+    "TimestampFromTicks",
+    "Binary",
+    "STRING",
+    "BINARY",
+    "NUMBER",
+    "DATETIME",
+    "ROWID",
 ]


### PR DESCRIPTION
Following https://www.python.org/dev/peps/pep-0249/#type-objects-and-constructors

Otherwise mypy will complain as:
```Module "psycopg" does not explicitly export attribute "Binary"; implicit reexport disabled```
