### PR TITLE
fix: sync pipeline after tpc_prepare()

### DIFF
--- a/psycopg/psycopg/connection.py
+++ b/psycopg/psycopg/connection.py
@@ -613,6 +613,8 @@ class BaseConnection(Generic[Row]):
         xid = self._tpc[0]
         self._tpc = (xid, True)
         yield from self._exec_command(SQL("PREPARE TRANSACTION {}").format(str(xid)))
+        if self._pipeline:
+            yield from self._pipeline._sync_gen()
 
     def _tpc_finish_gen(self, action: str, xid: Union[Xid, str, None]) -> PQGen[None]:
         fname = f"tpc_{action}()"

--- a/tests/test_tpc.py
+++ b/tests/test_tpc.py
@@ -4,7 +4,7 @@ import psycopg
 from psycopg.pq import TransactionStatus
 
 
-def test_tpc_disabled(conn):
+def test_tpc_disabled(conn, pipeline):
     val = int(conn.execute("show max_prepared_transactions").fetchone()[0])
     if val:
         pytest.skip("prepared transactions enabled")

--- a/tests/test_tpc_async.py
+++ b/tests/test_tpc_async.py
@@ -6,7 +6,7 @@ from psycopg.pq import TransactionStatus
 pytestmark = [pytest.mark.asyncio]
 
 
-async def test_tpc_disabled(aconn):
+async def test_tpc_disabled(aconn, apipeline):
     cur = await aconn.execute("show max_prepared_transactions")
     val = int((await cur.fetchone())[0])
     if val:


### PR DESCRIPTION
This is to get the NotSupported raised directly when calling
tpc_prepare() as expected in test_tpc_disabled().

(Other TPC tests pass when enabling pipeline mode overall.)