### PR TITLE
Re-export from psycopg._cmodule

### DIFF
--- a/psycopg/psycopg/_cmodule.py
+++ b/psycopg/psycopg/_cmodule.py
@@ -13,11 +13,11 @@ __version__: Optional[str] = None
 # Note: "c" must the first attempt so that mypy associates the variable the
 # right module interface. It will not result Optional, but hey.
 if pq.__impl__ == "c":
-    from psycopg_c import _psycopg
-    from psycopg_c import __version__  # noqa: F401
+    from psycopg_c import _psycopg as _psycopg
+    from psycopg_c import __version__ as __version__  # noqa: F401
 elif pq.__impl__ == "binary":
-    from psycopg_binary import _psycopg  # type: ignore
-    from psycopg_binary import __version__  # type: ignore  # noqa: F401
+    from psycopg_binary import _psycopg as _psycopg  # type: ignore
+    from psycopg_binary import __version__ as __version__  # type: ignore  # noqa: F401
 elif pq.__impl__ == "python":
     _psycopg = None  # type: ignore
 else:


### PR DESCRIPTION
I'm fixing a bug in mypy's `--no-implicit-reexport` logic in
https://github.com/python/mypy/pull/12704 and mypy-primer flagged this