### PR TITLE
open pools outside __init__()

### DIFF
--- a/docs/advanced/pool.rst
+++ b/docs/advanced/pool.rst
@@ -25,11 +25,11 @@ Pool life cycle
 ---------------
 
 A typical way to use the pool is to create a single instance of it, as a
-global object, and to use this object in the rest of the program, allowing
-other functions, modules, threads to use it. This is only a common use
-however, and not the necessary one; in particular the connection pool acts as
-a context manager and can be closed automatically at the end of its ``with``
-block::
+global object, open it, and to use this object in the rest of the program,
+allowing other functions, modules, threads to use it. This is only a common
+use however, and not the necessary one; in particular the connection pool acts
+as a context manager and can be closed automatically at the end of its
+``with`` block::
 
     from psycopg_pool import ConnectionPool
 
@@ -42,15 +42,15 @@ If necessary, or convenient, your application may create more than one pool,
 for instance to connect to more than one database or to provide separate
 read-only and read/write connections.
 
-Once a pool is instantiated, the constructor returns immediately, while the
-background workers try to create the required number of connections to fill
-the pool. If your application is misconfigured, or the network is down, it
-means that the pool will be available but threads requesting a connection will
-fail with a `PoolTimeout` after the `~ConnectionPool.connection()` timeout is
-expired. If this behaviour is not desirable you should call the
-`~ConnectionPool.wait()` method after creating the pool, which will block
-until the pool is full or will throw a `PoolTimeout` if the pool isn't ready
-within an allocated time.
+When a pool is instantiated, the constructor returns immediately. It is then
+required to open it to start the background workers that will try to create
+the required number of connections to fill the pool. If your application is
+misconfigured, or the network is down, it means that the pool will be
+available but threads requesting a connection will fail with a `PoolTimeout`
+after the `~ConnectionPool.connection()` timeout is expired. If this behaviour
+is not desirable you should call the `~ConnectionPool.wait()` method after
+opening the pool, which will block until the pool is full or will throw a
+`PoolTimeout` if the pool isn't ready within an allocated time.
 
 The pool background workers create connections according to the parameters
 *conninfo*, *kwargs*, and *connection_class* passed to `ConnectionPool`

--- a/docs/api/pool.rst
+++ b/docs/api/pool.rst
@@ -145,6 +145,8 @@ The `!ConnectionPool` class
 
           # the connection is now back in the pool
    
+   .. automethod:: open
+
    .. automethod:: close
 
       .. note::
@@ -233,6 +235,8 @@ listed here.
 
           # the connection is now back in the pool
    
+   .. automethod:: open
+
    .. automethod:: close
 
       .. note::

--- a/docs/api/pool.rst
+++ b/docs/api/pool.rst
@@ -152,7 +152,7 @@ The `!ConnectionPool` class
       .. note::
           
           The pool can be used as context manager too, in which case it will
-          be closed at the end of the block:
+          be opened when entering the block and closed at the end:
 
           .. code:: python
 
@@ -242,7 +242,7 @@ listed here.
       .. note::
           
           The pool can be used as context manager too, in which case it will
-          be closed at the end of the block:
+          be opened when entering the block and closed at the end:
 
           .. code:: python
 

--- a/docs/news_pool.rst
+++ b/docs/news_pool.rst
@@ -10,6 +10,12 @@
 Current release
 ---------------
 
+psycopg_pool 3.1.0
+^^^^^^^^^^^^^^^^^^
+
+- Add `ConnectionPool.open()` and `AsyncConnectionPool.open()`
+  (:ticket:`#155`).
+
 psycopg_pool 3.0.2
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/news_pool.rst
+++ b/docs/news_pool.rst
@@ -10,9 +10,11 @@
 Current release
 ---------------
 
-psycopg_pool 3.1.0
+psycopg_pool 4.0.0
 ^^^^^^^^^^^^^^^^^^
 
