### PR TITLE
use anyio in "core" psycopg

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Include dnspython to the packages to install
         if: ${{ matrix.ext == 'dns' }}
         run: |
-          echo "DEPS=$DEPS dnspython" >> $GITHUB_ENV
+          echo "DEPS=$DEPS anyio[trio] dnspython" >> $GITHUB_ENV
           echo "MARKERS=$MARKERS dns" >> $GITHUB_ENV
 
       - name: Include shapely to the packages to install

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,28 +26,29 @@ jobs:
       matrix:
         include:
           # Test different combinations of Python, Postgres, libpq.
-          - {impl: python, python: "3.7", postgres: "postgres:10", libpq: newest}
-          - {impl: python, python: "3.8", postgres: "postgres:12"}
-          - {impl: python, python: "3.9", postgres: "postgres:13"}
-          - {impl: python, python: "3.10", postgres: "postgres:14"}
-          - {impl: python, python: "3.11", postgres: "postgres:15", libpq: oldest}
+          - {impl: python, python: "3.7", postgres: "postgres:10", libpq: newest, pytest_opts: "--anyio=asyncio"}
+          - {impl: python, python: "3.8", postgres: "postgres:12", pytest_opts: ""}
+          - {impl: python, python: "3.9", postgres: "postgres:13", pytest_opts: "--anyio=trio"}
+          - {impl: python, python: "3.10", postgres: "postgres:14", pytest_opts: ""}
+          - {impl: python, python: "3.11", postgres: "postgres:15", libpq: oldest, pytest_opts: ""}
 
-          - {impl: c, python: "3.7", postgres: "postgres:15", libpq: newest}
-          - {impl: c, python: "3.8", postgres: "postgres:13"}
-          - {impl: c, python: "3.9", postgres: "postgres:14"}
-          - {impl: c, python: "3.10", postgres: "postgres:11", libpq: oldest}
-          - {impl: c, python: "3.11", postgres: "postgres:10", libpq: newest}
+          - {impl: c, python: "3.7", postgres: "postgres:15", libpq: newest, pytest_opts: ""}
+          - {impl: c, python: "3.8", postgres: "postgres:13", pytest_opts: "--anyio=asyncio"}
+          - {impl: c, python: "3.9", postgres: "postgres:14", pytest_opts: ""}
+          - {impl: c, python: "3.10", postgres: "postgres:11", libpq: oldest, pytest_opts: "--anyio=trio"}
+          - {impl: c, python: "3.11", postgres: "postgres:10", libpq: newest, pytest_opts: ""}
 
-          - {impl: python, python: "3.9", ext: dns, postgres: "postgres:14"}
-          - {impl: python, python: "3.9", ext: postgis, postgres: "postgis/postgis"}
+          - {impl: python, python: "3.9", ext: dns, postgres: "postgres:14", pytest_opts: ""}
+          - {impl: python, python: "3.9", ext: postgis, postgres: "postgis/postgis", pytest_opts: ""}
 
           # Test with minimum dependencies versions
-          - {impl: c, python: "3.7", ext: min, postgres: "postgres:15"}
+          - {impl: c, python: "3.7", ext: min, postgres: "postgres:15", pytest_opts: ""}
 
     env:
       PSYCOPG_IMPL: ${{ matrix.impl }}
       DEPS: ./psycopg[test] ./psycopg_pool
       PSYCOPG_TEST_DSN: "host=127.0.0.1 user=postgres password=password"
+      PYTEST_ADDOPTS: ${{ matrix.pytest_opts }}
       MARKERS: ""
 
     steps:
@@ -110,21 +111,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {impl: python, python: "3.7"}
-          - {impl: python, python: "3.8"}
-          - {impl: python, python: "3.9"}
-          - {impl: python, python: "3.10"}
-          - {impl: python, python: "3.11"}
-          - {impl: c, python: "3.7"}
-          - {impl: c, python: "3.8"}
-          - {impl: c, python: "3.9"}
-          - {impl: c, python: "3.10"}
-          - {impl: c, python: "3.11"}
+          - {impl: python, python: "3.7", pytest_opts: ""}
+          - {impl: python, python: "3.8", pytest_opts: "--anyio=asyncio"}
+          - {impl: python, python: "3.9", pytest_opts: ""}
+          - {impl: python, python: "3.10", pytest_opts: "--anyio=trio"}
+          - {impl: python, python: "3.11", pytest_opts: ""}
+          - {impl: c, python: "3.7", pytest_opts: "--anyio=trio"}
+          - {impl: c, python: "3.8", pytest_opts: ""}
+          - {impl: c, python: "3.9", pytest_opts: "--anyio=asyncio"}
+          - {impl: c, python: "3.10", pytest_opts: ""}
+          - {impl: c, python: "3.11", pytest_opts: ""}
 
     env:
       PSYCOPG_IMPL: ${{ matrix.impl }}
       DEPS: ./psycopg[test] ./psycopg_pool
       PSYCOPG_TEST_DSN: "host=127.0.0.1 user=runner dbname=postgres"
+      PYTEST_ADDOPTS: ${{ matrix.pytest_opts }}
       # MacOS on GitHub Actions seems particularly slow.
       # Don't run timing-based tests as they regularly fail.
       # pproxy-based tests fail too, with the proxy not coming up in 2s.
