### PR TITLE
Improve flake8 with flake8-bugbear

### DIFF
--- a/psycopg/setup.py
+++ b/psycopg/setup.py
@@ -49,6 +49,7 @@ extras_require = {
         "black >= 22.3.0",
         "dnspython >= 2.1",
         "flake8 >= 4.0",
+        "flake8-bugbear >= 22.6.22",
         "mypy >= 0.940",
         "types-setuptools >= 57.4",
         "wheel >= 0.37",


### PR DESCRIPTION
Find likely bugs and design problems with https://pypi.org/project/flake8-bugbear
```
7     B006 Do not use mutable data structures for argument defaults.  They are created during function definition time. All calls to the function reuse this one instance of that data structure, persisting changes between them.
57    B007 Loop control variable 'dirs' not used within the loop body. If this is intended, start the name with an underscore.
2     B008 Do not perform function calls in argument defaults.  The call is performed only once at function definition time. All calls to your function will reuse the result of that definition-time function call.  If this is intended, assign the function call to a module-level variable and use that variable as a default value.
7     B010 Do not call setattr with a constant attribute value, it is not any safer than normal property access.
12    B011 Do not call assert False since python -O removes these calls. Instead callers should raise AssertionError().
32    B015 Pointless comparison. This comparison does nothing but waste CPU instructions. Either prepend `assert` or remove it.
```
`B006` is the first item at https://docs.python-guide.org/writing/gotchas
`B007` could be ignored
https://github.com/PyCQA/flake8-bugbear#list-of-warnings
