### PR TITLE
fix: sync nested pipeline with pending commands upon enter

### DIFF
--- a/docs/advanced/pipeline.rst
+++ b/docs/advanced/pipeline.rst
@@ -239,6 +239,7 @@ point is established by Psycopg:
 - using the `Pipeline.sync()` method;
 - on `Connection.commit()` or `~Connection.rollback()`;
 - at the end of a `!Pipeline` block;
+- possibly when opening a nested `!Pipeline` block;
 - using a fetch method such as `Cursor.fetchone()` (which only flushes the
   query but doesn't issue a Sync and doesn't reset a pipeline state error).
 

--- a/psycopg/psycopg/connection.py
+++ b/psycopg/psycopg/connection.py
@@ -903,7 +903,6 @@ class Connection(BaseConnection[Row]):
         """
         tx = Transaction(self, savepoint_name, force_rollback)
         if self._pipeline:
-            self._pipeline.sync()
             with self.pipeline(), tx, self.pipeline():
                 yield tx
         else:

--- a/psycopg/psycopg/connection_async.py
+++ b/psycopg/psycopg/connection_async.py
@@ -293,7 +293,6 @@ class AsyncConnection(BaseConnection[Row]):
         """
         tx = AsyncTransaction(self, savepoint_name, force_rollback)
         if self._pipeline:
-            await self._pipeline.sync()
             async with self.pipeline(), tx, self.pipeline():
                 yield tx
         else:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -402,6 +402,9 @@ def test_auto_prepare(conn):
 
 
 def test_transaction(conn):
+    notices = []
+    conn.add_notice_handler(lambda diag: notices.append(diag.message_primary))
+
     with conn.pipeline():
         with conn.transaction():
             cur = conn.execute("select 'tx'")
@@ -415,6 +418,8 @@ def test_transaction(conn):
 
         (r,) = cur.fetchone()
         assert r == "rb"
+
+    assert not notices
 
 
 def test_transaction_nested(conn):

--- a/tests/test_pipeline_async.py
+++ b/tests/test_pipeline_async.py
@@ -402,6 +402,9 @@ async def test_auto_prepare(aconn):
 
 
 async def test_transaction(aconn):
+    notices = []
+    aconn.add_notice_handler(lambda diag: notices.append(diag.message_primary))
+
     async with aconn.pipeline():
         async with aconn.transaction():
             cur = await aconn.execute("select 'tx'")
@@ -415,6 +418,8 @@ async def test_transaction(aconn):
 
         (r,) = await cur.fetchone()
         assert r == "rb"
+
+    assert not notices
 
 
 async def test_transaction_nested(aconn):

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -663,8 +663,6 @@ def test_explicit_rollback_of_enclosing_tx_outer_tx_unaffected(conn, svcconn):
 def test_str(conn, pipeline):
     with conn.transaction() as tx:
         if pipeline:
-            assert "INTRANS" not in str(tx)
-            pipeline.sync()
             assert "[INTRANS, pipeline=ON]" in str(tx)
         else:
             assert "[INTRANS]" in str(tx)


### PR DESCRIPTION
When entering a nested pipeline and the outer one has pending commands,
we now sync the pipeline. This is probably less surprising at it makes
the implicit transaction from a nested pipeline isolated from the outer
one.

Fix https://github.com/psycopg/psycopg/issues/309.

---
second commit cherry-picked from 9ca0991f892d6ede9e6f5cd6327f9149170ac56a