@@ -165,21 +167,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {impl: python, python: "3.7"}
-          - {impl: python, python: "3.8"}
-          - {impl: python, python: "3.9"}
-          - {impl: python, python: "3.10"}
-          - {impl: python, python: "3.11"}
-          - {impl: c, python: "3.7"}
-          - {impl: c, python: "3.8"}
-          - {impl: c, python: "3.9"}
-          - {impl: c, python: "3.10"}
-          - {impl: c, python: "3.11"}
+          - {impl: python, python: "3.7", pytest_opts: "--anyio=asyncio"}
+          - {impl: python, python: "3.8", pytest_opts: ""}
+          - {impl: python, python: "3.9", pytest_opts: "--anyio=trio"}
+          - {impl: python, python: "3.10", pytest_opts: ""}
+          - {impl: python, python: "3.11", pytest_opts: ""}
+          - {impl: c, python: "3.7", pytest_opts: ""}
+          - {impl: c, python: "3.8", pytest_opts: "--anyio=trio"}
+          - {impl: c, python: "3.9", pytest_opts: ""}
+          - {impl: c, python: "3.10", pytest_opts: "--anyio=asyncio"}
+          - {impl: c, python: "3.11", pytest_opts: ""}
 
     env:
       PSYCOPG_IMPL: ${{ matrix.impl }}
       DEPS: ./psycopg[test] ./psycopg_pool
       PSYCOPG_TEST_DSN: "host=127.0.0.1 dbname=postgres"
+      PYTEST_ADDOPTS: ${{ matrix.pytest_opts }}
       # On windows pproxy doesn't seem very happy. Also a few timing test fail.
       NOT_MARKERS: "timing proxy mypy"
 
@@ -235,12 +238,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {impl: c, crdb: "latest-v22.1", python: "3.10", libpq: newest}
-          - {impl: python, crdb: "latest-v22.2", python: "3.11"}
+          - {impl: c, crdb: "latest-v22.1", python: "3.10", libpq: newest, pytest_opts: "--anyio=trio"}
+          - {impl: python, crdb: "latest-v22.2", python: "3.11", pytest_opts: ""}
     env:
       PSYCOPG_IMPL: ${{ matrix.impl }}
       DEPS: ./psycopg[test] ./psycopg_pool
       PSYCOPG_TEST_DSN: "host=127.0.0.1 port=26257 user=root dbname=defaultdb"
+      PYTEST_ADDOPTS: ${{ matrix.pytest_opts }}
 
     steps:
       - uses: actions/checkout@v3

--- a/docs/api/connections.rst
+++ b/docs/api/connections.rst
@@ -401,8 +401,8 @@ The `!Connection` class
         .. _pg_prepared_xacts: https://www.postgresql.org/docs/current/static/view-pg-prepared-xacts.html
 
 
-The `!AsyncConnection` class
-----------------------------
+The `!AsyncConnection` classes
+------------------------------
 
 .. autoclass:: AsyncConnection()
 
@@ -487,3 +487,14 @@ The `!AsyncConnection` class
     .. automethod:: tpc_commit
     .. automethod:: tpc_rollback
     .. automethod:: tpc_recover
+
+
+.. autoclass:: AnyIOConnection()
+
+    This is class is similar to `AsyncConnection` but uses anyio_ as an
+    asynchronous library instead of `asyncio`.
+
+    To use this class, run ``pip install "psycopg[anyio]"`` to install
+    required dependencies.
+
+.. _anyio: https://anyio.readthedocs.io/

--- a/psycopg/psycopg/__init__.py
+++ b/psycopg/psycopg/__init__.py
@@ -25,6 +25,7 @@ from .cursor_async import AsyncCursor
 from .server_cursor import AsyncServerCursor, ServerCursor
 from .client_cursor import AsyncClientCursor, ClientCursor
 from .connection_async import AsyncConnection
+from ._anyio.connection import AnyIOConnection
 
 from . import dbapi20
 from .dbapi20 import BINARY, DATETIME, NUMBER, ROWID, STRING
