### PR TITLE
control pool's tasks startup

### DIFF
--- a/docs/api/pool.rst
+++ b/docs/api/pool.rst
@@ -145,6 +145,8 @@ The `!ConnectionPool` class
 
           # the connection is now back in the pool
    
+   .. automethod:: open
+
    .. automethod:: close
 
       .. note::
@@ -233,6 +235,8 @@ listed here.
 
           # the connection is now back in the pool
    
+   .. automethod:: open
+
    .. automethod:: close
 
       .. note::

--- a/docs/api/pool.rst
+++ b/docs/api/pool.rst
@@ -156,7 +156,7 @@ The `!ConnectionPool` class
       .. note::
           
           The pool can be used as context manager too, in which case it will
-          be closed at the end of the block:
+          be opened when entering the block and closed at the end:
 
           .. code:: python
 
@@ -246,7 +246,7 @@ listed here.
       .. note::
           
           The pool can be used as context manager too, in which case it will
-          be closed at the end of the block:
+          be opened when entering the block and closed at the end:
 
           .. code:: python
 

--- a/docs/api/pool.rst
+++ b/docs/api/pool.rst
@@ -74,6 +74,10 @@ The `!ConnectionPool` class
                      before leaving the function.
    :type configure: `Callable[[Connection], None]`
 
+   :param open: Whether to open the pool at initialization; if `!True`, start
+        worker tasks immediately.
+   :type open: bool, default: `!True`
+
    :param reset: A callback to reset a function after it has been returned to
                  the pool. The connection is guaranteed to be passed to the
                  *reset()* function in "idle" state (no transaction). When

--- a/docs/news_pool.rst
+++ b/docs/news_pool.rst
@@ -15,6 +15,8 @@ psycopg_pool 3.1.0
 
 - Add `ConnectionPool.open()` and `AsyncConnectionPool.open()`
   (:ticket:`#151`).
+- Add an `open` parameter to pool initilization to control whether workers
+  should be started at initialization or not (:ticket:`#151`).
 
 psycopg_pool 3.0.2
 ^^^^^^^^^^^^^^^^^^

--- a/docs/news_pool.rst
+++ b/docs/news_pool.rst
@@ -15,6 +15,8 @@ psycopg_pool 3.1.0
 
 - Add `ConnectionPool.open()` and `AsyncConnectionPool.open()`
   (:ticket:`#151`).
+- Raise an `~psycopg.OperationalError` when trying to re-open a closed pool
+  (:ticket:`#151`).
 - Add an `open` parameter to pool initilization to control whether workers
   should be started at initialization or not (:ticket:`#151`).
 - Possibly open pool (start worker tasks) when entering context manager

--- a/docs/news_pool.rst
+++ b/docs/news_pool.rst
@@ -10,6 +10,12 @@
 Current release
 ---------------
 
+psycopg_pool 3.1.0
+^^^^^^^^^^^^^^^^^^
+
+- Add `ConnectionPool.open()` and `AsyncConnectionPool.open()`
+  (:ticket:`#151`).
+
 psycopg_pool 3.0.2
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/news_pool.rst
+++ b/docs/news_pool.rst
@@ -17,6 +17,8 @@ psycopg_pool 3.1.0
   (:ticket:`#151`).
 - Add an `open` parameter to pool initilization to control whether workers
   should be started at initialization or not (:ticket:`#151`).
+- Possibly open pool (start worker tasks) when entering context manager
+  (:ticket:`#151`).
 
 psycopg_pool 3.0.2
 ^^^^^^^^^^^^^^^^^^

--- a/psycopg_pool/psycopg_pool/base.py
+++ b/psycopg_pool/psycopg_pool/base.py
@@ -94,9 +94,7 @@ class BasePool(Generic[ConnectionType]):
         # connections to the pool.
         self._growing = False
 
-        # _close should be the last property to be set in the state
-        # to avoid warning on __del__ in case __init__ fails.
-        self._closed = False
+        self._closed = True
 
     def __repr__(self) -> str:
         return (

--- a/psycopg_pool/psycopg_pool/base.py
+++ b/psycopg_pool/psycopg_pool/base.py
@@ -51,6 +51,7 @@ class BasePool(Generic[ConnectionType]):
             Callable[["BasePool[ConnectionType]"], None]
         ] = None,
         num_workers: int = 3,
+        open: bool = True,
     ):
         if max_size is None:
             max_size = min_size
@@ -95,7 +96,8 @@ class BasePool(Generic[ConnectionType]):
         self._growing = False
 
         self._closed = True
