### PR TITLE
Update cibuildwheel to v2.2.2 to build `musllinux` wheels

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -93,6 +93,7 @@ jobs:
       matrix:
         arch: [x86_64, i686, ppc64le, aarch64]
         pyver: [cp36, cp37, cp38, cp39, cp310]
+        platform: [manylinux, musllinux]
 
     steps:
       - uses: actions/checkout@v2
@@ -112,7 +113,7 @@ jobs:
           CIBW_MANYLINUX_I686_IMAGE: manylinux_2_24
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_24
           CIBW_MANYLINUX_PPC64LE_IMAGE: manylinux_2_24
-          CIBW_BUILD: ${{matrix.pyver}}-manylinux_${{matrix.arch}}
+          CIBW_BUILD: ${{matrix.pyver}}-${{matrix.platform}}_${{matrix.arch}}
           CIBW_ARCHS_LINUX: auto aarch64 ppc64le
           CIBW_BEFORE_ALL_LINUX: ./tools/build/wheel_linux_before_all.sh
           CIBW_REPAIR_WHEEL_COMMAND: >-

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -104,7 +104,7 @@ jobs:
         run: python3 ./tools/build/copy_to_binary.py
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.1.2
+        uses: pypa/cibuildwheel@v2.2.2
         with:
           package-dir: psycopg_binary
         env:
@@ -167,7 +167,7 @@ jobs:
         run: python3 ./tools/build/copy_to_binary.py
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.1.2
+        uses: pypa/cibuildwheel@v2.2.2
         with:
           package-dir: psycopg_binary
         env:
@@ -211,7 +211,7 @@ jobs:
         run: python3 ./tools/build/copy_to_binary.py
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.1.2
+        uses: pypa/cibuildwheel@v2.2.2
         with:
           package-dir: psycopg_binary
         env:


### PR DESCRIPTION
The v2.2.x version of cibuildwheel adds supports for building `musllinux`[^1] wheels. Meaning Alpine users can finally take advantage of binary installations.

[^1]: https://www.python.org/dev/peps/pep-0656/