### PR TITLE
Fix typo in enums.py docstring

### DIFF
--- a/psycopg/psycopg/types/enum.py
+++ b/psycopg/psycopg/types/enum.py
@@ -23,7 +23,7 @@ EnumMapping: TypeAlias = Union[Mapping[E, str], Sequence[Tuple[E, str]], None]
 
 class _BaseEnumLoader(Loader, Generic[E]):
     """
-    Dumper for a specific Enum class
+    Loader for a specific Enum class
     """
 
     enum: Type[E]
@@ -45,7 +45,7 @@ class _BaseEnumLoader(Loader, Generic[E]):
 
 class _BaseEnumDumper(Dumper, Generic[E]):
     """
-    Loader for a specific Enum class
+    Dumper for a specific Enum class
     """
 
     enum: Type[E]


### PR DESCRIPTION
Just a tiny change.
Thank you for this library and the enum support!