### PR TITLE
Pool open

### DIFF
--- a/docs/api/pool.rst
+++ b/docs/api/pool.rst
@@ -145,6 +145,8 @@ The `!ConnectionPool` class
 
           # the connection is now back in the pool
    
+   .. automethod:: open
+
    .. automethod:: close
 
       .. note::
@@ -233,6 +235,8 @@ listed here.
 
           # the connection is now back in the pool
    
+   .. automethod:: open
+
    .. automethod:: close
 
       .. note::

--- a/docs/api/pool.rst
+++ b/docs/api/pool.rst
@@ -31,7 +31,7 @@ instance from the rest of the code (especially the
 The `!ConnectionPool` class
 ---------------------------
 
-.. autoclass:: ConnectionPool(conninfo, *, **arguments)
+.. autoclass:: ConnectionPool
 
    This class implements a connection pool serving `~psycopg.Connection`
    instances (or subclasses). The constructor has *alot* of arguments, but
@@ -66,6 +66,12 @@ The `!ConnectionPool` class
    :param connection_class: The class of the connections to serve. It should
                             be a `!Connection` subclass.
    :type connection_class: `!type`, default: `~psycopg.Connection`
+
+   :param open: If `!true`, open the pool, creating the required connections,
+                on init. If `!false`, open the pool when `!open()` is called or
+                when the pool context is entered. See the `open()` method
+                documentation for more details.
+   :type open: `!bool`, default: `!true`
 
    :param configure: A callback to configure a connection after creation.
                      Useful, for instance, to configure its adapters. If the
@@ -119,7 +125,7 @@ The `!ConnectionPool` class
                              the connection attempt is aborted and the
                              *reconnect_failed* callback invoked.
    :type reconnect_timeout: `!float`, default: 5 minutes
-                             
+
    :param reconnect_failed: Callback invoked if an attempt to create a new
                             connection fails for more than *reconnect_timeout*
                             seconds. The user may decide, for instance, to
@@ -135,29 +141,41 @@ The `!ConnectionPool` class
                        they are returned to the pool.
    :type num_workers: `!int`, default: 3
 
+   .. versionchanged:: psycopg_pool 3.1
+
+        Added `!open` parameter to init method.
+
+   .. note:: In a future version, the deafult value for the `!open` parameter
+        might be changed to `!false`. If you rely on this behaviour (e.g. if
+        you don't use the pool as a context manager) you might want to specify
+        this parameter explicitly.
+
    .. automethod:: wait
    .. automethod:: connection
-   
+
       .. code:: python
 
           with my_pool.connection() as conn:
               conn.execute(...)
 
           # the connection is now back in the pool
-   
+
    .. automethod:: open
+
+      .. versionadded:: psycopg_pool 3.1
+
 
    .. automethod:: close
 
-      .. note::
-          
-          The pool can be used as context manager too, in which case it will
-          be closed at the end of the block:
+   .. note::
 
-          .. code:: python
+      The pool can be also used as a context manager, in which case it will
+      be opened (if necessary) on entering the block and closed on exiting it:
 
-              with ConnectionPool(...) as pool:
-                  # code using the pool
+      .. code:: python
+
+          with ConnectionPool(...) as pool:
+              # code using the pool
 
    .. attribute:: name
       :type: str
@@ -170,7 +188,7 @@ The `!ConnectionPool` class
 
       The current minimum and maximum size of the pool. Use `resize()` to
       change them at runtime.
-   
+
    .. automethod:: resize
    .. automethod:: check
    .. automethod:: get_stats
@@ -182,6 +200,7 @@ The `!ConnectionPool` class
 
    .. automethod:: getconn
    .. automethod:: putconn
+
 
 Pool exceptions
 ---------------
@@ -210,7 +229,7 @@ so in the *connection_class* parameter.
 Only the function with different signature from `!ConnectionPool` are
 listed here.
 
-.. autoclass:: AsyncConnectionPool(conninfo, *, **arguments)
+.. autoclass:: AsyncConnectionPool
 
    All the other parameters are the same.
 
@@ -227,27 +246,28 @@ listed here.
 
    .. automethod:: wait
    .. automethod:: connection
-   
+
       .. code:: python
 
           async with my_pool.connection() as conn:
               await conn.execute(...)
 
           # the connection is now back in the pool
-   
+
    .. automethod:: open
 
    .. automethod:: close
 
-      .. note::
-          
-          The pool can be used as context manager too, in which case it will
-          be closed at the end of the block:
+   .. note::
 
-          .. code:: python
+      The pool can be also used as an async context manager, in which case it
+      will be opened (if necessary) on entering the block and closed on
+      exiting it:
 
-              async with AsyncConnectionPool(...) as pool:
-                  # code using the pool
+      .. code:: python
+
+          async with AsyncConnectionPool(...) as pool:
+              # code using the pool
 
    .. automethod:: resize
    .. automethod:: check

--- a/docs/news_pool.rst
+++ b/docs/news_pool.rst
@@ -10,6 +10,12 @@
 Current release
 ---------------
 
+psycopg_pool 3.1.0
+^^^^^^^^^^^^^^^^^^
+
+- Add `ConnectionPool.open()` and `AsyncConnectionPool.open()`
+  (:ticket:`#155`).
+
 psycopg_pool 3.0.2
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/news_pool.rst
+++ b/docs/news_pool.rst
@@ -15,6 +15,8 @@ psycopg_pool 3.1.0
 
 - Add `ConnectionPool.open()` and `AsyncConnectionPool.open()`
   (:ticket:`#155`).
+- Raise an `~psycopg.OperationalError` when trying to re-open a closed pool
+  (:ticket:`#155`).
 
 psycopg_pool 3.0.2
 ^^^^^^^^^^^^^^^^^^

--- a/docs/news_pool.rst
+++ b/docs/news_pool.rst
@@ -7,16 +7,18 @@
 ``psycopg_pool`` release notes
 ==============================
 
-Current release
+Future releases
 ---------------
 
-psycopg_pool 3.1.0
-^^^^^^^^^^^^^^^^^^
+psycopg_pool 3.1.0 (unreleased)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- Add `ConnectionPool.open()` and `AsyncConnectionPool.open()`
-  (:ticket:`#155`).
-- Raise an `~psycopg.OperationalError` when trying to re-open a closed pool
-  (:ticket:`#155`).
+- Add `ConnectionPool.open()` and `!open` parameter to the pool init
+  (:ticket:`#151`).
+
+
+Current release
+---------------
 
 psycopg_pool 3.0.2
 ^^^^^^^^^^^^^^^^^^

--- a/psycopg_pool/psycopg_pool/base.py
+++ b/psycopg_pool/psycopg_pool/base.py
@@ -94,9 +94,7 @@ class BasePool(Generic[ConnectionType]):
         # connections to the pool.
         self._growing = False
 
-        # _close should be the last property to be set in the state
-        # to avoid warning on __del__ in case __init__ fails.
-        self._closed = False
+        self._closed = True
 
     def __repr__(self) -> str:
         return (

--- a/psycopg_pool/psycopg_pool/base.py
+++ b/psycopg_pool/psycopg_pool/base.py
@@ -8,6 +8,7 @@ from random import random
 from typing import Any, Callable, Dict, Generic, Optional
 
 from psycopg.abc import ConnectionType
+from psycopg import errors as e
 
 from ._compat import Counter, Deque
 
@@ -94,6 +95,7 @@ class BasePool(Generic[ConnectionType]):
         # connections to the pool.
         self._growing = False
 
+        self._opened = False
         self._closed = True
 
     def __repr__(self) -> str:
@@ -114,6 +116,12 @@ class BasePool(Generic[ConnectionType]):
     def closed(self) -> bool:
         """`!True` if the pool is closed."""
         return self._closed
+
+    def _check_open(self) -> None:
+        if self._closed and self._opened:
+            raise e.OperationalError(
+                "pool has already been opened/closed and cannot be reused"
+            )
 
     def get_stats(self) -> Dict[str, int]:
         """

--- a/psycopg_pool/psycopg_pool/base.py
+++ b/psycopg_pool/psycopg_pool/base.py
@@ -128,13 +128,9 @@ class BasePool(Generic[ConnectionType]):
     def _check_open_getconn(self) -> None:
         if self._closed:
             if self._opened:
-                raise PoolClosed(
-                    f"the pool {self.name!r} has already been closed"
-                )
+                raise PoolClosed(f"the pool {self.name!r} is already closed")
             else:
-                raise PoolClosed(
-                    f"the pool {self.name!r} has not been opened yet"
-                )
+                raise PoolClosed(f"the pool {self.name!r} is not open yet")
 
     def get_stats(self) -> Dict[str, int]:
         """

--- a/psycopg_pool/psycopg_pool/base.py
+++ b/psycopg_pool/psycopg_pool/base.py
@@ -9,6 +9,7 @@ from typing import Any, Callable, Dict, Generic, Optional
 
 from psycopg.abc import ConnectionType
 from psycopg import errors as e
+from .errors import PoolClosed
 
 from ._compat import Counter, Deque
 
@@ -123,6 +124,17 @@ class BasePool(Generic[ConnectionType]):
             raise e.OperationalError(
                 "pool has already been opened/closed and cannot be reused"
             )
+
+    def _check_open_getconn(self) -> None:
+        if self._closed:
+            if self._opened:
+                raise PoolClosed(
+                    f"the pool {self.name!r} has already been closed"
+                )
+            else:
+                raise PoolClosed(
+                    f"the pool {self.name!r} has not been opened yet"
+                )
 
     def get_stats(self) -> Dict[str, int]:
         """

--- a/psycopg_pool/psycopg_pool/base.py
+++ b/psycopg_pool/psycopg_pool/base.py
@@ -42,6 +42,7 @@ class BasePool(Generic[ConnectionType]):
         kwargs: Optional[Dict[str, Any]] = None,
         min_size: int = 4,
         max_size: Optional[int] = None,
+        open: bool = True,
         name: Optional[str] = None,
         timeout: float = 30.0,
         max_waiting: int = 0,

--- a/psycopg_pool/psycopg_pool/pool.py
+++ b/psycopg_pool/psycopg_pool/pool.py
@@ -111,7 +111,6 @@ class ConnectionPool(BasePool[Connection[Any]]):
         :ref:`connection context behaviour <with-connection>` (commit/rollback
         the transaction in case of success/error). If the connection is no more
         in working state replace it with a new one.
-
         """
         conn = self.getconn(timeout=timeout)
         t0 = monotonic()
@@ -226,9 +225,11 @@ class ConnectionPool(BasePool[Connection[Any]]):
             self._return_connection(conn)
 
     def open(self) -> None:
-        """Open the pool by starting worker threads.
+        """Open the pool by starting connecting and and accepting clients.
 
-        No-op if the pool is already opened.
+        The method is no-op if the pool is already opened (because the method
+        was already called, or because the pool context was entered, or because
+        the pool was initialized with ``open=true``.
         """
         with self._lock:
             if not self._closed:
@@ -273,7 +274,7 @@ class ConnectionPool(BasePool[Connection[Any]]):
     def close(self, timeout: float = 5.0) -> None:
         """Close the pool and make it unavailable to new clients.
 
-        All the waiting and future client will fail to acquire a connection
+        All the waiting and future clients will fail to acquire a connection
         with a `PoolClosed` exception. Currently used connections will not be
         closed until returned to the pool.
 

--- a/psycopg_pool/psycopg_pool/pool.py
+++ b/psycopg_pool/psycopg_pool/pool.py
@@ -231,6 +231,8 @@ class ConnectionPool(BasePool[Connection[Any]]):
         if not self._closed:
             return
 
+        self._check_open()
+
         self._sched_runner = threading.Thread(
             target=self._sched.run, name=f"{self.name}-scheduler", daemon=True
         )
@@ -258,6 +260,7 @@ class ConnectionPool(BasePool[Connection[Any]]):
         self.schedule_task(ShrinkPool(self), self.max_idle)
 
         self._closed = False
+        self._opened = True
 
     def close(self, timeout: float = 5.0) -> None:
         """Close the pool and make it unavailable to new clients.

--- a/psycopg_pool/psycopg_pool/pool.py
+++ b/psycopg_pool/psycopg_pool/pool.py
@@ -137,8 +137,7 @@ class ConnectionPool(BasePool[Connection[Any]]):
         # Critical section: decide here if there's a connection ready
         # or if the client needs to wait.
         with self._lock:
-            if self._closed:
-                raise PoolClosed(f"the pool {self.name!r} is closed")
+            self._check_open_getconn()
 
             pos: Optional[WaitingClient] = None
             if self._pool:

--- a/psycopg_pool/psycopg_pool/pool_async.py
+++ b/psycopg_pool/psycopg_pool/pool_async.py
@@ -198,6 +198,8 @@ class AsyncConnectionPool(BasePool[AsyncConnection[Any]]):
         if not self._closed:
             return
 
+        self._check_open()
+
         self._sched_runner = create_task(
             self._sched.run(), name=f"{self.name}-scheduler"
         )
@@ -217,6 +219,7 @@ class AsyncConnectionPool(BasePool[AsyncConnection[Any]]):
         self.run_task(Schedule(self, ShrinkPool(self), self.max_idle))
 
         self._closed = False
+        self._opened = True
 
     async def close(self, timeout: float = 5.0) -> None:
         if self._closed:

--- a/psycopg_pool/psycopg_pool/pool_async.py
+++ b/psycopg_pool/psycopg_pool/pool_async.py
@@ -65,7 +65,7 @@ class AsyncConnectionPool(BasePool[AsyncConnection[Any]]):
         super().__init__(conninfo, **kwargs)
 
         if open:
-            self.open()
+            self._open()
 
     async def wait(self, timeout: float = 30.0) -> None:
         async with self._lock:
@@ -192,7 +192,11 @@ class AsyncConnectionPool(BasePool[AsyncConnection[Any]]):
         else:
             await self._return_connection(conn)
 
-    def open(self) -> None:
+    async def open(self) -> None:
+        async with self._lock:
+            self._open()
+
+    def _open(self) -> None:
         if not self._closed:
             return
 
@@ -279,7 +283,7 @@ class AsyncConnectionPool(BasePool[AsyncConnection[Any]]):
             )
 
     async def __aenter__(self) -> "AsyncConnectionPool":
-        self.open()
+        await self.open()
         return self
 
     async def __aexit__(

--- a/psycopg_pool/psycopg_pool/pool_async.py
+++ b/psycopg_pool/psycopg_pool/pool_async.py
@@ -111,8 +111,7 @@ class AsyncConnectionPool(BasePool[AsyncConnection[Any]]):
         # Critical section: decide here if there's a connection ready
         # or if the client needs to wait.
         async with self._lock:
-            if self._closed:
-                raise PoolClosed(f"the pool {self.name!r} is closed")
+            self._check_open_getconn()
 
             pos: Optional[AsyncClient] = None
             if self._pool:

--- a/psycopg_pool/psycopg_pool/pool_async.py
+++ b/psycopg_pool/psycopg_pool/pool_async.py
@@ -57,28 +57,13 @@ class AsyncConnectionPool(BasePool[AsyncConnection[Any]]):
         self._pool_full_event: Optional[asyncio.Event] = None
 
         self._sched = AsyncScheduler()
+        self._sched_runner: Optional[Task[None]] = None
         self._tasks: "asyncio.Queue[MaintenanceTask]" = asyncio.Queue()
         self._workers: List[Task[None]] = []
 
         super().__init__(conninfo, **kwargs)
 
-        self._sched_runner = create_task(
-            self._sched.run(), name=f"{self.name}-scheduler"
-        )
-        for i in range(self.num_workers):
-            t = create_task(
-                self.worker(self._tasks),
-                name=f"{self.name}-worker-{i}",
-            )
-            self._workers.append(t)
-
-        # populate the pool with initial min_size connections in background
-        for i in range(self._nconns):
-            self.run_task(AddConnection(self))
-
-        # Schedule a task to shrink the pool if connections over min_size have
-        # remained unused.
-        self.run_task(Schedule(self, ShrinkPool(self), self.max_idle))
+        self.open()
 
     async def wait(self, timeout: float = 30.0) -> None:
         async with self._lock:
@@ -205,6 +190,34 @@ class AsyncConnectionPool(BasePool[AsyncConnection[Any]]):
         else:
             await self._return_connection(conn)
 
+    def open(self) -> None:
+        """Open the pool by starting worker tasks.
+
+        No-op if the pool is already opened.
+        """
+        if not self._closed:
+            return
+
+        self._sched_runner = create_task(
+            self._sched.run(), name=f"{self.name}-scheduler"
+        )
+        for i in range(self.num_workers):
+            t = create_task(
+                self.worker(self._tasks),
+                name=f"{self.name}-worker-{i}",
+            )
+            self._workers.append(t)
+
+        # populate the pool with initial min_size connections in background
+        for i in range(self._nconns):
+            self.run_task(AddConnection(self))
+
+        # Schedule a task to shrink the pool if connections over min_size have
+        # remained unused.
+        self.run_task(Schedule(self, ShrinkPool(self), self.max_idle))
+
+        self._closed = False
+
     async def close(self, timeout: float = 5.0) -> None:
         if self._closed:
             return
@@ -238,6 +251,7 @@ class AsyncConnectionPool(BasePool[AsyncConnection[Any]]):
             await conn.close()
 
         # Wait for the worker tasks to terminate
+        assert self._sched_runner is not None
         wait = asyncio.gather(self._sched_runner, *self._workers)
         try:
             if timeout > 0:
@@ -250,6 +264,7 @@ class AsyncConnectionPool(BasePool[AsyncConnection[Any]]):
                 self.name,
                 timeout,
             )
+        self._sched_runner = None
 
     async def __aenter__(self) -> "AsyncConnectionPool":
         return self

--- a/tests/pool/test_pool.py
+++ b/tests/pool/test_pool.py
@@ -687,7 +687,7 @@ def test_closed_queue(dsn):
 def test_open_explicit(dsn):
     p = pool.ConnectionPool(dsn, open=False)
     assert p.closed
-    with pytest.raises(pool.PoolClosed, match="has not been opened yet"):
+    with pytest.raises(pool.PoolClosed, match="is not open yet"):
         p.getconn()
 
     with pytest.raises(pool.PoolClosed):
@@ -705,7 +705,7 @@ def test_open_explicit(dsn):
     finally:
         p.close()
 
-    with pytest.raises(pool.PoolClosed, match="has already been closed"):
+    with pytest.raises(pool.PoolClosed, match="is already closed"):
         p.getconn()
 
 

--- a/tests/pool/test_pool.py
+++ b/tests/pool/test_pool.py
@@ -687,7 +687,7 @@ def test_closed_queue(dsn):
 def test_open_explicit(dsn):
     p = pool.ConnectionPool(dsn, open=False)
     assert p.closed
-    with pytest.raises(pool.PoolClosed):
+    with pytest.raises(pool.PoolClosed, match="has not been opened yet"):
         p.getconn()
 
     with pytest.raises(pool.PoolClosed):
@@ -704,6 +704,9 @@ def test_open_explicit(dsn):
 
     finally:
         p.close()
+
+    with pytest.raises(pool.PoolClosed, match="has already been closed"):
+        p.getconn()
 
 
 def test_open_context(dsn):

--- a/tests/pool/test_pool.py
+++ b/tests/pool/test_pool.py
@@ -561,12 +561,12 @@ def test_fail_rollback_close(dsn, caplog, monkeypatch):
 
 def test_close_no_threads(dsn):
     p = pool.ConnectionPool(dsn)
-    assert p._sched_runner.is_alive()
+    assert p._sched_runner and p._sched_runner.is_alive()
     for t in p._workers:
         assert t.is_alive()
 
     p.close()
-    assert not p._sched_runner.is_alive()
+    assert p._sched_runner is None
     for t in p._workers:
         assert not t.is_alive()
 
@@ -603,6 +603,7 @@ def test_del_no_warning(dsn, recwarn):
 @pytest.mark.slow
 def test_del_stop_threads(dsn):
     p = pool.ConnectionPool(dsn)
+    assert p._sched_runner is not None
     ts = [p._sched_runner] + p._workers
     del p
     sleep(0.1)

--- a/tests/pool/test_pool.py
+++ b/tests/pool/test_pool.py
@@ -8,6 +8,7 @@ from typing import Any, List, Tuple
 import pytest
 
 import psycopg
+from psycopg.errors import OperationalError
 from psycopg.pq import TransactionStatus
 from psycopg._compat import Counter
 
@@ -690,12 +691,9 @@ def test_reopen(dsn):
     p.close()
     assert p._sched_runner is None
     assert not p._workers
-    p.open()
-    assert p._sched_runner is not None
-    assert p._workers
-    with p.connection() as conn:
-        conn.execute("select 1")
-    p.close()
+
+    with pytest.raises(OperationalError, match="cannot be reused"):
+        p.open()
 
 
 @pytest.mark.slow

--- a/tests/pool/test_pool_async.py
+++ b/tests/pool/test_pool_async.py
@@ -7,6 +7,7 @@ from typing import Any, List, Tuple
 import pytest
 
 import psycopg
+from psycopg.errors import OperationalError
 from psycopg.pq import TransactionStatus
 from psycopg._compat import create_task, Counter
 
@@ -678,11 +679,9 @@ async def test_reopen(dsn):
         await conn.execute("select 1")
     await p.close()
     assert p._sched_runner is None
-    p.open()
-    assert p._sched_runner is not None
-    async with p.connection() as conn:
-        await conn.execute("select 1")
-    await p.close()
+
+    with pytest.raises(OperationalError, match="cannot be reused"):
+        p.open()
 
 
 @pytest.mark.slow

--- a/tests/pool/test_pool_async.py
+++ b/tests/pool/test_pool_async.py
@@ -576,12 +576,12 @@ async def test_fail_rollback_close(dsn, caplog, monkeypatch):
 
 async def test_close_no_tasks(dsn):
     p = pool.AsyncConnectionPool(dsn)
-    assert not p._sched_runner.done()
+    assert p._sched_runner and not p._sched_runner.done()
     for t in p._workers:
         assert not t.done()
 
     await p.close()
-    assert p._sched_runner.done()
+    assert p._sched_runner is None
     for t in p._workers:
         assert t.done()
 

--- a/tests/pool/test_pool_async.py
+++ b/tests/pool/test_pool_async.py
@@ -679,7 +679,7 @@ async def test_open_explicit(dsn):
     with pytest.raises(pool.PoolClosed):
         await p.getconn()
 
-    with pytest.raises(pool.PoolClosed, match="has not been opened yet"):
+    with pytest.raises(pool.PoolClosed, match="is not open yet"):
         async with p.connection():
             pass
 
@@ -694,7 +694,7 @@ async def test_open_explicit(dsn):
     finally:
         await p.close()
 
-    with pytest.raises(pool.PoolClosed, match="has already been closed"):
+    with pytest.raises(pool.PoolClosed, match="is already closed"):
         await p.getconn()
 
 

--- a/tests/pool/test_pool_async.py
+++ b/tests/pool/test_pool_async.py
@@ -679,7 +679,7 @@ async def test_open_explicit(dsn):
     with pytest.raises(pool.PoolClosed):
         await p.getconn()
 
-    with pytest.raises(pool.PoolClosed):
+    with pytest.raises(pool.PoolClosed, match="has not been opened yet"):
         async with p.connection():
             pass
 
@@ -693,6 +693,9 @@ async def test_open_explicit(dsn):
 
     finally:
         await p.close()
+
+    with pytest.raises(pool.PoolClosed, match="has already been closed"):
+        await p.getconn()
 
 
 async def test_open_context(dsn):

--- a/tests/pool/test_pool_async.py
+++ b/tests/pool/test_pool_async.py
@@ -683,7 +683,7 @@ async def test_open_explicit(dsn):
         async with p.connection():
             pass
 
-    p.open()
+    await p.open()
     try:
         assert not p.closed
 
@@ -713,7 +713,7 @@ async def test_open_no_op(dsn):
     p = pool.AsyncConnectionPool(dsn)
     try:
         assert not p.closed
-        p.open()
+        await p.open()
         assert not p.closed
 
         async with p.connection() as conn:
@@ -732,7 +732,7 @@ async def test_reopen(dsn):
     assert p._sched_runner is None
 
     with pytest.raises(OperationalError, match="cannot be reused"):
-        p.open()
+        await p.open()
 
 
 @pytest.mark.slow


### PR DESCRIPTION
Hello @dlax!

I have resurrected #151 because the `open()` method is good to have in the API. I have added an `open` parameter to init, defaulting to `true`, so the behaviour is not changed and we can release this in 3.1.

In a future 4.0, if we think it's useful, we could change the default for open to False. [As you mentioned](https://github.com/psycopg/psycopg/pull/151#discussion_r753846910), an anyio-based pool might even have a different default for it.

This MR is largely made of your commits for #155, with the addition of the init open param, docs, better error messages. Happy to hear your opinion about merging and releasing this for 3.1.