### PR TITLE
fix: wrap transaction in an outer pipeline if the connection has one

### DIFF
--- a/psycopg/psycopg/connection.py
+++ b/psycopg/psycopg/connection.py
@@ -872,7 +872,7 @@ class Connection(BaseConnection[Row]):
         tx = Transaction(self, savepoint_name, force_rollback)
         if self._pipeline:
             self._pipeline.sync()
-            with tx, self.pipeline():
+            with self.pipeline(), tx, self.pipeline():
                 yield tx
         else:
             with tx:

--- a/psycopg/psycopg/connection.py
+++ b/psycopg/psycopg/connection.py
@@ -183,9 +183,10 @@ class BaseConnection(Generic[Row]):
         self._set_autocommit(value)
 
     def _set_autocommit(self, value: bool) -> None:
-        # Base implementation, not thread safe.
-        # Subclasses must call it holding a lock
-        self._check_intrans("autocommit")
+        raise NotImplementedError
+
+    def _set_autocommit_gen(self, value: bool) -> PQGen[None]:
+        yield from self._check_intrans_gen("autocommit")
         self._autocommit = bool(value)
 
     @property
@@ -200,9 +201,10 @@ class BaseConnection(Generic[Row]):
         self._set_isolation_level(value)
 
     def _set_isolation_level(self, value: Optional[IsolationLevel]) -> None:
-        # Base implementation, not thread safe.
-        # Subclasses must call it holding a lock
-        self._check_intrans("isolation_level")
+        raise NotImplementedError
+
+    def _set_isolation_level_gen(self, value: Optional[IsolationLevel]) -> PQGen[None]:
+        yield from self._check_intrans_gen("isolation_level")
         self._isolation_level = IsolationLevel(value) if value is not None else None
         self._begin_statement = b""
 
@@ -218,9 +220,10 @@ class BaseConnection(Generic[Row]):
         self._set_read_only(value)
 
     def _set_read_only(self, value: Optional[bool]) -> None:
-        # Base implementation, not thread safe.
-        # Subclasses must call it holding a lock
-        self._check_intrans("read_only")
+        raise NotImplementedError
+
+    def _set_read_only_gen(self, value: Optional[bool]) -> PQGen[None]:
+        yield from self._check_intrans_gen("read_only")
         self._read_only = bool(value)
         self._begin_statement = b""
 
@@ -236,15 +239,19 @@ class BaseConnection(Generic[Row]):
         self._set_deferrable(value)
 
     def _set_deferrable(self, value: Optional[bool]) -> None:
-        # Base implementation, not thread safe.
-        # Subclasses must call it holding a lock
-        self._check_intrans("deferrable")
+        raise NotImplementedError
+
+    def _set_deferrable_gen(self, value: Optional[bool]) -> PQGen[None]:
+        yield from self._check_intrans_gen("deferrable")
         self._deferrable = bool(value)
         self._begin_statement = b""
 
-    def _check_intrans(self, attribute: str) -> None:
+    def _check_intrans_gen(self, attribute: str) -> PQGen[None]:
         # Raise an exception if we are in a transaction
         status = self.pgconn.transaction_status