+- Open pool (i.e. start worker tasks) when entering context manager instead of
+  at object initialization (:ticket:`#155`).
 - Add `ConnectionPool.open()` and `AsyncConnectionPool.open()`
   (:ticket:`#155`).
 

--- a/docs/news_pool.rst
+++ b/docs/news_pool.rst
@@ -17,6 +17,8 @@ psycopg_pool 4.0.0
   at object initialization (:ticket:`#155`).
 - Add `ConnectionPool.open()` and `AsyncConnectionPool.open()`
   (:ticket:`#155`).
+- Raise an `~psycopg.OperationalError` when trying to re-open a closed pool
+  (:ticket:`#155`).
 
 psycopg_pool 3.0.2
 ^^^^^^^^^^^^^^^^^^

--- a/psycopg_pool/psycopg_pool/base.py
+++ b/psycopg_pool/psycopg_pool/base.py
@@ -94,9 +94,7 @@ class BasePool(Generic[ConnectionType]):
         # connections to the pool.
         self._growing = False
 
-        # _close should be the last property to be set in the state
-        # to avoid warning on __del__ in case __init__ fails.
-        self._closed = False
+        self._closed = True
 
     def __repr__(self) -> str:
         return (

--- a/psycopg_pool/psycopg_pool/base.py
+++ b/psycopg_pool/psycopg_pool/base.py
@@ -8,6 +8,7 @@ from random import random
 from typing import Any, Callable, Dict, Generic, Optional
 
 from psycopg.abc import ConnectionType
+from psycopg import errors as e
 
 from ._compat import Counter, Deque
 
@@ -94,6 +95,7 @@ class BasePool(Generic[ConnectionType]):
         # connections to the pool.
         self._growing = False
 
+        self._opened = False
         self._closed = True
 
     def __repr__(self) -> str:
@@ -114,6 +116,12 @@ class BasePool(Generic[ConnectionType]):
     def closed(self) -> bool:
         """`!True` if the pool is closed."""
         return self._closed
+
+    def _check_open(self) -> None:
+        if self._closed and self._opened:
+            raise e.OperationalError(
+                "pool has already been opened/closed and cannot be reused"
+            )
 
     def get_stats(self) -> Dict[str, int]:
         """

--- a/psycopg_pool/psycopg_pool/pool.py
+++ b/psycopg_pool/psycopg_pool/pool.py
@@ -229,6 +229,8 @@ class ConnectionPool(BasePool[Connection[Any]]):
         if not self._closed:
             return
 
+        self._check_open()
+
         self._sched_runner = threading.Thread(
             target=self._sched.run, name=f"{self.name}-scheduler", daemon=True
         )
@@ -256,6 +258,7 @@ class ConnectionPool(BasePool[Connection[Any]]):
         self.schedule_task(ShrinkPool(self), self.max_idle)
 
         self._closed = False
+        self._opened = True
 
     def close(self, timeout: float = 5.0) -> None:
         """Close the pool and make it unavailable to new clients.

--- a/psycopg_pool/psycopg_pool/pool.py
+++ b/psycopg_pool/psycopg_pool/pool.py
@@ -54,8 +54,6 @@ class ConnectionPool(BasePool[Connection[Any]]):
 
         super().__init__(conninfo, **kwargs)
 
-        self.open()
-
     def __del__(self) -> None:
         # If the '_closed' property is not set we probably failed in __init__.
         # Don't try anything complicated as probably it won't work.
@@ -327,6 +325,7 @@ class ConnectionPool(BasePool[Connection[Any]]):
                     )
 
     def __enter__(self) -> "ConnectionPool":