@@ -59,6 +60,7 @@ types.array.register_all_arrays(adapters)
 # this is the canonical place to obtain them and should be used by MyPy too,
 # so that function signatures are consistent with the documentation.
 __all__ = [
+    "AnyIOConnection",
     "AsyncClientCursor",
     "AsyncConnection",
     "AsyncCopy",

--- a/psycopg/psycopg/_anyio/connection.py
+++ b/psycopg/psycopg/_anyio/connection.py
@@ -1,0 +1,80 @@
+"""
+psycopg async connection objects using AnyIO
+"""
+
+# Copyright (C) 2022 The Psycopg Team
+
+
+from functools import lru_cache
+from typing import Any, Optional, TYPE_CHECKING
+
+from .. import errors as e
+from ..abc import PQGen, PQGenConn, RV
+from ..connection_async import AsyncConnection
+from ..rows import Row
+
+if TYPE_CHECKING:
+    import anyio
+    import sniffio
+    from . import waiting
+else:
+    anyio = sniffio = waiting = None
+
+
+@lru_cache()
+def _import_anyio() -> None:
+    global anyio, sniffio, waiting
+    try:
+        import anyio
+        import sniffio
+        from . import waiting
+    except ImportError as e:
+        raise ImportError(
+            "anyio is not installed; run `pip install psycopg[anyio]`"
+        ) from e
+
+
+class AnyIOConnection(AsyncConnection[Row]):
+    """
+    Asynchronous wrapper for a connection to the database using AnyIO
+    asynchronous library.
+    """
+
+    __module__ = "psycopg"
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        _import_anyio()
+        self._lockcls = anyio.Lock  # type: ignore[assignment]
+        super().__init__(*args, **kwargs)
+
+    @staticmethod
+    def _async_library() -> str:
+        _import_anyio()
+        return sniffio.current_async_library()
+
+    @staticmethod
+    def _getaddrinfo() -> Any:
+        _import_anyio()
+        return anyio.getaddrinfo
+
+    async def wait(self, gen: PQGen[RV]) -> RV:
+        try:
+            return await waiting.wait(gen, self.pgconn.socket)
+        except KeyboardInterrupt:
+            # TODO: this doesn't seem to work as it does for sync connections
+            # see tests/test_concurrency_async.py::test_ctrl_c
+            # In the test, the code doesn't reach this branch.
+
+            # On Ctrl-C, try to cancel the query in the server, otherwise
+            # otherwise the connection will be stuck in ACTIVE state
+            c = self.pgconn.get_cancel()
+            c.cancel()
+            try:
+                await waiting.wait(gen, self.pgconn.socket)
+            except e.QueryCanceled:
+                pass  # as expected
+            raise
+
+    @classmethod
+    async def _wait_conn(cls, gen: PQGenConn[RV], timeout: Optional[int]) -> RV:
+        return await waiting.wait_conn(gen, timeout)

--- a/psycopg/psycopg/_anyio/waiting.py
+++ b/psycopg/psycopg/_anyio/waiting.py
@@ -1,0 +1,140 @@
+"""
+Async waiting functions using AnyIO.
+"""
+
+# Copyright (C) 2022 The Psycopg Team
+
+
+import socket
+from typing import Optional
+
+import anyio
+
+from .. import errors as e
+from ..abc import PQGen, PQGenConn, RV
+from ..waiting import Ready, Wait
+
+
+def _fromfd(fileno: int) -> socket.socket:
+    # AnyIO's wait_socket_readable() and wait_socket_writable() functions work
+    # with socket object (despite the underlying async libraries -- asyncio and
+    # trio -- accept integer 'fileno' values):
+    # https://github.com/agronholm/anyio/issues/386
+    try:
+        return socket.fromfd(fileno, socket.AF_INET, socket.SOCK_STREAM)
+    except OSError as exc:
+        raise e.OperationalError(
+            f"failed to build a socket from connection file descriptor: {exc}"
+        )
+
+
+async def wait(gen: PQGen[RV], fileno: int) -> RV:
+    """
+    Coroutine waiting for a generator to complete.
+
+    :param gen: a generator performing database operations and yielding
+        `Ready` values when it would block.
+    :param fileno: the file descriptor to wait on.
+    :return: whatever *gen* returns on completion.
+
+    Behave like in `waiting.wait()`, but exposing an `anyio` interface.
+    """
+    s: Wait
+    ready: Ready
+    sock = _fromfd(fileno)
+
+    async def readable(ev: anyio.Event) -> None:
+        await anyio.wait_socket_readable(sock)
+        nonlocal ready
+        ready |= Ready.R  # type: ignore[assignment]
+        ev.set()
+
+    async def writable(ev: anyio.Event) -> None:
+        await anyio.wait_socket_writable(sock)
+        nonlocal ready
+        ready |= Ready.W  # type: ignore[assignment]
+        ev.set()
+
+    try:
+        s = next(gen)
+        while True:
+            reader = s & Wait.R
+            writer = s & Wait.W
+            if not reader and not writer:
+                raise e.InternalError(f"bad poll status: {s}")
+            ev = anyio.Event()
+            ready = 0  # type: ignore[assignment]
+            async with anyio.create_task_group() as tg:
+                if reader:
+                    tg.start_soon(readable, ev)
+                if writer:
+                    tg.start_soon(writable, ev)
+                await ev.wait()
+                tg.cancel_scope.cancel()  # Move on upon first task done.
+
+            s = gen.send(ready)
+
+    except StopIteration as ex:
+        rv: RV = ex.args[0] if ex.args else None
+        return rv
+
+    finally:
+        sock.close()
+
+
+async def wait_conn(gen: PQGenConn[RV], timeout: Optional[float] = None) -> RV:
+    """
+    Coroutine waiting for a connection generator to complete.
+
+    :param gen: a generator performing database operations and yielding
+        (fd, `Ready`) pairs when it would block.
+    :param timeout: timeout (in seconds) to check for other interrupt, e.g.
+        to allow Ctrl-C. If zero or None, wait indefinitely.
+    :return: whatever *gen* returns on completion.
+
+    Behave like in `waiting.wait()`, but take the fileno to wait from the
+    generator itself, which might change during processing.
+    """
+    s: Wait
+    ready: Ready
+
+    async def readable(sock: socket.socket, ev: anyio.Event) -> None:
+        await anyio.wait_socket_readable(sock)
+        nonlocal ready
+        ready = Ready.R
+        ev.set()
+
+    async def writable(sock: socket.socket, ev: anyio.Event) -> None:
+        await anyio.wait_socket_writable(sock)
+        nonlocal ready
+        ready = Ready.W
+        ev.set()
+
+    timeout = timeout or None
+    try:
+        fileno, s = next(gen)
+
+        while True:
+            reader = s & Wait.R
+            writer = s & Wait.W
+            if not reader and not writer:
+                raise e.InternalError(f"bad poll status: {s}")
+            ev = anyio.Event()
+            ready = 0  # type: ignore[assignment]
+            with _fromfd(fileno) as sock:
+                async with anyio.create_task_group() as tg:
+                    if reader:
+                        tg.start_soon(readable, sock, ev)
+                    if writer:
+                        tg.start_soon(writable, sock, ev)
+                    with anyio.fail_after(timeout):
+                        await ev.wait()
+
+            fileno, s = gen.send(ready)
+
+    except TimeoutError:
+        raise e.OperationalError("timeout expired")
+
+    except StopIteration as ex:
+        rv: RV = ex.args[0] if ex.args else None
+        return rv

--- a/psycopg/psycopg/_dns.py
+++ b/psycopg/psycopg/_dns.py
@@ -5,6 +5,7 @@ DNS query support
 
 # Copyright (C) 2021 The Psycopg Team
 
+import asyncio
 import os
 import re
 import warnings
@@ -48,7 +49,8 @@ async def resolve_hostaddr_async(params: Dict[str, Any]) -> Dict[str, Any]:
         "from psycopg 3.1, resolve_hostaddr_async() is not needed anymore",
         DeprecationWarning,
     )
