### PR TITLE
Run pytest with increased verbosity in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
       PSYCOPG_IMPL: ${{ matrix.impl }}
       PSYCOPG_TEST_DSN: "host=127.0.0.1 user=postgres"
       PGPASSWORD: password
-      PYTEST_ADDOPTS: --color yes
+      PYTEST_ADDOPTS: --color yes -vv
 
     steps:
       - uses: actions/checkout@v2
@@ -133,7 +133,7 @@ jobs:
       # MacOS on GitHub Actions seems particularly slow.
       # Don't run timing-based tests as they regularly fail.
       # pproxy-based tests fail too, with the proxy not coming up in 2s.
-      PYTEST_ADDOPTS: -m 'not timing and not proxy and not mypy' --color yes
+      PYTEST_ADDOPTS: -m 'not timing and not proxy and not mypy' --color yes -vv
 
     steps:
       - uses: actions/checkout@v2
@@ -184,7 +184,7 @@ jobs:
       PSYCOPG_IMPL: ${{ matrix.impl }}
       PSYCOPG_TEST_DSN: "host=127.0.0.1 dbname=postgres"
       # On windows pproxy doesn't seem very happy. Also a few timing test fail.
-      PYTEST_ADDOPTS: -m 'not timing and not proxy and not mypy' --color yes
+      PYTEST_ADDOPTS: -m 'not timing and not proxy and not mypy' --color yes -vv
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This way, we can watch individual tests progression (instead of per test
file previously) in github's CI report (making it easier to diagnose
possible blocking/timeouts for instance).