### PR TITLE
feat: wrap transaction in pipelines if the connection has one

### DIFF
--- a/psycopg/psycopg/_compat.py
+++ b/psycopg/psycopg/_compat.py
@@ -30,16 +30,45 @@ else:
 if sys.version_info >= (3, 9):
     from zoneinfo import ZoneInfo
     from collections import Counter, deque as Deque
+    from contextlib import AbstractAsyncContextManager, AbstractContextManager
 else:
     from backports.zoneinfo import ZoneInfo
-    from typing import Counter, Deque
+    from typing import (
+        Counter,
+        Deque,
+        AsyncContextManager as AbstractAsyncContextManager,
+        ContextManager as AbstractContextManager,
+    )
 
 if sys.version_info >= (3, 10):
+    from contextlib import nullcontext
     from typing import TypeAlias, TypeGuard
 else:
+    from contextlib import nullcontext as _nullcontext
     from typing_extensions import TypeAlias, TypeGuard
 
+    if sys.version_info >= (3, 9):
+
+        class nullcontext(_nullcontext[T]):
+            async def __aenter__(self) -> T:
+                return self.enter_result
+
+            async def __aexit__(self, *excinfo: Any) -> None:
+                pass
+
+    else:
+
+        class nullcontext(_nullcontext):
+            async def __aenter__(self) -> Any:
+                return self.enter_result
+
+            async def __aexit__(self, *excinfo: Any) -> None:
+                pass
+
+
 __all__ = [
+    "AbstractAsyncContextManager",
+    "AbstractContextManager",
     "Counter",
     "Deque",
     "Protocol",
@@ -47,4 +76,5 @@ __all__ = [
     "TypeGuard",
     "ZoneInfo",
     "create_task",
+    "nullcontext",
 ]

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -360,6 +360,16 @@ def test_outer_transaction_error(conn):
                 conn.execute("create table voila ()")
 
 
+def test_rollback_transaction(conn):
+    conn.autocommit = True
+    with pytest.raises(e.DivisionByZero):
+        with conn.pipeline():
+            with conn.transaction():
+                cur = conn.execute("select 1 / %s", [0])
+                cur.fetchone()
+    conn.execute("select 1")
+
+
 def test_concurrency(conn):
     with conn.transaction():
         conn.execute("drop table if exists pipeline_concurrency")

--- a/tests/test_pipeline_async.py
+++ b/tests/test_pipeline_async.py
@@ -364,6 +364,16 @@ async def test_outer_transaction_error(aconn):
                 await aconn.execute("create table voila ()")
 
 
+async def test_rollback_transaction(aconn):
+    await aconn.set_autocommit(True)
+    with pytest.raises(e.DivisionByZero):
+        async with aconn.pipeline():
+            async with aconn.transaction():
+                cur = await aconn.execute("select 1 / %s", [0])
+                await cur.fetchone()
+    await aconn.execute("select 1")
+
+
 async def test_concurrency(aconn):
     async with aconn.transaction():
         await aconn.execute("drop table if exists pipeline_concurrency")


### PR DESCRIPTION
(Alternative solution to #267; test introduced here taken from there.)

When the connection is in pipeline mode, we wrap each transaction block
with two pipelines: the inner one ensures that we'd get a Sync at the
end of transaction *before* the commit or rollback statement, thus
ensuring that the latter gets run even if the pipeline got in aborted
state during the transaction; the outer one ensures (also emitting a
sync) that the connection is restored into a usable state even when the
transaction rolled back.

Introduce nullcontext and Abstract(Async)ContextManager compat
definitions.