### PR TITLE
Executemany pipeline

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -16,6 +16,8 @@ Psycopg 3.1 (unreleased)
 - Add :ref:`Two-Phase Commit <two-phase-commit>` support (:ticket:`#72`).
 - Add ``returning`` parameter to `~Cursor.executemany()` to retrieve query
   results (:ticket:`#164`).
+- `~Cursor.executemany()` performance improved by using batch mode internally
+  (:ticket:`#145`).
 - Add `pq.PGconn.trace()` and related trace functions (:ticket:`#167`).
 - Add ``prepare_threshold`` parameter to `Connection` init (:ticket:`#200`).
 - Add `Error.pgconn` and `Error.pgresult` attributes (:ticket:`#242`).

--- a/psycopg/psycopg/_pipeline.py
+++ b/psycopg/psycopg/_pipeline.py
@@ -107,8 +107,7 @@ class BasePipeline:
             return
 
         if flush:
-            self.pgconn.send_flush_request()
-            yield from send(self.pgconn)
+            yield from self._flush_gen()
 
         to_process = []
         while self.result_queue:
@@ -122,6 +121,10 @@ class BasePipeline:
 
         for queued, results in to_process:
             self._process_results(queued, results)
+
+    def _flush_gen(self) -> PQGen[None]:
+        self.pgconn.send_flush_request()
+        yield from send(self.pgconn)
 
     def _process_results(
         self, queued: PendingResult, results: List["PGresult"]

--- a/psycopg/psycopg/_pipeline.py
+++ b/psycopg/psycopg/_pipeline.py
@@ -148,7 +148,7 @@ class BasePipeline:
             if result.status == ExecStatus.FATAL_ERROR:
                 raise e.error_from_result(result, encoding=pgconn_encoding(self.pgconn))
             elif result.status == ExecStatus.PIPELINE_ABORTED:
-                raise e.OperationalError("pipeline aborted")
+                raise e.PipelineAborted("pipeline aborted")
         else:
             cursor, prepinfo = queued
             cursor._set_results_from_pipeline(results)

--- a/psycopg/psycopg/connection.py
+++ b/psycopg/psycopg/connection.py
@@ -882,7 +882,10 @@ class Connection(BaseConnection[Row]):
 
         if not pipeline:
             # No-op re-entered inner pipeline block.
-            yield self._pipeline
+            try:
+                yield self._pipeline
+            finally:
+                self._pipeline.communicate()
             return
 
         try:

--- a/psycopg/psycopg/connection.py
+++ b/psycopg/psycopg/connection.py
@@ -882,10 +882,7 @@ class Connection(BaseConnection[Row]):
 
         if not pipeline:
             # No-op re-entered inner pipeline block.
-            try:
-                yield self._pipeline
-            finally:
-                self._pipeline.sync()
+            yield self._pipeline
             return
 
         try:

--- a/psycopg/psycopg/connection.py
+++ b/psycopg/psycopg/connection.py
@@ -871,29 +871,19 @@ class Connection(BaseConnection[Row]):
     def pipeline(self) -> Iterator[Pipeline]:
         """Context manager to switch the connection into pipeline mode."""
         with self.lock:
-            if self._pipeline is None:
-                # We must enter pipeline mode: create a new one
+            pipeline = self._pipeline
+            if pipeline is None:
                 # WARNING: reference loop, broken ahead.
                 pipeline = self._pipeline = Pipeline(self)
-            else:
-                # we are already in pipeline mode: bail out as soon as we
-                # leave the lock block.
-                pipeline = None
-
-        if not pipeline:
-            # No-op re-entered inner pipeline block.
-            try:
-                yield self._pipeline
-            finally:
-                self._pipeline.sync()
-            return
 
         try:
             with pipeline:
                 yield pipeline
         finally:
-            assert pipeline.status == pq.PipelineStatus.OFF, pipeline.status
-            self._pipeline = None
+            if pipeline.level == 0:
+                with self.lock:
+                    assert pipeline is self._pipeline
+                    self._pipeline = None
 
     def wait(self, gen: PQGen[RV], timeout: Optional[float] = 0.1) -> RV:
         """

--- a/psycopg/psycopg/connection.py
+++ b/psycopg/psycopg/connection.py
@@ -882,7 +882,10 @@ class Connection(BaseConnection[Row]):
 
         if not pipeline:
             # No-op re-entered inner pipeline block.
-            yield self._pipeline
+            try:
+                yield self._pipeline
+            finally:
+                self._pipeline.sync()
             return
 
         try:

--- a/psycopg/psycopg/connection.py
+++ b/psycopg/psycopg/connection.py
@@ -885,7 +885,7 @@ class Connection(BaseConnection[Row]):
             try:
                 yield self._pipeline
             finally:
-                self._pipeline.communicate()
+                self._pipeline.sync()
             return
 
         try:

--- a/psycopg/psycopg/connection_async.py
+++ b/psycopg/psycopg/connection_async.py
@@ -313,7 +313,7 @@ class AsyncConnection(BaseConnection[Row]):
             try:
                 yield self._pipeline
             finally:
-                await self._pipeline.communicate()
+                await self._pipeline.sync()
             return
 
         try:

--- a/psycopg/psycopg/connection_async.py
+++ b/psycopg/psycopg/connection_async.py
@@ -310,7 +310,10 @@ class AsyncConnection(BaseConnection[Row]):
 
         if not pipeline:
             # No-op re-entered inner pipeline block.
-            yield self._pipeline
+            try:
+                yield self._pipeline
+            finally:
+                await self._pipeline.sync()
             return
 
         try:

--- a/psycopg/psycopg/connection_async.py
+++ b/psycopg/psycopg/connection_async.py
@@ -14,7 +14,7 @@ from contextlib import asynccontextmanager
 
 from . import errors as e
 from . import waiting
-from .pq import Format, PipelineStatus, TransactionStatus
+from .pq import Format, TransactionStatus
 from .abc import AdaptContext, Params, PQGen, PQGenConn, Query, RV
 from ._tpc import Xid
 from .rows import Row, AsyncRowFactory, tuple_row, TupleRow, args_row
@@ -46,8 +46,7 @@ class AsyncConnection(BaseConnection[Row]):
     cursor_factory: Type[AsyncCursor[Row]]
     server_cursor_factory: Type[AsyncServerCursor[Row]]
     row_factory: AsyncRowFactory[Row]
-
-    _pipeline: "Optional[AsyncPipeline]"
+    _pipeline: Optional[AsyncPipeline]
 
     def __init__(
         self,
@@ -299,29 +298,19 @@ class AsyncConnection(BaseConnection[Row]):
     async def pipeline(self) -> AsyncIterator[AsyncPipeline]:
         """Context manager to switch the connection into pipeline mode."""
         async with self.lock:
-            if self._pipeline is None:
-                # We must enter pipeline mode: create a new one
+            pipeline = self._pipeline
+            if pipeline is None:
                 # WARNING: reference loop, broken ahead.
                 pipeline = self._pipeline = AsyncPipeline(self)
-            else:
-                # we are already in pipeline mode: bail out as soon as we
-                # leave the lock block.
-                pipeline = None
-
-        if not pipeline:
-            # No-op re-entered inner pipeline block.
-            try:
-                yield self._pipeline
-            finally:
-                await self._pipeline.sync()
-            return
 
         try:
             async with pipeline:
                 yield pipeline
         finally:
-            assert pipeline.status == PipelineStatus.OFF, pipeline.status
-            self._pipeline = None
+            if pipeline.level == 0:
+                async with self.lock:
+                    assert pipeline is self._pipeline
+                    self._pipeline = None
 
     async def wait(self, gen: PQGen[RV]) -> RV:
         try:

--- a/psycopg/psycopg/connection_async.py
+++ b/psycopg/psycopg/connection_async.py
@@ -310,10 +310,7 @@ class AsyncConnection(BaseConnection[Row]):
 
         if not pipeline:
             # No-op re-entered inner pipeline block.
-            try:
-                yield self._pipeline
-            finally:
-                await self._pipeline.sync()
+            yield self._pipeline
             return
 
         try:

--- a/psycopg/psycopg/connection_async.py
+++ b/psycopg/psycopg/connection_async.py
@@ -310,7 +310,10 @@ class AsyncConnection(BaseConnection[Row]):
 
         if not pipeline:
             # No-op re-entered inner pipeline block.
-            yield self._pipeline
+            try:
+                yield self._pipeline
+            finally:
+                await self._pipeline.communicate()
             return
 
         try:

--- a/psycopg/psycopg/cursor.py
+++ b/psycopg/psycopg/cursor.py
@@ -240,6 +240,9 @@ class BaseCursor(Generic[ConnectionType, Row]):
 
         self._last_query = query
 
+        if returning:
+            yield from pipeline._sync_gen()
+
         for cmd in self._conn._prepared.get_maintenance_commands():
             yield from self._conn._exec_command(cmd)
 

--- a/psycopg/psycopg/cursor.py
+++ b/psycopg/psycopg/cursor.py
@@ -847,4 +847,3 @@ class Cursor(BaseCursor["Connection[Any]", Row]):
         ):
             with self._conn.lock:
                 self._conn.wait(self._conn._pipeline._fetch_gen(flush=True))
-            assert self.pgresult

--- a/psycopg/psycopg/cursor.py
+++ b/psycopg/psycopg/cursor.py
@@ -493,7 +493,7 @@ class BaseCursor(Generic[ConnectionType, Row]):
         if result.status == ExecStatus.FATAL_ERROR:
             raise e.error_from_result(result, encoding=self._encoding)
         elif result.status == ExecStatus.PIPELINE_ABORTED:
-            raise e.OperationalError("pipeline aborted")
+            raise e.PipelineAborted("pipeline aborted")
         elif result.status in self._status_copy:
             raise e.ProgrammingError(
                 "COPY cannot be used with this method; use copy() insead"
@@ -593,7 +593,7 @@ class BaseCursor(Generic[ConnectionType, Row]):
         elif res.status == ExecStatus.FATAL_ERROR:
             raise e.error_from_result(res, encoding=pgconn_encoding(self._pgconn))
         elif res.status == ExecStatus.PIPELINE_ABORTED:
-            raise e.OperationalError("pipeline aborted")
+            raise e.PipelineAborted("pipeline aborted")
         elif res.status != ExecStatus.TUPLES_OK:
             raise e.ProgrammingError("the last operation didn't produce a result")
 

--- a/psycopg/psycopg/cursor.py
+++ b/psycopg/psycopg/cursor.py
@@ -514,9 +514,6 @@ class BaseCursor(Generic[ConnectionType, Row]):
 
         if self._execmany_returning is None:
             # Received from execute()
-            # TODO: bug we also end up here on executemany() if run from inside
-            # a pipeline block. This causes a wrong rowcount. As it isn't so
-            # serious, currently leaving it this way.
             self._results.extend(results)
             if first_batch:
                 self._set_current_result(0)

--- a/psycopg/psycopg/cursor.py
+++ b/psycopg/psycopg/cursor.py
@@ -266,7 +266,7 @@ class BaseCursor(Generic[ConnectionType, Row]):
             results = yield from self._maybe_prepare_gen(pgq, prepare=True)
             assert results is not None
             self._check_results(results)
-            if returning and results[0].status == ExecStatus.TUPLES_OK:
+            if returning:
                 self._results.extend(results)
 
             for res in results:
@@ -526,7 +526,7 @@ class BaseCursor(Generic[ConnectionType, Row]):
 
         else:
             # Received from executemany()
-            if self._execmany_returning and results[0].status == ExecStatus.TUPLES_OK:
+            if self._execmany_returning:
                 self._results.extend(results)
                 if first_batch:
                     self._set_current_result(0)

--- a/psycopg/psycopg/cursor.py
+++ b/psycopg/psycopg/cursor.py
@@ -387,6 +387,12 @@ class BaseCursor(Generic[ConnectionType, Row]):
 
     def _start_copy_gen(self, statement: Query) -> PQGen[None]:
         """Generator implementing sending a command for `Cursor.copy()."""
+
+        # The connection gets in an unrecoverable state if we attempt COPY in
+        # pipeline mode. Forbid it explicitly.
+        if self._conn._pipeline:
+            raise e.NotSupportedError("COPY cannot be used in pipeline mode")
+
         yield from self._start_query()
         query = self._convert_query(statement)
 

--- a/psycopg/psycopg/cursor.py
+++ b/psycopg/psycopg/cursor.py
@@ -240,8 +240,6 @@ class BaseCursor(Generic[ConnectionType, Row]):
         for cmd in self._conn._prepared.get_maintenance_commands():
             yield from self._conn._exec_command(cmd)
 
-        yield from pipeline._flush_gen()
-
     def _executemany_gen_no_pipeline(
         self, query: Query, params_seq: Iterable[Params], returning: bool
     ) -> PQGen[None]:

--- a/psycopg/psycopg/cursor_async.py
+++ b/psycopg/psycopg/cursor_async.py
@@ -195,4 +195,3 @@ class AsyncCursor(BaseCursor["AsyncConnection[Any]", Row]):
         ):
             async with self._conn.lock:
                 await self._conn.wait(self._conn._pipeline._fetch_gen(flush=True))
-            assert self.pgresult

--- a/psycopg/psycopg/errors.py
+++ b/psycopg/psycopg/errors.py
@@ -199,6 +199,14 @@ class ConnectionTimeout(OperationalError):
     """
 
 
+class PipelineAborted(OperationalError):
+    """
+    Raised when a operation fails because the current pipeline is in aborted state.
+
+    Subclass of `~psycopg.OperationalError`.
+    """
+
+
 class Diagnostic:
     """Details from a database error report."""
 

--- a/tests/fix_pq.py
+++ b/tests/fix_pq.py
@@ -1,8 +1,15 @@
 import sys
+from typing import Iterator, List, NamedTuple
+from tempfile import TemporaryFile
 
 import pytest
 
 from .utils import check_libpq_version
+
+try:
+    from psycopg import pq
+except ImportError:
+    pq = None  # type: ignore
 
 
 def pytest_report_header(config):
@@ -28,8 +35,6 @@ def pytest_configure(config):
 
 
 def pytest_runtest_setup(item):
-    from psycopg import pq
-
     for m in item.iter_markers(name="libpq"):
         assert len(m.args) == 1
         msg = check_libpq_version(pq.version(), m.args[0])
@@ -51,9 +56,71 @@ def libpq():
         assert libname, "libpq libname not found"
         return ctypes.pydll.LoadLibrary(libname)
     except Exception as e:
-        from psycopg import pq
-
         if pq.__impl__ == "binary":
             pytest.skip(f"can't load libpq for testing: {e}")
         else:
             raise
+
+
+@pytest.fixture
+def trace(libpq):
+    pqver = pq.__build_version__ or pq.version()
+    if pqver < 140000:
+        pytest.skip(f"trace not available on libpq {pqver}")
+    if sys.platform != "linux":
+        pytest.skip(f"trace not available on {sys.platform}")
+
+    yield Tracer()
+
+
+class Tracer:
+    def trace(self, conn):
+        pgconn: "pq.abc.PGconn"
+
+        if hasattr(conn, "exec_"):
+            pgconn = conn
+        elif hasattr(conn, "cursor"):
+            pgconn = conn.pgconn
+        else:
+            raise Exception()
+
+        return TraceLog(pgconn)
+
+
+class TraceLog:
+    def __init__(self, pgconn: "pq.abc.PGconn"):
+        self.pgconn = pgconn
+        self.tempfile = TemporaryFile(buffering=0)
+        pgconn.trace(self.tempfile.fileno())
+        pgconn.set_trace_flags(pq.Trace.SUPPRESS_TIMESTAMPS)
+
+    def __del__(self):
+        if self.pgconn.status == pq.ConnStatus.OK:
+            self.pgconn.untrace()
+        self.tempfile.close()
+
+    def __iter__(self) -> "Iterator[TraceEntry]":
+        self.tempfile.seek(0)
+        data = self.tempfile.read()
+        for entry in self._parse_entries(data):
+            yield entry
+
+    def _parse_entries(self, data: bytes) -> "Iterator[TraceEntry]":
+        for line in data.splitlines():
+            direction, length, type, *content = line.split(b"\t")
+            yield TraceEntry(
+                direction=direction.decode(),
+                length=int(length.decode()),
+                type=type.decode(),
+                # Note: the items encoding is not very solid: no escaped
+                # backslash, no escaped quotes.
+                # At the moment we don't need a proper parser.
+                content=[content[0]] if content else [],
+            )
+
+
+class TraceEntry(NamedTuple):
+    direction: str
+    length: int
+    type: str
+    content: List[bytes]

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -316,8 +316,13 @@ def test_executemany_no_result(conn, execmany):
         returning=True,
     )
     assert cur.rowcount == 2
+    assert cur.statusmessage.startswith("INSERT")
     with pytest.raises(psycopg.ProgrammingError):
         cur.fetchone()
+    pgresult = cur.pgresult
+    assert cur.nextset()
+    assert cur.statusmessage.startswith("INSERT")
+    assert pgresult is not cur.pgresult
     assert cur.nextset() is None
 
 

--- a/tests/test_cursor_async.py
+++ b/tests/test_cursor_async.py
@@ -304,8 +304,13 @@ async def test_executemany_no_result(aconn, execmany):
         returning=True,
     )
     assert cur.rowcount == 2
+    assert cur.statusmessage.startswith("INSERT")
     with pytest.raises(psycopg.ProgrammingError):
         await cur.fetchone()
+    pgresult = cur.pgresult
+    assert cur.nextset()
+    assert cur.statusmessage.startswith("INSERT")
+    assert pgresult is not cur.pgresult
     assert cur.nextset() is None
 
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -187,7 +187,7 @@ def test_executemany_rowcount(conn):
             [(10,), (20,)],
         )
 
-        # TODO: this is a bug. It is caused by reentering the pipeline mode in
+        # TODO: failing. It is caused by reentering the pipeline mode in
         # executemany(). Leaving it here to monitor how it changes. The snag is
         # in Cursor._set_results_from_pipeline()
         assert cur.rowcount == 2

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -194,6 +194,13 @@ def test_pipeline_commit_aborted(conn):
             conn.commit()
 
 
+def test_fetch_no_result(conn):
+    with conn.pipeline():
+        cur = conn.cursor()
+        with pytest.raises(e.ProgrammingError):
+            cur.fetchone()
+
+
 def test_executemany(conn):
     conn.autocommit = True
     conn.execute("drop table if exists execmanypipeline")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -98,6 +98,14 @@ def test_cannot_insert_multiple_commands(conn):
     assert cm.value.sqlstate == "42601"
 
 
+def test_copy(conn):
+    with conn.pipeline():
+        cur = conn.cursor()
+        with pytest.raises(e.NotSupportedError):
+            with cur.copy("copy (select 1) to stdout"):
+                pass
+
+
 def test_pipeline_processed_at_exit(conn):
     with conn.cursor() as cur:
         with conn.pipeline() as p:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -173,7 +173,7 @@ def test_pipeline_aborted(conn):
         c1 = conn.execute("select 1")
         with pytest.raises(e.UndefinedTable):
             conn.execute("select * from doesnotexist").fetchone()
-        with pytest.raises(e.OperationalError, match="pipeline aborted"):
+        with pytest.raises(e.PipelineAborted):
             conn.execute("select 'aborted'").fetchone()
         # Sync restore the connection in usable state.
         p.sync()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -189,7 +189,6 @@ def test_executemany_no_returning(conn):
             [(10,), (20,)],
             returning=False,
         )
-        assert cur.rowcount == 2
         with pytest.raises(e.ProgrammingError, match="no result available"):
             cur.fetchone()
         assert cur.nextset() is None

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -168,6 +168,12 @@ def test_executemany(conn):
             "insert into execmanypipeline(num) values (%s) returning id",
             [(10,), (20,)],
         )
+
+        # TODO: this is a bug, it should be 2. It is caused by reentering the
+        # pipeline mode in executemany(). Leaving it here to monitor how it
+        # changes. The snag is in Cursor._set_results_from_pipeline()
+        assert cur.rowcount == 0
+
         assert cur.fetchone() == (1,)
         assert cur.nextset()
         assert cur.fetchone() == (2,)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -167,6 +167,7 @@ def test_executemany(conn):
         cur.executemany(
             "insert into execmanypipeline(num) values (%s) returning id",
             [(10,), (20,)],
+            returning=True,
         )
         assert cur.fetchone() == (1,)
         assert cur.nextset()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -169,29 +169,11 @@ def test_executemany(conn):
             [(10,), (20,)],
             returning=True,
         )
+        assert cur.rowcount == 2
         assert cur.fetchone() == (1,)
         assert cur.nextset()
         assert cur.fetchone() == (2,)
         assert cur.nextset() is None
-
-
-@pytest.mark.xfail
-def test_executemany_rowcount(conn):
-    conn.autocommit = True
-    conn.execute(
-        "create temp table test_executemany_rowcount ("
-        " id serial primary key, num integer)"
-    )
-    with conn.pipeline(), conn.cursor() as cur:
-        cur.executemany(
-            "insert into test_executemany_rowcount (num) values (%s) returning id",
-            [(10,), (20,)],
-        )
-
-        # TODO: failing. It is caused by reentering the pipeline mode in
-        # executemany(). Leaving it here to monitor how it changes. The snag is
-        # in Cursor._set_results_from_pipeline()
-        assert cur.rowcount == 2
 
 
 def test_prepared(conn):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -168,16 +168,29 @@ def test_executemany(conn):
             "insert into execmanypipeline(num) values (%s) returning id",
             [(10,), (20,)],
         )
-
-        # TODO: this is a bug, it should be 2. It is caused by reentering the
-        # pipeline mode in executemany(). Leaving it here to monitor how it
-        # changes. The snag is in Cursor._set_results_from_pipeline()
-        assert cur.rowcount == 0
-
         assert cur.fetchone() == (1,)
         assert cur.nextset()
         assert cur.fetchone() == (2,)
         assert cur.nextset() is None
+
+
+@pytest.mark.xfail
+def test_executemany_rowcount(conn):
+    conn.autocommit = True
+    conn.execute(
+        "create temp table test_executemany_rowcount ("
+        " id serial primary key, num integer)"
+    )
+    with conn.pipeline(), conn.cursor() as cur:
+        cur.executemany(
+            "insert into test_executemany_rowcount (num) values (%s) returning id",
+            [(10,), (20,)],
+        )
+
+        # TODO: this is a bug. It is caused by reentering the pipeline mode in
+        # executemany(). Leaving it here to monitor how it changes. The snag is
+        # in Cursor._set_results_from_pipeline()
+        assert cur.rowcount == 2
 
 
 def test_prepared(conn):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -62,6 +62,23 @@ def test_pipeline_exit_error_noclobber(conn, caplog):
     assert len(caplog.records) == 1
 
 
+def test_pipeline_exit_sync_trace(conn, trace):
+    t = trace.trace(conn)
+    with conn.pipeline():
+        pass
+    conn.close()
+    assert len([i for i in t if i.type == "Sync"]) == 1
+
+
+def test_pipeline_nested_sync_trace(conn, trace):
+    t = trace.trace(conn)
+    with conn.pipeline():
+        with conn.pipeline():
+            pass
+    conn.close()
+    assert len([i for i in t if i.type == "Sync"]) == 2
+
+
 def test_cursor_stream(conn):
     with conn.pipeline(), conn.cursor() as cur:
         with pytest.raises(psycopg.ProgrammingError):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -62,6 +62,17 @@ def test_pipeline_exit_error_noclobber(conn, caplog):
     assert len(caplog.records) == 1
 
 
+def test_pipeline_exit_error_noclobber_nested(conn, caplog):
+    caplog.set_level(logging.WARNING, logger="psycopg")
+    with pytest.raises(ZeroDivisionError):
+        with conn.pipeline():
+            with conn.pipeline():
+                conn.close()
+                1 / 0
+
+    assert len(caplog.records) == 2
+
+
 def test_pipeline_exit_sync_trace(conn, trace):
     t = trace.trace(conn)
     with conn.pipeline():

--- a/tests/test_pipeline_async.py
+++ b/tests/test_pipeline_async.py
@@ -101,6 +101,14 @@ async def test_cannot_insert_multiple_commands(aconn):
     assert cm.value.sqlstate == "42601"
 
 
+async def test_copy(aconn):
+    async with aconn.pipeline():
+        cur = aconn.cursor()
+        with pytest.raises(e.NotSupportedError):
+            async with cur.copy("copy (select 1) to stdout") as copy:
+                await copy.read()
+
+
 async def test_pipeline_processed_at_exit(aconn):
     async with aconn.cursor() as cur:
         async with aconn.pipeline() as p:

--- a/tests/test_pipeline_async.py
+++ b/tests/test_pipeline_async.py
@@ -197,6 +197,13 @@ async def test_pipeline_commit_aborted(aconn):
             await aconn.commit()
 
 
+async def test_fetch_no_result(aconn):
+    async with aconn.pipeline():
+        cur = aconn.cursor()
+        with pytest.raises(e.ProgrammingError):
+            await cur.fetchone()
+
+
 async def test_executemany(aconn):
     await aconn.set_autocommit(True)
     await aconn.execute("drop table if exists execmanypipeline")

--- a/tests/test_pipeline_async.py
+++ b/tests/test_pipeline_async.py
@@ -176,7 +176,7 @@ async def test_pipeline_aborted(aconn):
         c1 = await aconn.execute("select 1")
         with pytest.raises(e.UndefinedTable):
             await (await aconn.execute("select * from doesnotexist")).fetchone()
-        with pytest.raises(e.OperationalError, match="pipeline aborted"):
+        with pytest.raises(e.PipelineAborted):
             await (await aconn.execute("select 'aborted'")).fetchone()
         # Sync restore the connection in usable state.
         await p.sync()

--- a/tests/test_pipeline_async.py
+++ b/tests/test_pipeline_async.py
@@ -141,7 +141,7 @@ async def test_pipeline_aborted(aconn):
         with pytest.raises(e.OperationalError, match="pipeline aborted"):
             await (await aconn.execute("select 'aborted'")).fetchone()
         # Sync restore the connection in usable state.
-        p.sync()
+        await p.sync()
         c2 = await aconn.execute("select 2")
 
     (r,) = await c1.fetchone()

--- a/tests/test_pipeline_async.py
+++ b/tests/test_pipeline_async.py
@@ -192,7 +192,6 @@ async def test_executemany_no_returning(aconn):
             [(10,), (20,)],
             returning=False,
         )
-        assert cur.rowcount == 2
         with pytest.raises(e.ProgrammingError, match="no result available"):
             await cur.fetchone()
         assert cur.nextset() is None

--- a/tests/test_pipeline_async.py
+++ b/tests/test_pipeline_async.py
@@ -65,6 +65,23 @@ async def test_pipeline_exit_error_noclobber(aconn, caplog):
     assert len(caplog.records) == 1
 
 
+async def test_pipeline_exit_sync_trace(aconn, trace):
+    t = trace.trace(aconn)
+    async with aconn.pipeline():
+        pass
+    await aconn.close()
+    assert len([i for i in t if i.type == "Sync"]) == 1
+
+
+async def test_pipeline_nested_sync_trace(aconn, trace):
+    t = trace.trace(aconn)
+    async with aconn.pipeline():
+        async with aconn.pipeline():
+            pass
+    await aconn.close()
+    assert len([i for i in t if i.type == "Sync"]) == 2
+
+
 async def test_cursor_stream(aconn):
     async with aconn.pipeline(), aconn.cursor() as cur:
         with pytest.raises(psycopg.ProgrammingError):

--- a/tests/test_pipeline_async.py
+++ b/tests/test_pipeline_async.py
@@ -65,6 +65,17 @@ async def test_pipeline_exit_error_noclobber(aconn, caplog):
     assert len(caplog.records) == 1
 
 
+async def test_pipeline_exit_error_noclobber_nested(aconn, caplog):
+    caplog.set_level(logging.WARNING, logger="psycopg")
+    with pytest.raises(ZeroDivisionError):
+        async with aconn.pipeline():
+            async with aconn.pipeline():
+                await aconn.close()
+                1 / 0
+
+    assert len(caplog.records) == 2
+
+
 async def test_pipeline_exit_sync_trace(aconn, trace):
     t = trace.trace(aconn)
     async with aconn.pipeline():

--- a/tests/test_pipeline_async.py
+++ b/tests/test_pipeline_async.py
@@ -172,6 +172,7 @@ async def test_executemany(aconn):
             [(10,), (20,)],
             returning=True,
         )
+        assert cur.rowcount == 2
         assert (await cur.fetchone()) == (1,)
         assert cur.nextset()
         assert (await cur.fetchone()) == (2,)

--- a/tests/test_pipeline_async.py
+++ b/tests/test_pipeline_async.py
@@ -170,6 +170,7 @@ async def test_executemany(aconn):
         await cur.executemany(
             "insert into execmanypipeline(num) values (%s) returning id",
             [(10,), (20,)],
+            returning=True,
         )
         assert (await cur.fetchone()) == (1,)
         assert cur.nextset()


### PR DESCRIPTION
Optimization of `Cursor.executemany()` using pipelines (#145). 

This branch is based on @dlax pipeline4 branch (#175) and will be merged after the other MR is.

Speedup looks in the region of the 2.5x improvement.

```python
# test-execmany.py 
import psycopg
cnn = psycopg.connect("host=localhost", autocommit=True)
cur = cnn.cursor()
cur.execute("""
    create temp table testmany (
        id serial primary key, n1 int, n2 int, s1 text, s2 text)
    """)
cur.executemany(
    "insert into testmany (n1, n2, s1, s2) values (%s, %s, %s, %s)",
    [(20, 5000, "foobar", "foobar" * 100)] * 100000,
)
```

```
$ time python test-execmany.py 
real	0m8.586s
user	0m3.416s
sys	0m1.469s

$ git co -
Switched to branch 'executemany-pipeline'

$ time python test-execmany.py 
real	0m3.347s
user	0m2.432s
sys	0m0.903s
```