### PR TITLE
adds a test `copy_to_large.py` for issue #158

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -149,6 +149,9 @@ jobs:
       - name: Install tox
         run: pip install tox
 
+      - name: Show file limits
+        run: launchctl limit maxfiles
+
       - name: Run tests (Python implementation)
         if: ${{ matrix.impl == 'python' }}
         run: tox -c psycopg -e ${{ matrix.python }} -- tests/test_copy_to_large.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -137,7 +137,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install PostgreSQL on the runner
-        run: brew install postgresql@13
+        run: brew install postgresql@14
 
       - name: Start PostgreSQL service for test
         run: brew services start postgresql

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,13 +70,13 @@ jobs:
 
       - name: Run tests (Python implementation)
         if: ${{ matrix.impl == 'python' }}
-        run: tox -c psycopg -e ${{ matrix.python }}
+        run: tox -c psycopg -e ${{ matrix.python }} -- tests/copy_to_large.py
 
       - name: Run tests (C implementation)
         if: ${{ matrix.impl == 'c' }}
         # skip tests failing on importing psycopg_c.pq on subprocess
         # they only fail on Travis, work ok locally under tox too.
-        run: tox -c psycopg_c -e ${{ matrix.python }} -- -m 'not subprocess'
+        run: tox -c psycopg_c -e ${{ matrix.python }} -- -m 'not subprocess' tests/copy_to_large.py
 
       - name: Run DNS-related tests
         if: ${{ matrix.impl == 'dns' }}
@@ -151,11 +151,11 @@ jobs:
 
       - name: Run tests (Python implementation)
         if: ${{ matrix.impl == 'python' }}
-        run: tox -c psycopg -e ${{ matrix.python }}
+        run: tox -c psycopg -e ${{ matrix.python }} -- tests/copy_to_large.py
 
       - name: Run tests (C implementation)
         if: ${{ matrix.impl == 'c' }}
-        run: tox -c psycopg_c -e ${{ matrix.python }}
+        run: tox -c psycopg_c -e ${{ matrix.python }} -- tests/copy_to_large.py
 
 
   # }}}
@@ -202,7 +202,7 @@ jobs:
 
       - name: Run tests (Python implementation)
         if: ${{ matrix.impl == 'python' }}
-        run: tox -c psycopg -e ${{ matrix.python }}
+        run: tox -c psycopg -e ${{ matrix.python }} -- tests/copy_to_large.py
 
       # Build a wheel package of the C extensions.
       # If the wheel is not delocated, import fails with some dll not found
@@ -226,7 +226,7 @@ jobs:
           &"pip" install @(Get-ChildItem wheelhouse\*.whl)
           # Fix the path for the tests using ctypes
           $env:Path = "C:\Program Files\PostgreSQL\14\bin\;$env:Path"
-          pytest
+          pytest tests/copy_to_large.py
 
 
   # }}}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -108,7 +108,7 @@ jobs:
   # }}}
 
   macos:  # {{{
-    runs-on: macos-10.15
+    runs-on: macos-11
 
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,13 +70,13 @@ jobs:
 
       - name: Run tests (Python implementation)
         if: ${{ matrix.impl == 'python' }}
-        run: tox -c psycopg -e ${{ matrix.python }} -- tests/copy_to_large.py
+        run: tox -c psycopg -e ${{ matrix.python }} -- tests/test_copy_to_large.py
 
       - name: Run tests (C implementation)
         if: ${{ matrix.impl == 'c' }}
         # skip tests failing on importing psycopg_c.pq on subprocess
         # they only fail on Travis, work ok locally under tox too.
-        run: tox -c psycopg_c -e ${{ matrix.python }} -- -m 'not subprocess' tests/copy_to_large.py
+        run: tox -c psycopg_c -e ${{ matrix.python }} -- -m 'not subprocess' tests/test_copy_to_large.py
 
       - name: Run DNS-related tests
         if: ${{ matrix.impl == 'dns' }}
@@ -151,11 +151,11 @@ jobs:
 
       - name: Run tests (Python implementation)
         if: ${{ matrix.impl == 'python' }}
-        run: tox -c psycopg -e ${{ matrix.python }} -- tests/copy_to_large.py
+        run: tox -c psycopg -e ${{ matrix.python }} -- tests/test_copy_to_large.py
 
       - name: Run tests (C implementation)
         if: ${{ matrix.impl == 'c' }}
-        run: tox -c psycopg_c -e ${{ matrix.python }} -- tests/copy_to_large.py
+        run: tox -c psycopg_c -e ${{ matrix.python }} -- tests/test_copy_to_large.py
 
 
   # }}}
@@ -202,7 +202,7 @@ jobs:
 
       - name: Run tests (Python implementation)
         if: ${{ matrix.impl == 'python' }}
-        run: tox -c psycopg -e ${{ matrix.python }} -- tests/copy_to_large.py
+        run: tox -c psycopg -e ${{ matrix.python }} -- tests/test_copy_to_large.py
 
       # Build a wheel package of the C extensions.
       # If the wheel is not delocated, import fails with some dll not found
@@ -226,7 +226,7 @@ jobs:
           &"pip" install @(Get-ChildItem wheelhouse\*.whl)
           # Fix the path for the tests using ctypes
           $env:Path = "C:\Program Files\PostgreSQL\14\bin\;$env:Path"