-    return await resolve_hostaddr_async_(params)
+    loop = asyncio.get_running_loop()
+    return await resolve_hostaddr_async_(params, getaddrinfo=loop.getaddrinfo)
 
 
 def resolve_srv(params: Dict[str, Any]) -> Dict[str, Any]:

--- a/psycopg/psycopg/connection.py
+++ b/psycopg/psycopg/connection.py
@@ -413,7 +413,7 @@ class BaseConnection(Generic[Row]):
     # These operations are expressed in terms of non-blocking generators
     # and the task of waiting when needed (when the generators yield) is left
     # to the connections subclass, which might wait either in blocking mode
-    # or through asyncio.
+    # or through an async library.
     #
     # All these generators assume exclusive access to the connection: subclasses
     # should have a lock and hold it before calling and consuming them.

--- a/psycopg/psycopg/connection_async.py
+++ b/psycopg/psycopg/connection_async.py
@@ -189,7 +189,8 @@ class AsyncConnection(BaseConnection[Row]):
             params["connect_timeout"] = None
 
         # Resolve host addresses in non-blocking way
-        params = await resolve_hostaddr_async(params)
+        loop = asyncio.get_running_loop()
+        params = await resolve_hostaddr_async(params, getaddrinfo=loop.getaddrinfo)
 
         return params
 

--- a/psycopg/psycopg/connection_async.py
+++ b/psycopg/psycopg/connection_async.py
@@ -345,7 +345,7 @@ class AsyncConnection(BaseConnection[Row]):
 
     async def wait(self, gen: PQGen[RV]) -> RV:
         try:
-            return await waiting.wait_async(gen, self.pgconn.socket)
+            return await waiting.wait_asyncio(gen, self.pgconn.socket)
         except KeyboardInterrupt:
             # TODO: this doesn't seem to work as it does for sync connections
             # see tests/test_concurrency_async.py::test_ctrl_c
@@ -356,14 +356,14 @@ class AsyncConnection(BaseConnection[Row]):
             c = self.pgconn.get_cancel()
             c.cancel()
             try:
-                await waiting.wait_async(gen, self.pgconn.socket)
+                await waiting.wait_asyncio(gen, self.pgconn.socket)
             except e.QueryCanceled:
                 pass  # as expected
             raise
 
     @classmethod
     async def _wait_conn(cls, gen: PQGenConn[RV], timeout: Optional[int]) -> RV:
-        return await waiting.wait_conn_async(gen, timeout)
+        return await waiting.wait_conn_asyncio(gen, timeout)
 
     def _set_autocommit(self, value: bool) -> None:
         self._no_set_async("autocommit")

--- a/psycopg/psycopg/conninfo.py
+++ b/psycopg/psycopg/conninfo.py
@@ -7,7 +7,6 @@ Functions to manipulate conninfo strings
 import os
 import re
 import socket
-import asyncio
 from typing import Any, Dict, List, Optional
 from pathlib import Path
 from datetime import tzinfo
@@ -275,7 +274,9 @@ class ConnectionInfo:
         return value.decode(self.encoding)
 
 