-        self.open()
+        if open:
+            self.open()
 
     def __repr__(self) -> str:
         return (

--- a/psycopg_pool/psycopg_pool/base.py
+++ b/psycopg_pool/psycopg_pool/base.py
@@ -95,6 +95,7 @@ class BasePool(Generic[ConnectionType]):
         self._growing = False
 
         self._closed = True
+        self.open()
 
     def __repr__(self) -> str:
         return (
@@ -114,6 +115,9 @@ class BasePool(Generic[ConnectionType]):
     def closed(self) -> bool:
         """`!True` if the pool is closed."""
         return self._closed
+
+    def open(self) -> None:
+        self._closed = False
 
     def get_stats(self) -> Dict[str, int]:
         """

--- a/psycopg_pool/psycopg_pool/pool.py
+++ b/psycopg_pool/psycopg_pool/pool.py
@@ -325,6 +325,7 @@ class ConnectionPool(BasePool[Connection[Any]]):
                     )
 
     def __enter__(self) -> "ConnectionPool":
+        self.open()
         return self
 
     def __exit__(

--- a/psycopg_pool/psycopg_pool/pool.py
+++ b/psycopg_pool/psycopg_pool/pool.py
@@ -54,8 +54,6 @@ class ConnectionPool(BasePool[Connection[Any]]):
 
         super().__init__(conninfo, **kwargs)
 
-        self.open()
-
     def __del__(self) -> None:
         # If the '_closed' property is not set we probably failed in __init__.
         # Don't try anything complicated as probably it won't work.
@@ -257,7 +255,7 @@ class ConnectionPool(BasePool[Connection[Any]]):
         # remained unused.
         self.schedule_task(ShrinkPool(self), self.max_idle)
 
-        self._closed = False
+        super().open()
 
     def close(self, timeout: float = 5.0) -> None:
         """Close the pool and make it unavailable to new clients.

--- a/psycopg_pool/psycopg_pool/pool_async.py
+++ b/psycopg_pool/psycopg_pool/pool_async.py
@@ -63,8 +63,6 @@ class AsyncConnectionPool(BasePool[AsyncConnection[Any]]):
 
         super().__init__(conninfo, **kwargs)
 
-        self.open()
-
     async def wait(self, timeout: float = 30.0) -> None:
         async with self._lock:
             assert not self._pool_full_event
@@ -216,7 +214,7 @@ class AsyncConnectionPool(BasePool[AsyncConnection[Any]]):
         # remained unused.
         self.run_task(Schedule(self, ShrinkPool(self), self.max_idle))
 
-        self._closed = False
+        super().open()
 
     async def close(self, timeout: float = 5.0) -> None:
         if self._closed:

--- a/psycopg_pool/psycopg_pool/pool_async.py
+++ b/psycopg_pool/psycopg_pool/pool_async.py
@@ -272,6 +272,7 @@ class AsyncConnectionPool(BasePool[AsyncConnection[Any]]):
             )
 
     async def __aenter__(self) -> "AsyncConnectionPool":
+        self.open()
         return self
 
     async def __aexit__(

--- a/psycopg_pool/psycopg_pool/pool_async.py
+++ b/psycopg_pool/psycopg_pool/pool_async.py
@@ -91,7 +91,7 @@ class AsyncConnectionPool(BasePool[AsyncConnection[Any]]):
         try:
             await asyncio.wait_for(self._pool_full_event.wait(), timeout)
         except asyncio.TimeoutError:
-            await self.close()  # stop all the threads
+            await self.close()  # stop all the tasks
             raise PoolTimeout(
                 f"pool initialization incomplete after {timeout} sec"
             ) from None
@@ -147,7 +147,7 @@ class AsyncConnectionPool(BasePool[AsyncConnection[Any]]):
                 self._waiting.append(pos)
                 self._stats[self._REQUESTS_QUEUED] += 1
 
-                # Allow only one thread at time to grow the pool (or returning
+                # Allow only one task at time to grow the pool (or returning
                 # connections might be starved).
                 if self._nconns < self._max_size and not self._growing:
                     self._nconns += 1
@@ -199,7 +199,7 @@ class AsyncConnectionPool(BasePool[AsyncConnection[Any]]):
             await conn.close()
             return
 
-        # Use a worker to perform eventual maintenance work in a separate thread
+        # Use a worker to perform eventual maintenance work in a separate task
         if self._reset:
             self.run_task(ReturnConnection(self, conn))
         else:
@@ -225,7 +225,7 @@ class AsyncConnectionPool(BasePool[AsyncConnection[Any]]):
         # Stop the scheduler
         await self._sched.enter(0, None)
 
-        # Stop the worker threads
+        # Stop the worker tasks
         for w in self._workers:
             self.run_task(StopWorker(self))
 
@@ -237,7 +237,7 @@ class AsyncConnectionPool(BasePool[AsyncConnection[Any]]):
         for conn in pool:
             await conn.close()
 
-        # Wait for the worker threads to terminate
+        # Wait for the worker tasks to terminate
         wait = asyncio.gather(self._sched_runner, *self._workers)
         if timeout > 0:
             wait = asyncio.wait_for(asyncio.shield(wait), timeout=timeout)
@@ -310,20 +310,20 @@ class AsyncConnectionPool(BasePool[AsyncConnection[Any]]):
         self._reconnect_failed(self)
 
     def run_task(self, task: "MaintenanceTask") -> None:
-        """Run a maintenance task in a worker thread."""
+        """Run a maintenance task in a worker."""
         self._tasks.put_nowait(task)
 
     async def schedule_task(
         self, task: "MaintenanceTask", delay: float
     ) -> None:
-        """Run a maintenance task in a worker thread in the future."""
+        """Run a maintenance task in a worker in the future."""
         await self._sched.enter(delay, task.tick)
 
     @classmethod
     async def worker(cls, q: "asyncio.Queue[MaintenanceTask]") -> None:
         """Runner to execute pending maintenance task.
 
-        The function is designed to run as a separate thread.
+        The function is designed to run as a task.
 
         Block on the queue *q*, run a task received. Finish running if a
         StopWorker is received.
@@ -634,7 +634,7 @@ class MaintenanceTask(ABC):
     async def run(self) -> None:
         """Run the task.
 
-        This usually happens in a worker thread. Call the concrete _run()
+        This usually happens in a worker. Call the concrete _run()
         implementation, if the pool is still alive.
         """
         pool = self.pool()
@@ -647,7 +647,7 @@ class MaintenanceTask(ABC):
     async def tick(self) -> None:
         """Run the scheduled task
 
-        This function is called by the scheduler thread. Use a worker to
+        This function is called by the scheduler task. Use a worker to
         run the task for real in order to free the scheduler immediately.
         """
         pool = self.pool()
@@ -663,7 +663,7 @@ class MaintenanceTask(ABC):
 
 
 class StopWorker(MaintenanceTask):
-    """Signal the maintenance thread to terminate."""
+    """Signal the maintenance worker to terminate."""
 
     async def _run(self, pool: "AsyncConnectionPool") -> None:
         pass

--- a/psycopg_pool/psycopg_pool/pool_async.py
+++ b/psycopg_pool/psycopg_pool/pool_async.py
@@ -239,7 +239,8 @@ class AsyncConnectionPool(BasePool[AsyncConnection[Any]]):
         await self._sched.enter(0, None)
 
         # Stop the worker tasks
-        for w in self._workers:
+        workers, self._workers = self._workers[:], []
+        for w in workers:
             self.run_task(StopWorker(self))
 
         # Signal to eventual clients in the queue that business is closed.
@@ -252,7 +253,8 @@ class AsyncConnectionPool(BasePool[AsyncConnection[Any]]):
 
         # Wait for the worker tasks to terminate
         assert self._sched_runner is not None
-        wait = asyncio.gather(self._sched_runner, *self._workers)
+        sched_runner, self._sched_runner = self._sched_runner, None
+        wait = asyncio.gather(sched_runner, *workers)
         if timeout > 0:
             wait = asyncio.wait_for(asyncio.shield(wait), timeout=timeout)
         try:
@@ -263,7 +265,6 @@ class AsyncConnectionPool(BasePool[AsyncConnection[Any]]):
                 self.name,
                 timeout,
             )
-        self._sched_runner = None
 
     async def __aenter__(self) -> "AsyncConnectionPool":
         return self

--- a/tests/pool/test_pool.py
+++ b/tests/pool/test_pool.py
@@ -8,6 +8,7 @@ from typing import Any, List, Tuple
 import pytest
 
 import psycopg
+from psycopg.errors import OperationalError
 from psycopg.pq import TransactionStatus
 from psycopg._compat import Counter
 
@@ -702,12 +703,9 @@ def test_reopen(dsn):
     p.close()
     assert p._sched_runner is None
     assert not p._workers
-    p.open()
-    assert p._sched_runner is not None
-    assert p._workers
-    with p.connection() as conn:
-        conn.execute("select 1")
-    p.close()
+
+    with pytest.raises(OperationalError, match="cannot be reused"):
+        p.open()
 
 
 @pytest.mark.slow

--- a/tests/pool/test_pool.py
+++ b/tests/pool/test_pool.py
@@ -688,11 +688,11 @@ def test_noopen(dsn):
     assert not p._sched_runner
     assert not p._workers
     assert p.closed
-    p.open()
-    assert p._sched_runner
-    assert p._workers
-    assert not p.closed
-    p.close()
+
+    with p:
+        assert p._sched_runner
+        assert p._workers
+        assert not p.closed
 
 
 def test_reopen(dsn):

--- a/tests/pool/test_pool.py
+++ b/tests/pool/test_pool.py
@@ -561,12 +561,12 @@ def test_fail_rollback_close(dsn, caplog, monkeypatch):
 
 def test_close_no_threads(dsn):
     p = pool.ConnectionPool(dsn)
-    assert p._sched_runner.is_alive()
+    assert p._sched_runner and p._sched_runner.is_alive()
     for t in p._workers:
         assert t.is_alive()
 
     p.close()
-    assert not p._sched_runner.is_alive()
+    assert p._sched_runner is None
     for t in p._workers:
         assert not t.is_alive()
 
@@ -603,6 +603,7 @@ def test_del_no_warning(dsn, recwarn):
 @pytest.mark.slow
 def test_del_stop_threads(dsn):
     p = pool.ConnectionPool(dsn)
+    assert p._sched_runner is not None
     ts = [p._sched_runner] + p._workers
     del p
     sleep(0.1)

--- a/tests/pool/test_pool.py
+++ b/tests/pool/test_pool.py
@@ -683,6 +683,18 @@ def test_closed_queue(dsn):
     assert len(success) == 2
 
 
+def test_noopen(dsn):
+    p = pool.ConnectionPool(dsn, open=False)
+    assert not p._sched_runner
+    assert not p._workers
+    assert p.closed
+    p.open()
+    assert p._sched_runner
+    assert p._workers
+    assert not p.closed
+    p.close()
+
+
 def test_reopen(dsn):
     p = pool.ConnectionPool(dsn)
     with p.connection() as conn:

--- a/tests/pool/test_pool_async.py
+++ b/tests/pool/test_pool_async.py
@@ -7,6 +7,7 @@ from typing import Any, List, Tuple
 import pytest
 
 import psycopg
+from psycopg.errors import OperationalError
 from psycopg.pq import TransactionStatus
 from psycopg._compat import create_task, Counter
 
@@ -690,11 +691,9 @@ async def test_reopen(dsn):
         await conn.execute("select 1")
     await p.close()
     assert p._sched_runner is None
-    p.open()
-    assert p._sched_runner is not None
-    async with p.connection() as conn:
-        await conn.execute("select 1")
-    await p.close()
+
+    with pytest.raises(OperationalError, match="cannot be reused"):
+        p.open()
 
 
 @pytest.mark.slow

--- a/tests/pool/test_pool_async.py
+++ b/tests/pool/test_pool_async.py
@@ -576,12 +576,12 @@ async def test_fail_rollback_close(dsn, caplog, monkeypatch):
 
 async def test_close_no_tasks(dsn):
     p = pool.AsyncConnectionPool(dsn)
-    assert not p._sched_runner.done()
+    assert p._sched_runner and not p._sched_runner.done()
     for t in p._workers:
         assert not t.done()
 
     await p.close()
-    assert p._sched_runner.done()
+    assert p._sched_runner is None
     for t in p._workers:
         assert t.done()
 

--- a/tests/pool/test_pool_async.py
+++ b/tests/pool/test_pool_async.py
@@ -672,6 +672,18 @@ async def test_closed_queue(dsn):
     assert len(success) == 2
 
 
+async def test_noopen(dsn):
+    p = pool.AsyncConnectionPool(dsn, open=False)
+    assert not p._sched_runner
+    assert not p._workers
+    assert p.closed
+    p.open()
+    assert p._sched_runner
+    assert p._workers
+    assert not p.closed
+    await p.close()
+
+
 async def test_reopen(dsn):
     p = pool.AsyncConnectionPool(dsn)
     async with p.connection() as conn:

--- a/tests/pool/test_pool_async.py
+++ b/tests/pool/test_pool_async.py
@@ -672,16 +672,16 @@ async def test_closed_queue(dsn):
     assert len(success) == 2
 
 
-async def test_noopen(dsn):
+async def test_noopen_at_init_contextmanager(dsn):
     p = pool.AsyncConnectionPool(dsn, open=False)
     assert not p._sched_runner
     assert not p._workers
     assert p.closed
-    p.open()
-    assert p._sched_runner
-    assert p._workers
-    assert not p.closed
-    await p.close()
+
+    async with p:
+        assert p._sched_runner
+        assert p._workers
+        assert not p.closed
 
 
 async def test_reopen(dsn):


### PR DESCRIPTION
(edit)
- Add `ConnectionPool.open()` and `AsyncConnectionPool.open()`
- Make it possible to re-open a closed pool.
- Add an `open` parameter to pool initilization to control whether workers should be started at initialization or not.
- Possibly open pool (start worker tasks) when entering context manager.

* * * 
~~This is a refactoring (mostly moving code around), and also a behavior change; that would help moving to anyio as discussed in https://github.com/psycopg/psycopg/issues/29#issuecomment-966153249~~

