### PR TITLE
docs: document PGconn needs_password and used_password attributes

### DIFF
--- a/docs/api/errors.rst
+++ b/docs/api/errors.rst
@@ -53,7 +53,7 @@ These classes are exposed both by this module and the root `psycopg` module.
         Most likely it will be in `~psycopg.pq.ConnStatus.BAD` state;
         however it might be useful to verify precisely what went wrong, for
         instance checking the `~psycopg.pq.PGconn.needs_password` and
-        `~psycopg.pq.PGconn.used_password`.
+        `~psycopg.pq.PGconn.used_password` attributes.
 
         .. versionadded:: 3.1
 

--- a/docs/api/pq.rst
+++ b/docs/api/pq.rst
@@ -88,6 +88,8 @@ Objects wrapping libpq structures and functions
 
     .. autoattribute:: pgconn_ptr
     .. automethod:: get_cancel
+    .. autoattribute:: needs_password
+    .. autoattribute:: used_password
 
 
 .. autoclass:: PGresult()

--- a/psycopg/psycopg/pq/pq_ctypes.py
+++ b/psycopg/psycopg/pq/pq_ctypes.py
@@ -240,10 +240,19 @@ class PGconn:
 
     @property
     def needs_password(self) -> bool:
+        """True if the connection authentication method required a password,
+        but none was available.
+
+        See :pq:`PQconnectionNeedsPassword` for details.
+        """
         return bool(impl.PQconnectionNeedsPassword(self._pgconn_ptr))
 
     @property
     def used_password(self) -> bool:
+        """True if the connection authentication method used a password.
+
+        See :pq:`PQconnectionUsedPassword` for details.
+        """
         return bool(impl.PQconnectionUsedPassword(self._pgconn_ptr))
 
     @property


### PR DESCRIPTION
This improves the documentation of Error class, which refers to those
in the new pgconn attribute documentation.

(The base branch is `pgconn-in-exception`.)

* * *
The rest of `pgconn-in-exception` branch looks good to me and would certainly help with #242 (the OP is  a colleague of mine).