### PR TITLE
codespell the entire repo?

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
       PSYCOPG_TEST_DSN: "host=127.0.0.1 user=postgres"
       PGPASSWORD: password
       PYTEST_ADDOPTS: --color yes
-      # Enable to run tests using the minumum version of dependencies.
+      # Enable to run tests using the minimum version of dependencies.
       # PIP_CONSTRAINT: ${{ github.workspace }}/tests/constraints.txt
 
     steps:

--- a/psycopg/psycopg/_pipeline.py
+++ b/psycopg/psycopg/_pipeline.py
@@ -69,7 +69,7 @@ class BasePipeline:
 
     @staticmethod
     def is_supported() -> bool:
-        """Return `!True` if the psycopg libpq wrapper suports pipeline mode."""
+        """Return `!True` if the psycopg libpq wrapper supports pipeline mode."""
         if BasePipeline._is_supported is None:
             # Support only depends on the libpq functions available in the pq
             # wrapper, not on the database version.
@@ -148,7 +148,7 @@ class BasePipeline:
     ) -> None:
         """Process a results set fetched from the current pipeline.
 
-        This matchs 'results' with its respective element in the pipeline
+        This matches 'results' with its respective element in the pipeline
         queue. For commands (None value in the pipeline queue), results are
         checked directly. For prepare statement creation requests, update the
         cache. Otherwise, results are attached to their respective cursor.
@@ -218,7 +218,7 @@ class Pipeline(BasePipeline):
                 self._exit()
             except Exception as exc2:
                 # Notice that this error might be pretty irrecoverable. It
-                # happens on COPY, for insance: even if sync succeeds, exiting
+                # happens on COPY, for instance: even if sync succeeds, exiting
                 # fails with "cannot exit pipeline mode with uncollected results"
                 if exc_val:
                     logger.warning("error ignored exiting %r: %s", self, exc2)

--- a/psycopg/psycopg/copy.py
+++ b/psycopg/psycopg/copy.py
@@ -64,7 +64,7 @@ class BaseCopy(Generic[ConnectionType]):
 
     # Size of data to accumulate before sending it down the network. We fill a
     # buffer this size field by field, and when it passes the threshold size
-    # wee ship it, so it may end up being bigger than this.
+    # we ship it, so it may end up being bigger than this.
     BUFFER_SIZE = 32 * 1024
 
     # Maximum data size we want to queue to send to the libpq copy. Sending a

--- a/psycopg/psycopg/cursor.py
+++ b/psycopg/psycopg/cursor.py
@@ -785,7 +785,7 @@ class Cursor(BaseCursor["Connection[Any]", Row]):
                     first = False
         except e.Error as ex:
             # try to get out of ACTIVE state. Just do a single attempt, which
-            # shoud work to recover from an error or query cancelled.
+            # should work to recover from an error or query cancelled.
             if self._pgconn.transaction_status == ACTIVE:
                 try:
                     self._conn.wait(self._stream_fetchone_gen(first))

--- a/psycopg/psycopg/cursor_async.py
+++ b/psycopg/psycopg/cursor_async.py
@@ -145,7 +145,7 @@ class AsyncCursor(BaseCursor["AsyncConnection[Any]", Row]):
                     first = False
         except e.Error as ex:
             # try to get out of ACTIVE state. Just do a single attempt, which
-            # shoud work to recover from an error or query cancelled.
+            # should work to recover from an error or query cancelled.
             if self._pgconn.transaction_status == pq.TransactionStatus.ACTIVE:
                 try:
                     await self._conn.wait(self._stream_fetchone_gen(first))

--- a/psycopg/psycopg/types/enum.py
+++ b/psycopg/psycopg/types/enum.py
@@ -39,7 +39,7 @@ class _BaseEnumLoader(Loader, Generic[E]):
             enc = conn_encoding(self.connection)
             label = data.decode(enc, "replace")  # type: ignore[union-attr]
             raise e.DataError(
-                f"bad memeber for enum {self.enum.__qualname__}: {label!r}"
+                f"bad member for enum {self.enum.__qualname__}: {label!r}"
             )
 
 

--- a/tools/update_errors.py
+++ b/tools/update_errors.py
@@ -53,7 +53,7 @@ def parse_errors_txt(url):
         m = re.match(r"(.....)\s+(?:E|W|S)\s+ERRCODE_(\S+)(?:\s+(\S+))?$", line)
         if m:
             sqlstate, macro, spec = m.groups()
-            # skip sqlstates without specs as they are not publically visible
+            # skip sqlstates without specs as they are not publicly visible
             if not spec:
                 continue
             errlabel = spec.upper()

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ deps =
     ./psycopg_pool
 
 [testenv:codespell]
-commands = codespell docs psycopg* tests
+commands = codespell
 deps =
     codespell
 


### PR DESCRIPTION
codespell is blindingly fast so it is better not to restrict its vision.
```
./psycopg/psycopg/cursor.py:788: shoud ==> should
./psycopg/psycopg/copy.py:67: wee ==> we
./psycopg/psycopg/_pipeline.py:72: suports ==> supports
./psycopg/psycopg/_pipeline.py:151: matchs ==> matches
./psycopg/psycopg/_pipeline.py:221: insance ==> instance, insane
./psycopg/psycopg/cursor_async.py:148: shoud ==> should
./psycopg/psycopg/types/enum.py:42: memeber ==> member
./tools/update_errors.py:56: publically ==> publicly
./.github/workflows/tests.yml:44: minumum ==> minimum
```