+        self.open()
         return self
 
     def __exit__(

--- a/psycopg_pool/psycopg_pool/pool_async.py
+++ b/psycopg_pool/psycopg_pool/pool_async.py
@@ -63,8 +63,6 @@ class AsyncConnectionPool(BasePool[AsyncConnection[Any]]):
 
         super().__init__(conninfo, **kwargs)
 
-        self.open()
-
     async def wait(self, timeout: float = 30.0) -> None:
         async with self._lock:
             assert not self._pool_full_event
@@ -275,6 +273,7 @@ class AsyncConnectionPool(BasePool[AsyncConnection[Any]]):
             )
 
     async def __aenter__(self) -> "AsyncConnectionPool":
+        self.open()
         return self
 
     async def __aexit__(

--- a/psycopg_pool/psycopg_pool/pool_async.py
+++ b/psycopg_pool/psycopg_pool/pool_async.py
@@ -196,6 +196,8 @@ class AsyncConnectionPool(BasePool[AsyncConnection[Any]]):
         if not self._closed:
             return
 
+        self._check_open()
+
         self._sched_runner = create_task(
             self._sched.run(), name=f"{self.name}-scheduler"
         )
@@ -215,6 +217,7 @@ class AsyncConnectionPool(BasePool[AsyncConnection[Any]]):
         self.run_task(Schedule(self, ShrinkPool(self), self.max_idle))
 
         self._closed = False
+        self._opened = True
 
     async def close(self, timeout: float = 5.0) -> None:
         if self._closed:

--- a/psycopg_pool/psycopg_pool/pool_async.py
+++ b/psycopg_pool/psycopg_pool/pool_async.py
@@ -57,28 +57,13 @@ class AsyncConnectionPool(BasePool[AsyncConnection[Any]]):
         self._pool_full_event: Optional[asyncio.Event] = None
 
         self._sched = AsyncScheduler()
+        self._sched_runner: Optional[Task[None]] = None
         self._tasks: "asyncio.Queue[MaintenanceTask]" = asyncio.Queue()
         self._workers: List[Task[None]] = []
 
         super().__init__(conninfo, **kwargs)
 
-        self._sched_runner = create_task(
-            self._sched.run(), name=f"{self.name}-scheduler"
-        )
-        for i in range(self.num_workers):
-            t = create_task(
-                self.worker(self._tasks),
-                name=f"{self.name}-worker-{i}",
-            )
-            self._workers.append(t)
-
-        # populate the pool with initial min_size connections in background
-        for i in range(self._nconns):
-            self.run_task(AddConnection(self))
-
-        # Schedule a task to shrink the pool if connections over min_size have
-        # remained unused.
-        self.run_task(Schedule(self, ShrinkPool(self), self.max_idle))
+        self.open()
 
     async def wait(self, timeout: float = 30.0) -> None:
         async with self._lock:
@@ -205,6 +190,34 @@ class AsyncConnectionPool(BasePool[AsyncConnection[Any]]):
         else:
             await self._return_connection(conn)
 
+    def open(self) -> None:
+        """Open the pool by starting worker tasks.
+
+        No-op if the pool is already opened.
+        """
+        if not self._closed:
+            return
+
+        self._sched_runner = create_task(
+            self._sched.run(), name=f"{self.name}-scheduler"
+        )
+        for i in range(self.num_workers):
+            t = create_task(
+                self.worker(self._tasks),
+                name=f"{self.name}-worker-{i}",
+            )
+            self._workers.append(t)
+
+        # populate the pool with initial min_size connections in background
+        for i in range(self._nconns):
+            self.run_task(AddConnection(self))
+
+        # Schedule a task to shrink the pool if connections over min_size have
+        # remained unused.
+        self.run_task(Schedule(self, ShrinkPool(self), self.max_idle))
+
+        self._closed = False
+
     async def close(self, timeout: float = 5.0) -> None:
         if self._closed:
             return
@@ -238,6 +251,7 @@ class AsyncConnectionPool(BasePool[AsyncConnection[Any]]):
             await conn.close()
 
         # Wait for the worker tasks to terminate
+        assert self._sched_runner is not None
         wait = asyncio.gather(self._sched_runner, *self._workers)
         try:
             if timeout > 0:
@@ -250,6 +264,7 @@ class AsyncConnectionPool(BasePool[AsyncConnection[Any]]):
                 self.name,
                 timeout,
             )
