### PR TITLE
Sync the client on sync() and commit()

### DIFF
--- a/docs/advanced/pipeline.rst
+++ b/docs/advanced/pipeline.rst
@@ -237,7 +237,7 @@ Flushing query results to the client can happen either when a synchronization
 point is established by Psycopg:
 
 - using the `Pipeline.sync()` method;
-- on `Connection.rollback()`;
+- on `Connection.commit()` or `~Connection.rollback()`;
 - at the end of a `!Pipeline` block;
 - using a fetch method such as `Cursor.fetchone()` (which only flushes the
   query but doesn't issue a Sync and doesn't reset a pipeline state error).

--- a/docs/advanced/pipeline.rst
+++ b/docs/advanced/pipeline.rst
@@ -257,10 +257,13 @@ For example, the following block:
 
     >>> with psycopg.connect(autocommit=True) as conn:
     ...     with conn.pipeline() as p, conn.cursor() as cur:
-    ...         cur.execute("INSERT INTO mytable (data) VALUES (%s)", ["one"])
-    ...         cur.execute("INSERT INTO no_such_table (data) VALUES (%s)", ["two"])
-    ...         conn.execute("INSERT INTO mytable (data) VALUES (%s)", ["three"])
-    ...         p.sync()
+    ...         try:
+    ...             cur.execute("INSERT INTO mytable (data) VALUES (%s)", ["one"])
+    ...             cur.execute("INSERT INTO no_such_table (data) VALUES (%s)", ["two"])
+    ...             conn.execute("INSERT INTO mytable (data) VALUES (%s)", ["three"])
+    ...             p.sync()
+    ...         except psycopg.errors.UndefinedTable:
+    ...             pass
     ...         cur.execute("INSERT INTO mytable (data) VALUES (%s)", ["four"])
 
 fails with the error ``relation "no_such_table" does not exist`` and, at the

--- a/docs/advanced/pipeline.rst
+++ b/docs/advanced/pipeline.rst
@@ -251,7 +251,7 @@ only committed when the Sync is received. As such, a failure in a group of
 statements will probably invalidate the effect of statements executed after
 the previous Sync, and will propagate to the following Sync.
 
-For example, the following block:
+For example, in the following block:
 
 .. code:: python
 
@@ -266,8 +266,9 @@ For example, the following block:
     ...             pass
     ...         cur.execute("INSERT INTO mytable (data) VALUES (%s)", ["four"])
 
-fails with the error ``relation "no_such_table" does not exist`` and, at the
-end of the block, the table will contain:
+there will be an error in the block, ``relation "no_such_table" does not
+exist`` caused by the insert ``two``, but probably raised by the `!sync()`
+call. At at the end of the block, the table will contain:
 
 .. code:: text
 
@@ -290,15 +291,15 @@ because:
 
 .. warning::
 
-    The exact Python statement where the exception is raised is somewhat
-    arbitrary: it depends on when the server returns the error message. In the
-    above example, the `!execute()` of the statement ``two`` is not the one
-    expected to raise the exception. The exception might be raised by the
-    `!sync()`, or when leaving the `!Pipeline` block.
+    The exact Python statement where an exception caused by a server error is
+    raised is somewhat arbitrary: it depends on when the server flushes its
+    buffered result.
 
-    Do not rely on expectations of a precise point where the exception is
-    raised; make sure to use transactions if you want to guarantee that a set
-    of statements is handled atomically by the server.
+    If you want to make sure that a group of statements is applied atomically
+    by the server, do make use of transaction methods such as
+    `~Connection.commit()` or `~Connection.transaction()`: these methods will
+    also sync the pipeline and raise an exception if there was any error in
+    the commands executed so far.
 
 
 The fine prints

--- a/psycopg/psycopg/_pipeline.py
+++ b/psycopg/psycopg/_pipeline.py
@@ -87,13 +87,15 @@ class BasePipeline:
     def _sync_gen(self) -> PQGen[None]:
         self._enqueue_sync()
         yield from self._communicate_gen()
+        yield from self._fetch_gen(flush=False)
 
     def _exit_gen(self) -> PQGen[None]:
         """Exit current pipeline by sending a Sync and, unless within a nested
         pipeline, also fetch back all remaining results.
         """
         try:
-            yield from self._sync_gen()
+            self._enqueue_sync()
+            yield from self._communicate_gen()
         finally:
             if self.level == 1:
                 # No need to force flush since we emitted a sync just before.

--- a/psycopg/psycopg/_pipeline.py
+++ b/psycopg/psycopg/_pipeline.py
@@ -90,16 +90,15 @@ class BasePipeline:
         yield from self._fetch_gen(flush=False)
 
     def _exit_gen(self) -> PQGen[None]:
-        """Exit current pipeline by sending a Sync and, unless within a nested
-        pipeline, also fetch back all remaining results.
+        """
+        Exit current pipeline by sending a Sync and fetch back all remaining results.
         """
         try:
             self._enqueue_sync()
             yield from self._communicate_gen()
         finally:
-            if self.level == 1:
-                # No need to force flush since we emitted a sync just before.
-                yield from self._fetch_gen(flush=False)
+            # No need to force flush since we emitted a sync just before.
+            yield from self._fetch_gen(flush=False)
 
     def _communicate_gen(self) -> PQGen[None]:
         """Communicate with pipeline to send commands and possibly fetch