+        if status == TransactionStatus.IDLE and self._pipeline:
+            yield from self._pipeline._sync_gen()
+            status = self.pgconn.transaction_status
         if status != TransactionStatus.IDLE:
             if self._num_transactions:
                 raise e.ProgrammingError(
@@ -937,19 +944,19 @@ class Connection(BaseConnection[Row]):
 
     def _set_autocommit(self, value: bool) -> None:
         with self.lock:
-            super()._set_autocommit(value)
+            self.wait(self._set_autocommit_gen(value))
 
     def _set_isolation_level(self, value: Optional[IsolationLevel]) -> None:
         with self.lock:
-            super()._set_isolation_level(value)
+            self.wait(self._set_isolation_level_gen(value))
 
     def _set_read_only(self, value: Optional[bool]) -> None:
         with self.lock:
-            super()._set_read_only(value)
+            self.wait(self._set_read_only_gen(value))
 
     def _set_deferrable(self, value: Optional[bool]) -> None:
         with self.lock:
-            super()._set_deferrable(value)
+            self.wait(self._set_deferrable_gen(value))
 
     def tpc_begin(self, xid: Union[Xid, str]) -> None:
         """

--- a/psycopg/psycopg/connection_async.py
+++ b/psycopg/psycopg/connection_async.py
@@ -347,7 +347,7 @@ class AsyncConnection(BaseConnection[Row]):
     async def set_autocommit(self, value: bool) -> None:
         """Async version of the `~Connection.autocommit` setter."""
         async with self.lock:
-            super()._set_autocommit(value)
+            await self.wait(self._set_autocommit_gen(value))
 
     def _set_isolation_level(self, value: Optional[IsolationLevel]) -> None:
         self._no_set_async("isolation_level")
@@ -355,7 +355,7 @@ class AsyncConnection(BaseConnection[Row]):
     async def set_isolation_level(self, value: Optional[IsolationLevel]) -> None:
         """Async version of the `~Connection.isolation_level` setter."""
         async with self.lock:
-            super()._set_isolation_level(value)
+            await self.wait(self._set_isolation_level_gen(value))
 
     def _set_read_only(self, value: Optional[bool]) -> None:
         self._no_set_async("read_only")
@@ -363,7 +363,7 @@ class AsyncConnection(BaseConnection[Row]):
     async def set_read_only(self, value: Optional[bool]) -> None:
         """Async version of the `~Connection.read_only` setter."""
         async with self.lock:
-            super()._set_read_only(value)
+            await self.wait(self._set_read_only_gen(value))
 
     def _set_deferrable(self, value: Optional[bool]) -> None:
         self._no_set_async("deferrable")
@@ -371,7 +371,7 @@ class AsyncConnection(BaseConnection[Row]):
     async def set_deferrable(self, value: Optional[bool]) -> None:
         """Async version of the `~Connection.deferrable` setter."""
         async with self.lock:
-            super()._set_deferrable(value)
+            await self.wait(self._set_deferrable_gen(value))
 
     def _no_set_async(self, attribute: str) -> None:
         raise AttributeError(

--- a/psycopg/psycopg/connection_async.py
+++ b/psycopg/psycopg/connection_async.py
@@ -284,7 +284,7 @@ class AsyncConnection(BaseConnection[Row]):
         tx = AsyncTransaction(self, savepoint_name, force_rollback)
         if self._pipeline:
             await self._pipeline.sync()
-            async with tx, self.pipeline():
+            async with self.pipeline(), tx, self.pipeline():
                 yield tx
         else:
             async with tx:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,11 @@ def pytest_configure(config):
     for marker in markers:
         config.addinivalue_line("markers", marker)
 
+    config.addinivalue_line(
+        "markers",
+        "pipeline: the test runs with connection in pipeline mode",
+    )
+
 
 def pytest_addoption(parser):
     parser.addoption(

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -336,7 +336,7 @@ def test_autocommit_inerror(conn):
 def test_autocommit_unknown(conn):
     conn.close()
     assert conn.pgconn.transaction_status == conn.TransactionStatus.UNKNOWN
-    with pytest.raises(psycopg.ProgrammingError):
+    with pytest.raises(psycopg.OperationalError):
         conn.autocommit = True
     assert not conn.autocommit
 

--- a/tests/test_connection_async.py
+++ b/tests/test_connection_async.py
@@ -340,7 +340,7 @@ async def test_autocommit_inerror(aconn):
 async def test_autocommit_unknown(aconn):
     await aconn.close()
     assert aconn.pgconn.transaction_status == aconn.TransactionStatus.UNKNOWN
-    with pytest.raises(psycopg.ProgrammingError):
+    with pytest.raises(psycopg.OperationalError):
         await aconn.set_autocommit(True)
     assert not aconn.autocommit
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -10,7 +10,10 @@ import psycopg
 from psycopg import pq
 from psycopg import errors as e
 
-pytestmark = pytest.mark.libpq(">= 14")
+pytestmark = [
+    pytest.mark.libpq(">= 14"),
+    pytest.mark.pipeline,
+]
 
 
 def test_repr(conn):

--- a/tests/test_pipeline_async.py
+++ b/tests/test_pipeline_async.py
@@ -11,8 +11,9 @@ from psycopg import pq
 from psycopg import errors as e
 
 pytestmark = [
-    pytest.mark.libpq(">= 14"),
     pytest.mark.asyncio,
+    pytest.mark.libpq(">= 14"),
+    pytest.mark.pipeline,
 ]
 
 

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -7,6 +7,11 @@ import pytest
 from psycopg import Connection, ProgrammingError, Rollback
 
 
+@pytest.fixture
+def conn(conn, pipeline):
+    return conn
+
+
 @pytest.fixture(autouse=True)
 def create_test_table(svcconn):
     """Creates a table called 'test_table' for use in tests."""
@@ -70,10 +75,12 @@ class ExpectedException(Exception):
     pass
 
 
-def test_basic(conn):
+def test_basic(conn, pipeline):
     """Basic use of transaction() to BEGIN and COMMIT a transaction."""
     assert not in_transaction(conn)
     with conn.transaction():
+        if pipeline:
+            pipeline.sync()
         assert in_transaction(conn)
     assert not in_transaction(conn)
 
@@ -103,11 +110,13 @@ def test_cant_reenter(conn):
             pass
 
 
-def test_begins_on_enter(conn):
+def test_begins_on_enter(conn, pipeline):
     """Transaction does not begin until __enter__() is called."""
     tx = conn.transaction()
     assert not in_transaction(conn)
     with tx:
+        if pipeline:
+            pipeline.sync()
         assert in_transaction(conn)
     assert not in_transaction(conn)
 
@@ -132,7 +141,11 @@ def test_rollback_on_exception_exit(conn):
     assert not inserted(conn)
 
 
-def test_context_inerror_rollback_no_clobber(conn, dsn, caplog):
+def test_context_inerror_rollback_no_clobber(conn, pipeline, dsn, caplog):
+    if pipeline:
+        # Only 'conn' is possibly in pipeline mode, but the transaction and
+        # checks are on 'conn2'.
+        pytest.skip("not applicable")
     caplog.set_level(logging.WARNING, logger="psycopg")
 
     with pytest.raises(ZeroDivisionError):
@@ -186,12 +199,17 @@ def test_interaction_dbapi_transaction(conn):
     assert inserted(conn) == {"foo", "baz"}
 
 
-def test_prohibits_use_of_commit_rollback_autocommit(conn):
+def test_prohibits_use_of_commit_rollback_autocommit(conn, pipeline):
     """
     Within a Transaction block, it is forbidden to touch commit, rollback,
     or the autocommit setting on the connection, as this would interfere
     with the transaction scope being managed by the Transaction block.
     """
+    if pipeline:
+        # TODO: Fixing Connection._check_intrans() would require calling
+        # conn._pipeline.sync(), which implies turning _check_intrans() into a
+        # generator method.
+        pytest.xfail("Connection._check_intrans() does not account for pipeline mode")
     conn.autocommit = False
     conn.commit()
     conn.rollback()
@@ -264,7 +282,7 @@ def test_autocommit_off_but_no_tx_started_exception_exit(conn, svcconn):
     assert not inserted(svcconn)
 
 
-def test_autocommit_off_and_tx_in_progress_successful_exit(conn, svcconn):
+def test_autocommit_off_and_tx_in_progress_successful_exit(conn, pipeline, svcconn):
     """
     Scenario:
     * Connection has autocommit off but and a transaction is already in
@@ -278,6 +296,8 @@ def test_autocommit_off_and_tx_in_progress_successful_exit(conn, svcconn):
     """
     conn.autocommit = False
     insert_row(conn, "prior")
+    if pipeline:
+        pipeline.sync()
     assert in_transaction(conn)
     with conn.transaction():
         insert_row(conn, "new")
@@ -287,7 +307,7 @@ def test_autocommit_off_and_tx_in_progress_successful_exit(conn, svcconn):
     assert not inserted(svcconn)
 
 
-def test_autocommit_off_and_tx_in_progress_exception_exit(conn, svcconn):
+def test_autocommit_off_and_tx_in_progress_exception_exit(conn, pipeline, svcconn):
     """
     Scenario:
     * Connection has autocommit off but and a transaction is already in
@@ -302,6 +322,8 @@ def test_autocommit_off_and_tx_in_progress_exception_exit(conn, svcconn):
     """
     conn.autocommit = False
     insert_row(conn, "prior")
+    if pipeline:
+        pipeline.sync()
     assert in_transaction(conn)
     with pytest.raises(ExpectedException):
         with conn.transaction():
@@ -643,16 +665,27 @@ def test_explicit_rollback_of_enclosing_tx_outer_tx_unaffected(conn, svcconn):
     assert inserted(svcconn) == {"outer-before", "outer-after"}
 
 
-def test_str(conn):
+def test_str(conn, pipeline):
     with conn.transaction() as tx:
-        assert "[INTRANS]" in str(tx)
+        if pipeline:
+            assert "INTRANS" not in str(tx)
+            pipeline.sync()
+            assert "[INTRANS, pipeline=ON]" in str(tx)
+        else:
+            assert "[INTRANS]" in str(tx)
         assert "(active)" in str(tx)
         assert "'" not in str(tx)
         with conn.transaction("wat") as tx2:
-            assert "[INTRANS]" in str(tx2)
+            if pipeline:
+                assert "[INTRANS, pipeline=ON]" in str(tx2)
+            else:
+                assert "[INTRANS]" in str(tx2)
             assert "'wat'" in str(tx2)
 
-    assert "[IDLE]" in str(tx)
+    if pipeline:
+        assert "[IDLE, pipeline=ON]" in str(tx)
+    else:
+        assert "[IDLE]" in str(tx)
     assert "(terminated)" in str(tx)
 
     with pytest.raises(ZeroDivisionError):

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -199,17 +199,12 @@ def test_interaction_dbapi_transaction(conn):
     assert inserted(conn) == {"foo", "baz"}
 
 
-def test_prohibits_use_of_commit_rollback_autocommit(conn, pipeline):
+def test_prohibits_use_of_commit_rollback_autocommit(conn):
     """
     Within a Transaction block, it is forbidden to touch commit, rollback,
     or the autocommit setting on the connection, as this would interfere
     with the transaction scope being managed by the Transaction block.
     """
-    if pipeline:
-        # TODO: Fixing Connection._check_intrans() would require calling
-        # conn._pipeline.sync(), which implies turning _check_intrans() into a
-        # generator method.
-        pytest.xfail("Connection._check_intrans() does not account for pipeline mode")
     conn.autocommit = False
     conn.commit()
     conn.rollback()

--- a/tests/test_transaction_async.py
+++ b/tests/test_transaction_async.py
@@ -142,17 +142,12 @@ async def test_interaction_dbapi_transaction(aconn):
     assert await inserted(aconn) == {"foo", "baz"}
 
 
-async def test_prohibits_use_of_commit_rollback_autocommit(aconn, apipeline):
+async def test_prohibits_use_of_commit_rollback_autocommit(aconn):
     """
     Within a Transaction block, it is forbidden to touch commit, rollback,
     or the autocommit setting on the connection, as this would interfere
     with the transaction scope being managed by the Transaction block.
     """
-    if apipeline:
-        # TODO: Fixing Connection._check_intrans() would require calling
-        # conn._pipeline.sync(), which implies turning _check_intrans() into a
-        # generator method.
-        pytest.xfail("Connection._check_intrans() does not account for pipeline mode")
     await aconn.set_autocommit(False)
     await aconn.commit()
     await aconn.rollback()

--- a/tests/test_transaction_async.py
+++ b/tests/test_transaction_async.py
@@ -13,10 +13,17 @@ from .test_transaction import create_test_table  # noqa  # autouse fixture
 pytestmark = pytest.mark.asyncio
 
 
-async def test_basic(aconn):
+@pytest.fixture
+async def aconn(aconn, apipeline):
+    return aconn
+
+
+async def test_basic(aconn, apipeline):
     """Basic use of transaction() to BEGIN and COMMIT a transaction."""
     assert not in_transaction(aconn)
     async with aconn.transaction():
+        if apipeline:
+            await apipeline.sync()
         assert in_transaction(aconn)
     assert not in_transaction(aconn)
 
@@ -46,11 +53,13 @@ async def test_cant_reenter(aconn):
             pass
 
 
-async def test_begins_on_enter(aconn):
+async def test_begins_on_enter(aconn, apipeline):
     """Transaction does not begin until __enter__() is called."""
     tx = aconn.transaction()
     assert not in_transaction(aconn)
     async with tx:
+        if apipeline:
+            await apipeline.sync()
         assert in_transaction(aconn)
     assert not in_transaction(aconn)
 
@@ -75,7 +84,11 @@ async def test_rollback_on_exception_exit(aconn):
     assert not await inserted(aconn)
 
 
-async def test_context_inerror_rollback_no_clobber(aconn, dsn, caplog):
+async def test_context_inerror_rollback_no_clobber(aconn, apipeline, dsn, caplog):
+    if apipeline:
+        # Only 'aconn' is possibly in pipeline mode, but the transaction and
+        # checks are on 'conn2'.
+        pytest.skip("not applicable")
     caplog.set_level(logging.WARNING, logger="psycopg")
 
     with pytest.raises(ZeroDivisionError):
@@ -129,12 +142,17 @@ async def test_interaction_dbapi_transaction(aconn):
     assert await inserted(aconn) == {"foo", "baz"}
 
 
-async def test_prohibits_use_of_commit_rollback_autocommit(aconn):
+async def test_prohibits_use_of_commit_rollback_autocommit(aconn, apipeline):
     """
     Within a Transaction block, it is forbidden to touch commit, rollback,
     or the autocommit setting on the connection, as this would interfere
     with the transaction scope being managed by the Transaction block.
     """
+    if apipeline:
+        # TODO: Fixing Connection._check_intrans() would require calling
+        # conn._pipeline.sync(), which implies turning _check_intrans() into a
+        # generator method.
+        pytest.xfail("Connection._check_intrans() does not account for pipeline mode")
     await aconn.set_autocommit(False)
     await aconn.commit()
     await aconn.rollback()
@@ -207,7 +225,9 @@ async def test_autocommit_off_but_no_tx_started_exception_exit(aconn, svcconn):
     assert not inserted(svcconn)
 
 
-async def test_autocommit_off_and_tx_in_progress_successful_exit(aconn, svcconn):
+async def test_autocommit_off_and_tx_in_progress_successful_exit(
+    aconn, apipeline, svcconn
+):
     """
     Scenario:
     * Connection has autocommit off but and a transaction is already in
@@ -221,6 +241,8 @@ async def test_autocommit_off_and_tx_in_progress_successful_exit(aconn, svcconn)
     """
     await aconn.set_autocommit(False)
     await insert_row(aconn, "prior")
+    if apipeline:
+        await apipeline.sync()
     assert in_transaction(aconn)
     async with aconn.transaction():
         await insert_row(aconn, "new")
@@ -230,7 +252,9 @@ async def test_autocommit_off_and_tx_in_progress_successful_exit(aconn, svcconn)
     assert not inserted(svcconn)
 
 
-async def test_autocommit_off_and_tx_in_progress_exception_exit(aconn, svcconn):
+async def test_autocommit_off_and_tx_in_progress_exception_exit(
+    aconn, apipeline, svcconn
+):
     """
     Scenario:
     * Connection has autocommit off but and a transaction is already in
@@ -245,6 +269,8 @@ async def test_autocommit_off_and_tx_in_progress_exception_exit(aconn, svcconn):
     """
     await aconn.set_autocommit(False)
     await insert_row(aconn, "prior")
+    if apipeline:
+        await apipeline.sync()
     assert in_transaction(aconn)
     with pytest.raises(ExpectedException):
         async with aconn.transaction():
@@ -590,16 +616,27 @@ async def test_explicit_rollback_of_enclosing_tx_outer_tx_unaffected(aconn, svcc
     assert inserted(svcconn) == {"outer-before", "outer-after"}
 
 
-async def test_str(aconn):
+async def test_str(aconn, apipeline):
     async with aconn.transaction() as tx:
-        assert "[INTRANS]" in str(tx)
+        if apipeline:
+            assert "[INTRANS]" not in str(tx)
+            await apipeline.sync()
+            assert "[INTRANS, pipeline=ON]" in str(tx)
+        else:
+            assert "[INTRANS]" in str(tx)
         assert "(active)" in str(tx)
         assert "'" not in str(tx)
         async with aconn.transaction("wat") as tx2:
-            assert "[INTRANS]" in str(tx2)
+            if apipeline:
+                assert "[INTRANS, pipeline=ON]" in str(tx2)
+            else:
+                assert "[INTRANS]" in str(tx2)
             assert "'wat'" in str(tx2)
 
-    assert "[IDLE]" in str(tx)
+    if apipeline:
+        assert "[IDLE, pipeline=ON]" in str(tx)
+    else:
+        assert "[IDLE]" in str(tx)
     assert "(terminated)" in str(tx)
 
     with pytest.raises(ZeroDivisionError):


### PR DESCRIPTION
Follow-up #297, almost resurrecting #271 (but without `nullcontext()`):
* Now running (almost) all transaction tests with and without the connection in pipeline mode;
* Fixing connection state at exit of transaction state;
* See the TODO in tests, about `Connection._check_intrans()`.