### PR TITLE
Add ConnectionInfo.pipeline_status

### DIFF
--- a/docs/api/objects.rst
+++ b/docs/api/objects.rst
@@ -34,6 +34,8 @@ Connection information
         is bad. `!ACTIVE` is reported only when a query has been sent to the
         server and not yet completed.
 
+    .. autoattribute:: pipeline_status
+
     .. autoattribute:: backend_pid
     .. autoattribute:: server_version
     .. autoattribute:: error_message

--- a/docs/api/pq.rst
+++ b/docs/api/pq.rst
@@ -135,6 +135,12 @@ Enumerations
     .. seealso:: :pq:`PQresultStatus` for a description of these states.
 
 
+.. autoclass:: PipelineStatus
+    :members:
+
+    .. seealso:: :pq:`PQpipelineStatus` for a description of these states.
+
+
 .. autoclass:: Format
     :members:
 

--- a/psycopg/psycopg/conninfo.py
+++ b/psycopg/psycopg/conninfo.py
@@ -210,6 +210,14 @@ class ConnectionInfo:
         """
         return pq.TransactionStatus(self.pgconn.transaction_status)
 
+    @property
+    def pipeline_status(self) -> pq.PipelineStatus:
+        """
+        The current pipeline status of the client.
+        See :pq:`PQpipelineStatus()`.
+        """
+        return pq.PipelineStatus(self.pgconn.pipeline_status)
+
     def parameter_status(self, param_name: str) -> Optional[str]:
         """
         Return a parameter setting of the connection.

--- a/tests/test_conninfo.py
+++ b/tests/test_conninfo.py
@@ -172,6 +172,19 @@ class TestConnectionInfo:
         conn.close()
         assert conn.info.transaction_status.name == "UNKNOWN"
 
+    @pytest.mark.libpq(">= 14")
+    def test_pipeline_status(self, conn):
+        assert not conn.info.pipeline_status
+        assert conn.info.pipeline_status.name == "OFF"
+        with conn.pipeline():
+            assert conn.info.pipeline_status
+            assert conn.info.pipeline_status.name == "ON"
+
+    @pytest.mark.libpq("< 14")
+    def test_pipeline_status_no_pipeline(self, conn):
+        assert not conn.info.pipeline_status
+        assert conn.info.pipeline_status.name == "OFF"
+
     def test_no_password(self, dsn):
         dsn2 = make_conninfo(dsn, password="the-pass-word")
         pgconn = psycopg.pq.PGconn.connect_start(dsn2.encode())


### PR DESCRIPTION
@dlax It occurred to me that we don't have a public way to check for the pipeline status. There is `Connection.pgconn.pipeline_status` but it sort of require "internal libpq knowledge". Ok with this?

Will flesh more docs (even just a "see also: pipeline mode") to the docs branch.