-async def resolve_hostaddr_async(params: Dict[str, Any]) -> Dict[str, Any]:
+async def resolve_hostaddr_async(
+    params: Dict[str, Any], *, getaddrinfo: Any
+) -> Dict[str, Any]:
     """
     Perform async DNS lookup of the hosts and return a new params dict.
 
@@ -323,7 +324,6 @@ async def resolve_hostaddr_async(params: Dict[str, Any]) -> Dict[str, Any]:
 
     hosts_out = []
     hostaddr_out = []
-    loop = asyncio.get_running_loop()
     for i, host in enumerate(hosts_in):
         if not host or host.startswith("/") or host[1:2] == ":":
             # Local path
@@ -343,7 +343,7 @@ async def resolve_hostaddr_async(params: Dict[str, Any]) -> Dict[str, Any]:
 
         try:
             port = ports_in[i] if ports_in else default_port
-            ans = await loop.getaddrinfo(
+            ans = await getaddrinfo(
                 host, port, proto=socket.IPPROTO_TCP, type=socket.SOCK_STREAM
             )
         except OSError as ex:

--- a/psycopg/psycopg/crdb/__init__.py
+++ b/psycopg/psycopg/crdb/__init__.py
@@ -6,6 +6,7 @@ CockroachDB support package.
 
 from . import _types
 from .connection import CrdbConnection, AsyncCrdbConnection, CrdbConnectionInfo
+from ._anyio import AnyIOCrdbConnection
 
 adapters = _types.adapters  # exposed by the package
 connect = CrdbConnection.connect
@@ -14,6 +15,7 @@ _types.register_crdb_types(adapters.types)
 _types.register_crdb_adapters(adapters)
 
 __all__ = [
+    "AnyIOCrdbConnection",
     "AsyncCrdbConnection",
     "CrdbConnection",
     "CrdbConnectionInfo",

--- a/psycopg/psycopg/crdb/_anyio.py
+++ b/psycopg/psycopg/crdb/_anyio.py
@@ -1,0 +1,63 @@
+"""
+CockroachDB-specific connections for AnyIO.
+"""
+
+# Copyright (C) 2022 The Psycopg Team
+
+
+from typing import Any, Optional, Union, Type, overload, TYPE_CHECKING
+
+from ..abc import AdaptContext
+from ..rows import AsyncRowFactory, Row, TupleRow
+from .._anyio.connection import AnyIOConnection
+from .connection import _CrdbConnectionMixin
+
+if TYPE_CHECKING:
+    from ..cursor_async import AsyncCursor
+
+
+class AnyIOCrdbConnection(_CrdbConnectionMixin, AnyIOConnection[Row]):
+    """
+    Wrapper for an async connection to a CockroachDB database using AnyIO
+    asynchronous library.
+    """
+
+    __module__ = "psycopg.crdb"
+
+    # TODO: this method shouldn't require re-definition if the base class
+    # implements a generic self.
+    # https://github.com/psycopg/psycopg/issues/308
+    @overload
+    @classmethod
+    async def connect(
+        cls,
+        conninfo: str = "",
+        *,
+        autocommit: bool = False,
+        prepare_threshold: Optional[int] = 5,
+        row_factory: AsyncRowFactory[Row],
+        cursor_factory: "Optional[Type[AsyncCursor[Row]]]" = None,
+        context: Optional[AdaptContext] = None,
+        **kwargs: Union[None, int, str],
+    ) -> "AnyIOCrdbConnection[Row]":
+        ...
+
+    @overload
+    @classmethod
+    async def connect(
+        cls,
+        conninfo: str = "",
+        *,
+        autocommit: bool = False,
+        prepare_threshold: Optional[int] = 5,
+        cursor_factory: "Optional[Type[AsyncCursor[Any]]]" = None,
+        context: Optional[AdaptContext] = None,
+        **kwargs: Union[None, int, str],
+    ) -> "AnyIOCrdbConnection[TupleRow]":
+        ...
+
+    @classmethod
+    async def connect(
+        cls, conninfo: str = "", **kwargs: Any
+    ) -> "AnyIOCrdbConnection[Any]":
+        return await super().connect(conninfo, **kwargs)  # type: ignore [no-any-return]

--- a/psycopg/psycopg/cursor.py
+++ b/psycopg/psycopg/cursor.py
@@ -178,7 +178,7 @@ class BaseCursor(Generic[ConnectionType, Row]):
     # Generators for the high level operations on the cursor
     #
     # Like for sync/async connections, these are implemented as generators
-    # so that different concurrency strategies (threads,asyncio) can use their
+    # so that different concurrency strategies (threads, async lib) can use their
     # own way of waiting (or better, `connection.wait()`).
     #
 

--- a/psycopg/psycopg/waiting.py
+++ b/psycopg/psycopg/waiting.py
@@ -96,7 +96,7 @@ def wait_conn(gen: PQGenConn[RV], timeout: Optional[float] = None) -> RV:
         return rv
 
 
-async def wait_async(gen: PQGen[RV], fileno: int) -> RV:
+async def wait_asyncio(gen: PQGen[RV], fileno: int) -> RV:
     """
     Coroutine waiting for a generator to complete.
 
@@ -146,7 +146,7 @@ async def wait_async(gen: PQGen[RV], fileno: int) -> RV:
         return rv
 
 
