### PR TITLE
Add a minimal coverage configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ __pycache__/
 /psycopg_binary/
 .vscode
 .venv
+.coverage
+htmlcov

--- a/psycopg/setup.py
+++ b/psycopg/setup.py
@@ -41,6 +41,7 @@ extras_require = {
         "pproxy ~= 2.7.8",
         "pytest ~= 6.2.5",
         "pytest-asyncio ~= 0.16.0",
+        "pytest-cov ~= 3.0.0",
         "pytest-randomly ~= 3.10.1",
         "tenacity ~= 8.0.1",
     ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,16 @@ testpaths=[
 # log_format = "%(asctime)s.%(msecs)03d %(levelname)-8s %(name)s:%(filename)s:%(lineno)d %(message)s"
 # log_level = "DEBUG"
 
+[tool.coverage.run]
+source = [
+    "psycopg/psycopg",
+    "psycopg_pool/psycopg_pool",
+]
+[tool.coverage.report]
+exclude_lines = [
+    "if TYPE_CHECKING:",
+    '\.\.\.$',
+]
 
 [tool.mypy]
 files = [


### PR DESCRIPTION

This does not check psycopg_c code, and I'm sure if/how this can be achieved, but this is enough to be useful to me for now.