-          pytest tests/copy_to_large.py
+          pytest tests/test_copy_to_large.py
 
 
   # }}}

--- a/tests/test_copy_to_large.py
+++ b/tests/test_copy_to_large.py
@@ -25,7 +25,7 @@ SELECT
     md5('13' || x::text)::text AS col_13,
     md5('14' || x::text)::text AS col_14,
     md5('15' || x::text)::text AS col_15
-FROM generate_series(1, 3000000) AS x;"""
+FROM generate_series(1, 10000000) AS x;"""
     )
 
     with cur.copy("""COPY pg_temp.dump_test_table TO STDOUT;""") as copy:

--- a/tests/test_copy_to_large.py
+++ b/tests/test_copy_to_large.py
@@ -25,7 +25,7 @@ SELECT
     md5('13' || x::text)::text AS col_13,
     md5('14' || x::text)::text AS col_14,
     md5('15' || x::text)::text AS col_15
-FROM generate_series(1, 20000000) AS x;"""
+FROM generate_series(1, 5000000) AS x;"""
     )
 
     with cur.copy("""COPY pg_temp.dump_test_table TO STDOUT;""") as copy:

--- a/tests/test_copy_to_large.py
+++ b/tests/test_copy_to_large.py
@@ -25,7 +25,7 @@ SELECT
     md5('13' || x::text)::text AS col_13,
     md5('14' || x::text)::text AS col_14,
     md5('15' || x::text)::text AS col_15
-FROM generate_series(1, 5000000) AS x;"""
+FROM generate_series(1, 10000000) AS x;"""
     )
 
     with cur.copy("""COPY pg_temp.dump_test_table TO STDOUT;""") as copy:

--- a/tests/test_copy_to_large.py
+++ b/tests/test_copy_to_large.py
@@ -25,7 +25,7 @@ SELECT
     md5('13' || x::text)::text AS col_13,
     md5('14' || x::text)::text AS col_14,
     md5('15' || x::text)::text AS col_15
-FROM generate_series(1, 10000000) AS x;"""
+FROM generate_series(1, 20000000) AS x;"""
     )
 
     with cur.copy("""COPY pg_temp.dump_test_table TO STDOUT;""") as copy:

--- a/tests/test_copy_to_large.py
+++ b/tests/test_copy_to_large.py
@@ -5,7 +5,8 @@ import pytest
 def test_copy_to_large(conn):
     cur = conn.cursor()
 
-    cur.execute("""
+    cur.execute(
+        """
 CREATE TEMP TABLE dump_test_table AS
 SELECT 
     md5('00' || x::text)::text AS col_00,
@@ -24,7 +25,8 @@ SELECT
     md5('13' || x::text)::text AS col_13,
     md5('14' || x::text)::text AS col_14,
     md5('15' || x::text)::text AS col_15
-FROM generate_series(1, 3000000) AS x;""")
+FROM generate_series(1, 3000000) AS x;"""
+    )
 
     with cur.copy("""COPY pg_temp.dump_test_table TO STDOUT;""") as copy:
         while copy.read():

--- a/tests/test_copy_to_large.py
+++ b/tests/test_copy_to_large.py
@@ -8,7 +8,7 @@ def test_copy_to_large(conn):
     cur.execute(
         """
 CREATE TEMP TABLE dump_test_table AS
-SELECT 
+SELECT
     md5('00' || x::text)::text AS col_00,
     md5('01' || x::text)::text AS col_01,
     md5('02' || x::text)::text AS col_02,

--- a/tests/test_copy_to_large.py
+++ b/tests/test_copy_to_large.py
@@ -1,0 +1,35 @@
+import pytest
+
+
+@pytest.mark.slow
+def test_copy_to_large(conn):
+    cur = conn.cursor()
+
+    cur.execute("""
+CREATE TEMP TABLE dump_test_table AS
+SELECT 
+    md5('00' || x::text)::text AS col_00,
+    md5('01' || x::text)::text AS col_01,
+    md5('02' || x::text)::text AS col_02,
+    md5('03' || x::text)::text AS col_03,
+    md5('04' || x::text)::text AS col_04,
+    md5('05' || x::text)::text AS col_05,
+    md5('06' || x::text)::text AS col_06,
+    md5('07' || x::text)::text AS col_07,
+    md5('08' || x::text)::text AS col_08,
+    md5('09' || x::text)::text AS col_09,
+    md5('10' || x::text)::text AS col_10,
+    md5('11' || x::text)::text AS col_11,
+    md5('12' || x::text)::text AS col_12,
+    md5('13' || x::text)::text AS col_13,
+    md5('14' || x::text)::text AS col_14,
+    md5('15' || x::text)::text AS col_15
+FROM generate_series(1, 3000000) AS x;""")
+
+    with cur.copy("""COPY pg_temp.dump_test_table TO STDOUT;""") as copy:
+        while copy.read():
+            pass
+
+    cur.execute("""DISCARD TEMP;""")
+
+    assert conn.pgconn.transaction_status == conn.TransactionStatus.INTRANS


### PR DESCRIPTION
As discussed in issue #158. This test should fire if file descriptors leak in large `COPY ... TO` operations.