-async def wait_conn_async(gen: PQGenConn[RV], timeout: Optional[float] = None) -> RV:
+async def wait_conn_asyncio(gen: PQGenConn[RV], timeout: Optional[float] = None) -> RV:
     """
     Coroutine waiting for a connection generator to complete.
 

--- a/psycopg/setup.cfg
+++ b/psycopg/setup.cfg
@@ -62,10 +62,13 @@ c =
     psycopg-c == 3.2.0.dev1
 binary =
     psycopg-binary == 3.2.0.dev1
+anyio =
+    anyio
+    sniffio
 pool =
     psycopg-pool
 test =
-    anyio >= 3.6.2
+    anyio[trio] >= 3.6.2
     mypy >= 0.990
     pproxy >= 2.7
     pytest >= 6.2.5
@@ -83,6 +86,7 @@ docs =
     furo == 2022.6.21
     sphinx-autobuild >= 2021.3.14
     sphinx-autodoc-typehints >= 1.12
+    anyio
 
 [options.package_data]
 psycopg = py.typed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,10 @@ build-backend = "setuptools.build_meta"
 [tool.pytest.ini_options]
 filterwarnings = [
     "error",
+    # Workaround for Python 3.9.7 (see https://bugs.python.org/issue45097)
+    "ignore:The loop argument is deprecated since Python 3\\.8, and scheduled for removal in Python 3\\.10\\.:DeprecationWarning:asyncio",
+    # Ignore warning about custom excepthook from 'exceptiongroup', pulled by pytest.
+    "ignore:You seem to already have a custom sys.excepthook handler installed. I'll skip installing Trio's custom handler, but this means MultiErrors will not show full tracebacks.:RuntimeWarning:trio[.*]",
 ]
 testpaths=[
     "tests",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,7 +73,10 @@ if sys.platform == "win32" and sys.version_info >= (3, 8):
 
 
 @pytest.fixture(
-    params=[pytest.param(("asyncio", asyncio_options.copy()), id="asyncio")],
+    params=[
+        pytest.param(("asyncio", asyncio_options.copy()), id="asyncio"),
+        pytest.param(("trio", {}), id="trio"),
+    ],
     scope="session",
 )
 def anyio_backend(request):
@@ -81,6 +84,20 @@ def anyio_backend(request):
     if request.config.option.loop == "uvloop":
         options["use_uvloop"] = True
     return backend, options
+
+
+@pytest.fixture(scope="session")
+def anyio_backend_name(anyio_backend):
+    # Redefined because 'anyio_backend' is session-scoped for us.
+    if isinstance(anyio_backend, str):
+        return anyio_backend
+    else:
+        return anyio_backend[0]
+
+
+asyncio_backend = pytest.mark.parametrize(
+    "anyio_backend", [("asyncio", asyncio_options)], ids=["asyncio"], scope="session"
+)
 
 
 allow_fail_messages: List[str] = []

--- a/tests/crdb/test_cursor_async.py
+++ b/tests/crdb/test_cursor_async.py
@@ -8,6 +8,7 @@ from psycopg import pq, errors as e
 from psycopg.rows import namedtuple_row
 from psycopg._compat import create_task
 
+from ..conftest import asyncio_backend
 from .test_cursor import testfeed
 
 testfeed  # fixture
@@ -17,6 +18,7 @@ pytestmark = [pytest.mark.crdb, pytest.mark.anyio]
 
 @pytest.mark.slow
 @pytest.mark.parametrize("fmt_out", pq.Format)
+@asyncio_backend
 async def test_changefeed(aconn_cls, dsn, aconn, testfeed, fmt_out):
     await aconn.set_autocommit(True)
     q: "Queue[Any]" = Queue()

--- a/tests/fix_db.py
+++ b/tests/fix_db.py
@@ -239,14 +239,21 @@ def conn_cls(session_dsn):
 
 
 @pytest.fixture(scope="session")
-def aconn_cls(session_dsn, anyio_backend):
-    cls = psycopg.AsyncConnection
+def aconn_cls(session_dsn, anyio_backend_name):
+    cls_by_backend = {
+        "asyncio": psycopg.AsyncConnection,
+        "trio": psycopg.AnyIOConnection,
+    }
+
     if crdb_version:
-        from psycopg.crdb import AsyncCrdbConnection
+        from psycopg.crdb import AsyncCrdbConnection, AnyIOCrdbConnection
 
-        cls = AsyncCrdbConnection
+        cls_by_backend = {
+            "asyncio": AsyncCrdbConnection,
+            "trio": AnyIOCrdbConnection,
+        }
 
-    return cls
+    return cls_by_backend[anyio_backend_name]
 
 
 @pytest.fixture(scope="session")

--- a/tests/fix_db.py
+++ b/tests/fix_db.py
@@ -239,21 +239,15 @@ def conn_cls(session_dsn):
 
 
 @pytest.fixture(scope="session")
-def aconn_cls(session_dsn, anyio_backend_name):
-    cls_by_backend = {
-        "asyncio": psycopg.AsyncConnection,
-        "trio": psycopg.AnyIOConnection,
-    }
+def aconn_cls(session_dsn, use_anyio):
+    cls = psycopg.AnyIOConnection if use_anyio else psycopg.AsyncConnection
 
     if crdb_version:
         from psycopg.crdb import AsyncCrdbConnection, AnyIOCrdbConnection
 
-        cls_by_backend = {
-            "asyncio": AsyncCrdbConnection,
-            "trio": AnyIOCrdbConnection,
-        }
+        cls = AnyIOCrdbConnection if use_anyio else AsyncCrdbConnection
 
-    return cls_by_backend[anyio_backend_name]
+    return cls
 
 
 @pytest.fixture(scope="session")

--- a/tests/pool/conftest.py
+++ b/tests/pool/conftest.py
@@ -3,12 +3,9 @@ import pytest
 from ..conftest import asyncio_options
 
 
-@pytest.fixture(
-    params=[pytest.param(("asyncio", asyncio_options.copy()), id="asyncio")],
-    scope="session",
-)
+@pytest.fixture(scope="session")
 def anyio_backend(request):
-    backend, options = request.param
+    options = asyncio_options.copy()
     if request.config.option.loop == "uvloop":
         options["use_uvloop"] = True
-    return backend, options
+    return "asyncio", options

--- a/tests/scripts/pipeline-demo.py
+++ b/tests/scripts/pipeline-demo.py
@@ -212,7 +212,7 @@ async def pipeline_demo_pq_async(rows_to_send: int, logger: logging.Logger) -> N
         results_queue,
     ):
         while results_queue:
-            fetched = await waiting.wait_async(
+            fetched = await waiting.wait_asyncio(
                 pipeline_communicate(
                     pgconn,  # type: ignore[arg-type]
                     commands,

--- a/tests/test_client_cursor_async.py
+++ b/tests/test_client_cursor_async.py
@@ -433,11 +433,13 @@ async def test_rownumber(aconn):
     await cur.fetchmany(10)
     assert cur.rownumber == 12
     rns: List[int] = []
-    async for i in cur:
+    itcur = cur.__aiter__()
+    async for i in itcur:
         assert cur.rownumber
         rns.append(cur.rownumber)
         if len(rns) >= 3:
             break
+    await itcur.aclose()
     assert rns == [13, 14, 15]
     assert len(await cur.fetchall()) == 42 - rns[-1]
     assert cur.rownumber == 42
@@ -455,13 +457,17 @@ async def test_iter(aconn):
 async def test_iter_stop(aconn):
     cur = aconn.cursor()
     await cur.execute("select generate_series(1, 3)")
-    async for rec in cur:
+    itcur = cur.__aiter__()
+    async for rec in itcur:
         assert rec == (1,)
         break
+    await itcur.aclose()
 
-    async for rec in cur:
+    itcur = cur.__aiter__()
+    async for rec in itcur:
         assert rec == (2,)
         break
+    await itcur.aclose()
 
     assert (await cur.fetchone()) == (3,)
     async for rec in cur:

--- a/tests/test_concurrency_async.py
+++ b/tests/test_concurrency_async.py
@@ -12,8 +12,11 @@ import psycopg
 from psycopg import errors as e
 from psycopg._compat import create_task
 
+from .conftest import asyncio_backend
+
 
 @pytest.mark.slow
+@asyncio_backend
 async def test_commit_concurrency(aconn):
     # Check the condition reported in psycopg2#103
     # Because of bad status check, we commit even when a commit is already on
@@ -43,6 +46,7 @@ async def test_commit_concurrency(aconn):
 
 
 @pytest.mark.slow
+@asyncio_backend
 async def test_concurrent_execution(aconn_cls, dsn):
     async def worker():
         cnn = await aconn_cls.connect(dsn)
@@ -60,6 +64,7 @@ async def test_concurrent_execution(aconn_cls, dsn):
 @pytest.mark.slow
 @pytest.mark.timing
 @pytest.mark.crdb_skip("notify")
+@asyncio_backend
 async def test_notifies(aconn_cls, aconn, dsn):
     nconn = await aconn_cls.connect(dsn, autocommit=True)
     npid = nconn.pgconn.backend_pid
@@ -111,6 +116,7 @@ async def canceller(aconn, errors):
 
 @pytest.mark.slow
 @pytest.mark.crdb_skip("cancel")
+@asyncio_backend
 async def test_cancel(aconn):
     async def worker():
         cur = aconn.cursor()
@@ -136,6 +142,7 @@ async def test_cancel(aconn):
 
 @pytest.mark.slow
 @pytest.mark.crdb_skip("cancel")
+@asyncio_backend
 async def test_cancel_stream(aconn):
     async def worker():
         cur = aconn.cursor()
@@ -162,6 +169,7 @@ async def test_cancel_stream(aconn):
 
 @pytest.mark.slow
 @pytest.mark.crdb_skip("pg_terminate_backend")
+@asyncio_backend
 async def test_identify_closure(aconn_cls, dsn):
     async def closer():
         await asyncio.sleep(0.2)

--- a/tests/test_connection_async.py
+++ b/tests/test_connection_async.py
@@ -737,7 +737,7 @@ async def test_cancel_closed(aconn):
 
 
 @pytest.fixture
-async def fake_resolve(monkeypatch, anyio_backend_name):
+async def fake_resolve(monkeypatch, use_anyio):
     fake_hosts = {"foo.com": "1.1.1.1"}
 
     async def fake_getaddrinfo(host, port, **kwargs):
@@ -748,7 +748,7 @@ async def fake_resolve(monkeypatch, anyio_backend_name):
         else:
             return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (addr, 432))]
 
-    if anyio_backend_name == "asyncio":
+    if not use_anyio:
         monkeypatch.setattr(asyncio.get_running_loop(), "getaddrinfo", fake_getaddrinfo)
     else:
         monkeypatch.setattr(anyio, "getaddrinfo", fake_getaddrinfo)

--- a/tests/test_copy_async.py
+++ b/tests/test_copy_async.py
@@ -18,6 +18,7 @@ from psycopg.adapt import PyFormat
 from psycopg.types.hstore import register_hstore
 from psycopg.types.numeric import Int4
 
+from .conftest import asyncio_backend
 from .utils import alist, eur, gc_collect, gc_count
 from .test_copy import sample_text, sample_binary, sample_binary_rows  # noqa
 from .test_copy import sample_values, sample_records, sample_tabledef
@@ -642,6 +643,7 @@ async def test_description(aconn):
 @pytest.mark.parametrize(
     "format, buffer", [(Format.TEXT, "sample_text"), (Format.BINARY, "sample_binary")]
 )
+@asyncio_backend
 async def test_worker_life(aconn, format, buffer):
     cur = aconn.cursor()
     await ensure_table(cur, sample_tabledef)
@@ -659,6 +661,7 @@ async def test_worker_life(aconn, format, buffer):
     assert data == sample_records
 
 
+@asyncio_backend
 async def test_worker_error_propagated(aconn, monkeypatch):
     def copy_to_broken(pgconn, buffer):
         raise ZeroDivisionError

--- a/tests/test_cursor_async.py
+++ b/tests/test_cursor_async.py
@@ -409,11 +409,13 @@ async def test_rownumber(aconn):
     await cur.fetchmany(10)
     assert cur.rownumber == 12
     rns: List[int] = []
-    async for i in cur:
+    itcur = cur.__aiter__()
+    async for i in itcur:
         assert cur.rownumber
         rns.append(cur.rownumber)
         if len(rns) >= 3:
             break
+    await itcur.aclose()
     assert rns == [13, 14, 15]
     assert len(await cur.fetchall()) == 42 - rns[-1]
     assert cur.rownumber == 42
@@ -460,13 +462,17 @@ async def test_iter(aconn):
 async def test_iter_stop(aconn):
     cur = aconn.cursor()
     await cur.execute("select generate_series(1, 3)")
-    async for rec in cur:
+    itcur = cur.__aiter__()
+    async for rec in itcur:
         assert rec == (1,)
         break
+    await itcur.aclose()
 
-    async for rec in cur:
+    itcur = cur.__aiter__()
+    async for rec in itcur:
         assert rec == (2,)
         break
+    await itcur.aclose()
 
     assert (await cur.fetchone()) == (3,)
     async for rec in cur:
@@ -619,6 +625,7 @@ async def test_stream_row_factory(aconn):
     assert (await ait.__anext__())["a"] == 1
     cur.row_factory = rows.namedtuple_row
     assert (await ait.__anext__()).a == 2
+    await ait.aclose()
 
 
 async def test_stream_no_row(aconn):

--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -3,10 +3,12 @@ import pytest
 import psycopg
 from psycopg.conninfo import conninfo_to_dict
 
+from .conftest import asyncio_backend
+
 pytestmark = [pytest.mark.dns]
 
 
-@pytest.mark.parametrize("anyio_backend", ["asyncio"])
+@asyncio_backend
 async def test_resolve_hostaddr_async_warning(recwarn, anyio_backend):
     import_dnspython()
     conninfo = "dbname=foo"

--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -6,8 +6,8 @@ from psycopg.conninfo import conninfo_to_dict
 pytestmark = [pytest.mark.dns]
 
 
-@pytest.mark.anyio
-async def test_resolve_hostaddr_async_warning(recwarn):
+@pytest.mark.parametrize("anyio_backend", ["asyncio"])
+async def test_resolve_hostaddr_async_warning(recwarn, anyio_backend):
     import_dnspython()
     conninfo = "dbname=foo"
     params = conninfo_to_dict(conninfo)

--- a/tests/test_pipeline_async.py
+++ b/tests/test_pipeline_async.py
@@ -10,6 +10,7 @@ import psycopg
 from psycopg import pq
 from psycopg import errors as e
 
+from .conftest import asyncio_backend
 from .test_pipeline import pipeline_aborted
 
 pytestmark = [
@@ -544,6 +545,7 @@ async def test_transaction_state_implicit_begin(aconn, trace):
     ] == [b' "" "BEGIN" 0']
 
 
+@asyncio_backend
 async def test_concurrency(aconn):
     async with aconn.transaction():
         await aconn.execute("drop table if exists pipeline_concurrency")

--- a/tests/test_transaction_async.py
+++ b/tests/test_transaction_async.py
@@ -7,6 +7,7 @@ from psycopg import Rollback
 from psycopg import errors as e
 from psycopg._compat import create_task
 
+from .conftest import asyncio_backend
 from .test_transaction import in_transaction, insert_row, inserted, get_exc_info
 from .test_transaction import ExpectedException, crdb_skip_external_observer
 from .test_transaction import create_test_table  # noqa  # autouse fixture
@@ -700,6 +701,7 @@ async def test_out_of_order_exit_same_name(aconn, exit_error):
 
 
 @pytest.mark.parametrize("what", ["commit", "rollback", "error"])
+@asyncio_backend
 async def test_concurrency(aconn, what):
     await aconn.set_autocommit(True)
 

--- a/tests/test_waiting.py
+++ b/tests/test_waiting.py
@@ -117,7 +117,7 @@ def test_wait_large_fd(dsn, waitfn):
 @pytest.mark.anyio
 async def test_wait_conn_async(dsn, timeout):
     gen = generators.connect(dsn)
-    conn = await waiting.wait_conn_async(gen, **timeout)
+    conn = await waiting.wait_conn_asyncio(gen, **timeout)
     assert conn.status == ConnStatus.OK
 
 
@@ -125,7 +125,7 @@ async def test_wait_conn_async(dsn, timeout):
 async def test_wait_conn_async_bad(dsn):
     gen = generators.connect("dbname=nosuchdb")
     with pytest.raises(psycopg.OperationalError):
-        await waiting.wait_conn_async(gen)
+        await waiting.wait_conn_asyncio(gen)
 
 
 @pytest.mark.anyio
@@ -137,7 +137,7 @@ async def test_wait_ready_async(wait, ready):
         return r
 
     with socket.socket() as s:
-        r = await waiting.wait_async(gen(), s.fileno())
+        r = await waiting.wait_asyncio(gen(), s.fileno())
     assert r & ready
 
 
@@ -156,4 +156,4 @@ async def test_wait_async_bad(pgconn):
     socket = pgconn.socket
     pgconn.finish()
     with pytest.raises(psycopg.OperationalError):
-        await waiting.wait_async(gen, socket)
+        await waiting.wait_asyncio(gen, socket)

--- a/tests/test_waiting.py
+++ b/tests/test_waiting.py
@@ -116,19 +116,13 @@ def test_wait_large_fd(dsn, waitfn):
 
 
 @pytest.fixture
-def wait_async(anyio_backend_name):
-    return {
-        "asyncio": waiting.wait_asyncio,
-        "trio": waiting_anyio.wait,
-    }[anyio_backend_name]
+def wait_async(use_anyio):
+    return waiting_anyio.wait if use_anyio else waiting.wait_asyncio
 
 
 @pytest.fixture
-def wait_conn_async(anyio_backend_name):
-    return {
-        "asyncio": waiting.wait_conn_asyncio,
-        "trio": waiting_anyio.wait_conn,
-    }[anyio_backend_name]
+def wait_conn_async(use_anyio):
+    return waiting_anyio.wait_conn if use_anyio else waiting.wait_conn_asyncio
 
 
 @pytest.mark.parametrize("timeout", timeouts)

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -4,9 +4,12 @@ import sys
 
 from psycopg.errors import InterfaceError
 
+from .conftest import asyncio_backend
+
 
 @pytest.mark.skipif(sys.platform != "win32", reason="windows only test")
-def test_windows_error(aconn_cls, dsn):
+@asyncio_backend
+def test_windows_error(aconn_cls, dsn, anyio_backend):
     loop = asyncio.ProactorEventLoop()  # type: ignore[attr-defined]
 
     async def go():


### PR DESCRIPTION
This adds support for anyio in psycopg "core" (i.e. not the psycopg_pool) through an `AnyIOConnection` class, associated waiting functions ~~and a custom `AnyIOLibpqWriter` implementation~~.

This uses conditional imports and pulls no explicit dependency on anyio.

The test suite now uses [anyio pytest plugin](https://anyio.readthedocs.io/en/stable/testing.html), instead of pytest-asyncio (this change has beed submitted as another PR #352, which this one is based on).

ticket #29 