+        self._sched_runner = None
 
     async def __aenter__(self) -> "AsyncConnectionPool":
         return self

--- a/psycopg_pool/psycopg_pool/pool_async.py
+++ b/psycopg_pool/psycopg_pool/pool_async.py
@@ -188,7 +188,7 @@ class AsyncConnectionPool(BasePool[AsyncConnection[Any]]):
         else:
             await self._return_connection(conn)
 
-    def open(self) -> None:
+    async def open(self) -> None:
         """Open the pool by starting worker tasks.
 
         No-op if the pool is already opened.
@@ -276,7 +276,7 @@ class AsyncConnectionPool(BasePool[AsyncConnection[Any]]):
             )
 
     async def __aenter__(self) -> "AsyncConnectionPool":
-        self.open()
+        await self.open()
         return self
 
     async def __aexit__(

--- a/tests/pool/test_pool.py
+++ b/tests/pool/test_pool.py
@@ -8,6 +8,7 @@ from typing import Any, List, Tuple
 import pytest
 
 import psycopg
+from psycopg.errors import OperationalError
 from psycopg.pq import TransactionStatus
 from psycopg._compat import Counter
 
@@ -699,12 +700,9 @@ def test_reopen(dsn):
     p.close()
     assert p._sched_runner is None
     assert not p._workers
-    p.open()
-    assert p._sched_runner is not None
-    assert p._workers
-    with p.connection() as conn:
-        conn.execute("select 1")
-    p.close()
+
+    with pytest.raises(OperationalError, match="cannot be reused"):
+        p.open()
 
 
 @pytest.mark.slow

--- a/tests/pool/test_pool.py
+++ b/tests/pool/test_pool.py
@@ -561,12 +561,12 @@ def test_fail_rollback_close(dsn, caplog, monkeypatch):
 
 def test_close_no_threads(dsn):
     p = pool.ConnectionPool(dsn)
-    assert p._sched_runner.is_alive()
+    assert p._sched_runner and p._sched_runner.is_alive()
     for t in p._workers:
         assert t.is_alive()
 
     p.close()
-    assert not p._sched_runner.is_alive()
+    assert p._sched_runner is None
     for t in p._workers:
         assert not t.is_alive()
 
@@ -603,6 +603,7 @@ def test_del_no_warning(dsn, recwarn):
 @pytest.mark.slow
 def test_del_stop_threads(dsn):
     p = pool.ConnectionPool(dsn)
+    assert p._sched_runner is not None
     ts = [p._sched_runner] + p._workers
     del p
     sleep(0.1)

--- a/tests/pool/test_pool_async.py
+++ b/tests/pool/test_pool_async.py
@@ -7,6 +7,7 @@ from typing import Any, List, Tuple
 import pytest
 
 import psycopg
+from psycopg.errors import OperationalError
 from psycopg.pq import TransactionStatus
 from psycopg._compat import create_task, Counter
 
@@ -683,11 +684,9 @@ async def test_reopen(dsn):
         await conn.execute("select 1")
     await p.close()
     assert p._sched_runner is None
-    p.open()
-    assert p._sched_runner is not None
-    async with p.connection() as conn:
-        await conn.execute("select 1")
-    await p.close()
+
+    with pytest.raises(OperationalError, match="cannot be reused"):
+        p.open()
 
 
 @pytest.mark.slow

--- a/tests/pool/test_pool_async.py
+++ b/tests/pool/test_pool_async.py
@@ -576,12 +576,12 @@ async def test_fail_rollback_close(dsn, caplog, monkeypatch):
 
 async def test_close_no_tasks(dsn):
     p = pool.AsyncConnectionPool(dsn)
-    assert not p._sched_runner.done()
+    assert p._sched_runner and not p._sched_runner.done()
     for t in p._workers:
         assert not t.done()
 
     await p.close()
-    assert p._sched_runner.done()
+    assert p._sched_runner is None
     for t in p._workers:
         assert t.done()
 

--- a/tests/pool/test_pool_async.py
+++ b/tests/pool/test_pool_async.py
@@ -577,7 +577,7 @@ async def test_fail_rollback_close(dsn, caplog, monkeypatch):
 
 async def test_close_no_tasks(dsn):
     p = pool.AsyncConnectionPool(dsn)
-    p.open()
+    await p.open()
     assert p._sched_runner and not p._sched_runner.done()
     assert p._workers
     workers = p._workers[:]
@@ -610,7 +610,7 @@ async def test_putconn_wrong_pool(dsn):
 
 async def test_closed_getconn(dsn):
     p = pool.AsyncConnectionPool(dsn, min_size=1)
-    p.open()
+    await p.open()
     assert not p.closed
     async with p.connection():
         pass
@@ -625,7 +625,7 @@ async def test_closed_getconn(dsn):
 
 async def test_closed_putconn(dsn):
     p = pool.AsyncConnectionPool(dsn, min_size=1)
-    p.open()
+    await p.open()
 
     async with p.connection() as conn:
         pass
@@ -656,7 +656,7 @@ async def test_closed_queue(dsn):
     e2 = asyncio.Event()
 
     p = pool.AsyncConnectionPool(dsn, min_size=1)
-    p.open()
+    await p.open()
     await p.wait()
     success: List[str] = []
 
@@ -679,14 +679,14 @@ async def test_closed_queue(dsn):
 
 async def test_reopen(dsn):
     p = pool.AsyncConnectionPool(dsn)
-    p.open()
+    await p.open()
     async with p.connection() as conn:
         await conn.execute("select 1")
     await p.close()
     assert p._sched_runner is None
 
     with pytest.raises(OperationalError, match="cannot be reused"):
-        p.open()
+        await p.open()
 
 
 @pytest.mark.slow

--- a/tests/pool/test_pool_async.py
+++ b/tests/pool/test_pool_async.py
@@ -576,6 +576,7 @@ async def test_fail_rollback_close(dsn, caplog, monkeypatch):
 
 async def test_close_no_tasks(dsn):
     p = pool.AsyncConnectionPool(dsn)
+    p.open()
     assert p._sched_runner and not p._sched_runner.done()
     assert p._workers
     workers = p._workers[:]
@@ -608,6 +609,7 @@ async def test_putconn_wrong_pool(dsn):
 
 async def test_closed_getconn(dsn):
     p = pool.AsyncConnectionPool(dsn, min_size=1)
+    p.open()
     assert not p.closed
     async with p.connection():
         pass
@@ -622,6 +624,7 @@ async def test_closed_getconn(dsn):
 
 async def test_closed_putconn(dsn):
     p = pool.AsyncConnectionPool(dsn, min_size=1)
+    p.open()
 
     async with p.connection() as conn:
         pass
@@ -652,6 +655,7 @@ async def test_closed_queue(dsn):
     e2 = asyncio.Event()
 
     p = pool.AsyncConnectionPool(dsn, min_size=1)
+    p.open()
     await p.wait()
     success: List[str] = []
 
@@ -674,6 +678,7 @@ async def test_closed_queue(dsn):
 
 async def test_reopen(dsn):
     p = pool.AsyncConnectionPool(dsn)
+    p.open()
     async with p.connection() as conn:
         await conn.execute("select 1")
     await p.close()


### PR DESCRIPTION
Per discussions in #151, this PR removes pools opening (workers startup) from `__init__()` and instead performs this at context manager enter or at explicit call of the new `open()` method.
This is breaking change, thus targetting psycopg_pool version 4.0