--- a/psycopg/psycopg/connection.py
+++ b/psycopg/psycopg/connection.py
@@ -869,8 +869,13 @@ class Connection(BaseConnection[Row]):
             block even if there were no error (e.g. to try a no-op process).
         :rtype: Transaction
         """
-        with Transaction(self, savepoint_name, force_rollback) as tx:
-            yield tx
+        tx = Transaction(self, savepoint_name, force_rollback)
+        if self._pipeline:
+            with tx, self.pipeline():
+                yield tx
+        else:
+            with tx:
+                yield tx
 
     def notifies(self) -> Generator[Notify, None, None]:
         """

--- a/psycopg/psycopg/connection.py
+++ b/psycopg/psycopg/connection.py
@@ -519,6 +519,9 @@ class BaseConnection(Generic[Row]):
 
         yield from self._exec_command(b"COMMIT")
 
+        if self._pipeline:
+            yield from self._pipeline._sync_gen()
+
     def _rollback_gen(self) -> PQGen[None]:
         """Generator implementing `Connection.rollback()`."""
         if self._num_transactions:

--- a/psycopg/psycopg/connection.py
+++ b/psycopg/psycopg/connection.py
@@ -871,6 +871,7 @@ class Connection(BaseConnection[Row]):
         """
         tx = Transaction(self, savepoint_name, force_rollback)
         if self._pipeline:
+            self._pipeline.sync()
             with tx, self.pipeline():
                 yield tx
         else:

--- a/psycopg/psycopg/connection_async.py
+++ b/psycopg/psycopg/connection_async.py
@@ -283,6 +283,7 @@ class AsyncConnection(BaseConnection[Row]):
         """
         tx = AsyncTransaction(self, savepoint_name, force_rollback)
         if self._pipeline:
+            await self._pipeline.sync()
             async with tx, self.pipeline():
                 yield tx
         else:

--- a/psycopg/psycopg/connection_async.py
+++ b/psycopg/psycopg/connection_async.py
@@ -282,8 +282,12 @@ class AsyncConnection(BaseConnection[Row]):
         :rtype: AsyncTransaction
         """
         tx = AsyncTransaction(self, savepoint_name, force_rollback)
-        async with tx:
-            yield tx
+        if self._pipeline:
+            async with tx, self.pipeline():
+                yield tx
+        else:
+            async with tx:
+                yield tx
 
     async def notifies(self) -> AsyncGenerator[Notify, None]:
         while 1:

--- a/psycopg/psycopg/transaction.py
+++ b/psycopg/psycopg/transaction.py
@@ -138,6 +138,9 @@ class BaseTransaction(Generic[ConnectionType]):
         for command in self._get_commit_commands():
             yield from self._conn._exec_command(command)
 
+        if self._conn._pipeline:
+            yield from self._conn._pipeline._sync_gen()
+
     def _rollback_gen(self, exc_val: Optional[BaseException]) -> PQGen[bool]:
         if isinstance(exc_val, Rollback):
             logger.debug(f"{self._conn}: Explicit rollback from: ", exc_info=True)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -237,7 +237,6 @@ def test_errors_raised_on_transaction_exit(conn):
             with conn.transaction():
                 conn.execute("select 1 from nosuchtable")
                 here = True
-        conn.rollback()  # TODO: inconsistent with non-pipeline.
         cur1 = conn.execute("select 1")
     assert here
     cur2 = conn.execute("select 2")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -201,6 +201,22 @@ def test_pipeline_commit_aborted(conn):
             conn.commit()
 
 
+def test_sync_syncs_results(conn):
+    with conn.pipeline() as p:
+        cur = conn.execute("select 1")
+        assert cur.statusmessage is None
+        p.sync()
+        assert cur.statusmessage == "SELECT 1"
+
+
+def test_sync_syncs_errors(conn):
+    conn.autocommit = True
+    with conn.pipeline() as p:
+        conn.execute("select 1 from nosuchtable")
+        with pytest.raises(e.UndefinedTable):
+            p.sync()
+
+
 def test_fetch_no_result(conn):
     with conn.pipeline():
         cur = conn.cursor()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -222,7 +222,7 @@ def test_errors_raised_on_commit(conn):
         conn.execute("select 1 from nosuchtable")
         with pytest.raises(e.UndefinedTable):
             conn.commit()
-        conn.rollback()  # TODO: inconsistent with non-pipeline.
+        conn.rollback()
         cur1 = conn.execute("select 1")
     cur2 = conn.execute("select 2")
 
@@ -253,7 +253,6 @@ def test_errors_raised_on_nested_transaction_exit(conn):
                 with conn.transaction():
                     conn.execute("select 1 from nosuchtable")
                     here = True
-        conn.rollback()  # TODO: inconsistent with non-pipeline.
         cur1 = conn.execute("select 1")
     assert here
     cur2 = conn.execute("select 2")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -398,6 +398,16 @@ def test_transaction_nested(conn):
         assert r == "inner"
 
 
+def test_transaction_nested_no_statement(conn):
+    with conn.pipeline():
+        with conn.transaction():
+            with conn.transaction():
+                cur = conn.execute("select 1")
+
+        (r,) = cur.fetchone()
+        assert r == 1
+
+
 def test_outer_transaction(conn):
     with conn.transaction():
         with conn.pipeline():

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -248,12 +248,12 @@ def test_errors_raised_on_transaction_exit(conn):
 def test_errors_raised_on_nested_transaction_exit(conn):
     here = False
     with conn.pipeline():
-        with pytest.raises(e.UndefinedTable):
-            with conn.transaction():
+        with conn.transaction():
+            with pytest.raises(e.UndefinedTable):
                 with conn.transaction():
                     conn.execute("select 1 from nosuchtable")
                     here = True
-        cur1 = conn.execute("select 1")
+            cur1 = conn.execute("select 1")
     assert here
     cur2 = conn.execute("select 2")
 

--- a/tests/test_pipeline_async.py
+++ b/tests/test_pipeline_async.py
@@ -240,7 +240,6 @@ async def test_errors_raised_on_transaction_exit(aconn):
             async with aconn.transaction():
                 await aconn.execute("select 1 from nosuchtable")
                 here = True
-        await aconn.rollback()  # TODO: inconsistent with non-pipeline.
         cur1 = await aconn.execute("select 1")
     assert here
     cur2 = await aconn.execute("select 2")

--- a/tests/test_pipeline_async.py
+++ b/tests/test_pipeline_async.py
@@ -225,7 +225,7 @@ async def test_errors_raised_on_commit(aconn):
         await aconn.execute("select 1 from nosuchtable")
         with pytest.raises(e.UndefinedTable):
             await aconn.commit()
-        await aconn.rollback()  # TODO: inconsistent with non-pipeline.
+        await aconn.rollback()
         cur1 = await aconn.execute("select 1")
     cur2 = await aconn.execute("select 2")
 
@@ -256,7 +256,6 @@ async def test_errors_raised_on_nested_transaction_exit(aconn):
                 async with aconn.transaction():
                     await aconn.execute("select 1 from nosuchtable")
                     here = True
-        await aconn.rollback()  # TODO: inconsistent with non-pipeline.
         cur1 = await aconn.execute("select 1")
     assert here
     cur2 = await aconn.execute("select 2")

--- a/tests/test_pipeline_async.py
+++ b/tests/test_pipeline_async.py
@@ -400,6 +400,16 @@ async def test_transaction_nested(aconn):
         assert r == "inner"
 
 
+async def test_transaction_nested_no_statement(aconn):
+    async with aconn.pipeline():
+        async with aconn.transaction():
+            async with aconn.transaction():
+                cur = await aconn.execute("select 1")
+
+        (r,) = await cur.fetchone()
+        assert r == 1
+
+
 async def test_outer_transaction(aconn):
     async with aconn.transaction():
         async with aconn.pipeline():

--- a/tests/test_pipeline_async.py
+++ b/tests/test_pipeline_async.py
@@ -204,6 +204,22 @@ async def test_pipeline_commit_aborted(aconn):
             await aconn.commit()
 
 
+async def test_sync_syncs_results(aconn):
+    async with aconn.pipeline() as p:
+        cur = await aconn.execute("select 1")
+        assert cur.statusmessage is None
+        await p.sync()
+        assert cur.statusmessage == "SELECT 1"
+
+
+async def test_sync_syncs_errors(aconn):
+    await aconn.set_autocommit(True)
+    async with aconn.pipeline() as p:
+        await aconn.execute("select 1 from nosuchtable")
+        with pytest.raises(e.UndefinedTable):
+            await p.sync()
+
+
 async def test_fetch_no_result(aconn):
     async with aconn.pipeline():
         cur = aconn.cursor()

--- a/tests/test_pipeline_async.py
+++ b/tests/test_pipeline_async.py
@@ -251,12 +251,12 @@ async def test_errors_raised_on_transaction_exit(aconn):
 async def test_errors_raised_on_nested_transaction_exit(aconn):
     here = False
     async with aconn.pipeline():
-        with pytest.raises(e.UndefinedTable):
-            async with aconn.transaction():
+        async with aconn.transaction():
+            with pytest.raises(e.UndefinedTable):
                 async with aconn.transaction():
                     await aconn.execute("select 1 from nosuchtable")
                     here = True
-        cur1 = await aconn.execute("select 1")
+            cur1 = await aconn.execute("select 1")
     assert here
     cur2 = await aconn.execute("select 2")
 


### PR DESCRIPTION
As highlighted in #296, we should make sure that on `sync()` and on `commit()` the state of the Python connection reflects what's in the server, in particular we should throw an exception if there is any error.

This MR fixes the behaviour of these functions as well as the nested transaction.

The tests also highlight a difference between pipeline and non-pipeline mode: if commit fails in pipeline mode, the transaction is left INERROR instead of going IDLE.