### PR TITLE
test: use anyio instead of pytest-asyncio

### DIFF
--- a/psycopg/setup.cfg
+++ b/psycopg/setup.cfg
@@ -65,10 +65,10 @@ binary =
 pool =
     psycopg-pool
 test =
+    anyio >= 3.6.2
     mypy >= 0.990
     pproxy >= 2.7
     pytest >= 6.2.5
-    pytest-asyncio >= 0.17
     pytest-cov >= 3.0
     pytest-randomly >= 3.5
 dev =

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ requires = ["setuptools>=49.2.0", "wheel>=0.37"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
-asyncio_mode = "auto"
 filterwarnings = [
     "error",
 ]

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -9,10 +9,10 @@ typing-extensions == 4.1.0
 importlib-metadata == 1.4
 
 # From the 'test' extra
+anyio == 3.6.2
 mypy == 0.990
 pproxy == 2.7.0
 pytest == 6.2.5
-pytest-asyncio == 0.17.0
 pytest-cov == 3.0.0
 pytest-randomly == 3.5.0
 

--- a/tests/crdb/test_connection_async.py
+++ b/tests/crdb/test_connection_async.py
@@ -8,7 +8,7 @@ from psycopg._compat import create_task
 
 import pytest
 
-pytestmark = [pytest.mark.crdb, pytest.mark.asyncio]
+pytestmark = [pytest.mark.crdb, pytest.mark.anyio]
 
 
 async def test_is_crdb(aconn):

--- a/tests/crdb/test_copy_async.py
+++ b/tests/crdb/test_copy_async.py
@@ -13,7 +13,7 @@ from ..test_copy import sample_records
 from ..test_copy_async import ensure_table
 from .test_copy import sample_tabledef, copyopt
 
-pytestmark = [pytest.mark.crdb, pytest.mark.asyncio]
+pytestmark = [pytest.mark.crdb, pytest.mark.anyio]
 
 
 @pytest.mark.parametrize(

--- a/tests/crdb/test_cursor_async.py
+++ b/tests/crdb/test_cursor_async.py
@@ -12,7 +12,7 @@ from .test_cursor import testfeed
 
 testfeed  # fixture
 
-pytestmark = [pytest.mark.crdb, pytest.mark.asyncio]
+pytestmark = [pytest.mark.crdb, pytest.mark.anyio]
 
 
 @pytest.mark.slow

--- a/tests/fix_db.py
+++ b/tests/fix_db.py
@@ -239,7 +239,7 @@ def conn_cls(session_dsn):
 
 
 @pytest.fixture(scope="session")
-def aconn_cls(session_dsn):
+def aconn_cls(session_dsn, anyio_backend):
     cls = psycopg.AsyncConnection
     if crdb_version:
         from psycopg.crdb import AsyncCrdbConnection

--- a/tests/pool/conftest.py
+++ b/tests/pool/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+
+from ..conftest import asyncio_options
+
+
+@pytest.fixture(
+    params=[pytest.param(("asyncio", asyncio_options.copy()), id="asyncio")],
+    scope="session",
+)
+def anyio_backend(request):
+    backend, options = request.param
+    if request.config.option.loop == "uvloop":
+        options["use_uvloop"] = True
+    return backend, options

--- a/tests/pool/test_null_pool_async.py
+++ b/tests/pool/test_null_pool_async.py
@@ -11,7 +11,7 @@ from psycopg.pq import TransactionStatus
 from psycopg._compat import create_task
 from .test_pool_async import delay_connection, ensure_waiting
 
-pytestmark = [pytest.mark.asyncio]
+pytestmark = [pytest.mark.anyio]
 
 try:
     from psycopg_pool import AsyncNullConnectionPool  # noqa: F401

--- a/tests/pool/test_pool_async.py
+++ b/tests/pool/test_pool_async.py
@@ -15,7 +15,7 @@ except ImportError:
     # Tests should have been skipped if the package is not available
     pass
 
-pytestmark = [pytest.mark.asyncio]
+pytestmark = [pytest.mark.anyio]
 
 
 async def test_defaults(dsn):

--- a/tests/pool/test_sched_async.py
+++ b/tests/pool/test_sched_async.py
@@ -13,7 +13,7 @@ except ImportError:
     # Tests should have been skipped if the package is not available
     pass
 
-pytestmark = [pytest.mark.asyncio, pytest.mark.timing]
+pytestmark = [pytest.mark.anyio, pytest.mark.timing]
 
 
 @pytest.mark.slow

--- a/tests/test_client_cursor_async.py
+++ b/tests/test_client_cursor_async.py
@@ -14,7 +14,7 @@ from .test_cursor import execmany, _execmany  # noqa: F401
 from .fix_crdb import crdb_encoding
 
 execmany = execmany  # avoid F811 underneath
-pytestmark = pytest.mark.asyncio
+pytestmark = pytest.mark.anyio
 
 
 @pytest.fixture

--- a/tests/test_concurrency_async.py
+++ b/tests/test_concurrency_async.py
@@ -12,8 +12,6 @@ import psycopg
 from psycopg import errors as e
 from psycopg._compat import create_task
 
-pytestmark = pytest.mark.asyncio
-
 
 @pytest.mark.slow
 async def test_commit_concurrency(aconn):
@@ -194,7 +192,7 @@ async def test_identify_closure(aconn_cls, dsn):
     sys.platform == "win32", reason="don't know how to Ctrl-C on Windows"
 )
 @pytest.mark.crdb_skip("cancel")
-async def test_ctrl_c(dsn):
+def test_ctrl_c(dsn):
     script = f"""\
 import signal
 import asyncio

--- a/tests/test_connection_async.py
+++ b/tests/test_connection_async.py
@@ -17,7 +17,7 @@ from .test_connection import testctx  # noqa: F401  # fixture
 from .test_adapt import make_bin_dumper, make_dumper
 from .test_conninfo import fake_resolve  # noqa: F401
 
-pytestmark = pytest.mark.asyncio
+pytestmark = pytest.mark.anyio
 
 
 async def test_connect(aconn_cls, dsn):

--- a/tests/test_conninfo.py
+++ b/tests/test_conninfo.py
@@ -348,7 +348,7 @@ class TestConnectionInfo:
         ),
     ],
 )
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resolve_hostaddr_async_no_resolve(
     setpgenv, conninfo, want, env, fail_resolve
 ):
@@ -398,7 +398,7 @@ async def test_resolve_hostaddr_async_no_resolve(
         ),
     ],
 )
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resolve_hostaddr_async(conninfo, want, env, fake_resolve):
     params = conninfo_to_dict(conninfo)
     params = await resolve_hostaddr_async(params)
@@ -414,7 +414,7 @@ async def test_resolve_hostaddr_async(conninfo, want, env, fake_resolve):
         ("host=1.1.1.1,2.2.2.2", {"PGPORT": "1,2,3"}),
     ],
 )
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resolve_hostaddr_async_bad(setpgenv, conninfo, env, fake_resolve):
     setpgenv(env)
     params = conninfo_to_dict(conninfo)

--- a/tests/test_copy_async.py
+++ b/tests/test_copy_async.py
@@ -24,7 +24,6 @@ from .test_copy import sample_values, sample_records, sample_tabledef
 from .test_copy import py_to_raw, special_chars
 
 pytestmark = [
-    pytest.mark.asyncio,
     pytest.mark.crdb_skip("copy"),
 ]
 

--- a/tests/test_cursor_async.py
+++ b/tests/test_cursor_async.py
@@ -13,7 +13,6 @@ from .test_cursor import execmany, _execmany  # noqa: F401
 from .fix_crdb import crdb_encoding
 
 execmany = execmany  # avoid F811 underneath
-pytestmark = pytest.mark.asyncio
 
 
 async def test_init(aconn):

--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -6,7 +6,7 @@ from psycopg.conninfo import conninfo_to_dict
 pytestmark = [pytest.mark.dns]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_resolve_hostaddr_async_warning(recwarn):
     import_dnspython()
     conninfo = "dbname=foo"

--- a/tests/test_dns_srv.py
+++ b/tests/test_dns_srv.py
@@ -52,7 +52,7 @@ def test_srv(conninfo, want, env, fake_srv, setpgenv):
     assert conninfo_to_dict(want) == params
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 @pytest.mark.parametrize("conninfo, want, env", samples_ok)
 async def test_srv_async(conninfo, want, env, afake_srv, setpgenv):
     setpgenv(env)
@@ -75,7 +75,7 @@ def test_srv_bad(conninfo, env, fake_srv, setpgenv):
         psycopg._dns.resolve_srv(params)  # type: ignore[attr-defined]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 @pytest.mark.parametrize("conninfo,  env", samples_bad)
 async def test_srv_bad_async(conninfo, env, afake_srv, setpgenv):
     setpgenv(env)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -216,7 +216,6 @@ def test_diag_from_commit(conn):
     assert exc.value.diag.sqlstate == "23503"
 
 
-@pytest.mark.asyncio
 @pytest.mark.crdb_skip("deferrable")
 async def test_diag_from_commit_async(aconn):
     cur = aconn.cursor()

--- a/tests/test_pipeline_async.py
+++ b/tests/test_pipeline_async.py
@@ -13,7 +13,6 @@ from psycopg import errors as e
 from .test_pipeline import pipeline_aborted
 
 pytestmark = [
-    pytest.mark.asyncio,
     pytest.mark.pipeline,
     pytest.mark.skipif("not psycopg.AsyncPipeline.is_supported()"),
 ]

--- a/tests/test_prepared_async.py
+++ b/tests/test_prepared_async.py
@@ -9,8 +9,6 @@ import pytest
 
 from psycopg.rows import namedtuple_row
 
-pytestmark = pytest.mark.asyncio
-
 
 @pytest.mark.parametrize("value", [None, 0, 3])
 async def test_prepare_threshold_init(aconn_cls, dsn, value):

--- a/tests/test_server_cursor_async.py
+++ b/tests/test_server_cursor_async.py
@@ -5,7 +5,6 @@ from psycopg import rows, errors as e
 from psycopg.pq import Format
 
 pytestmark = [
-    pytest.mark.asyncio,
     pytest.mark.crdb_skip("server-side cursor"),
 ]
 

--- a/tests/test_tpc_async.py
+++ b/tests/test_tpc_async.py
@@ -4,7 +4,6 @@ import psycopg
 from psycopg.pq import TransactionStatus
 
 pytestmark = [
-    pytest.mark.asyncio,
     pytest.mark.crdb_skip("2-phase commit"),
 ]
 

--- a/tests/test_transaction_async.py
+++ b/tests/test_transaction_async.py
@@ -11,11 +11,9 @@ from .test_transaction import in_transaction, insert_row, inserted, get_exc_info
 from .test_transaction import ExpectedException, crdb_skip_external_observer
 from .test_transaction import create_test_table  # noqa  # autouse fixture
 
-pytestmark = pytest.mark.asyncio
-
 
 @pytest.fixture
-async def aconn(aconn, apipeline):
+async def aconn(aconn, apipeline, anyio_backend):
     return aconn
 
 

--- a/tests/test_typeinfo.py
+++ b/tests/test_typeinfo.py
@@ -42,7 +42,6 @@ def test_fetch(conn, name, status, encoding):
     assert info.regtype == "text"
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("name", ["text", sql.Identifier("text")])
 @pytest.mark.parametrize("status", ["IDLE", "INTRANS", None])
 @pytest.mark.parametrize(
@@ -111,7 +110,6 @@ def test_fetch_not_found(conn, name, status, info_cls, monkeypatch):
     assert info is None
 
 
-@pytest.mark.asyncio
 @_name
 @_status
 @_info_cls

--- a/tests/test_waiting.py
+++ b/tests/test_waiting.py
@@ -114,21 +114,21 @@ def test_wait_large_fd(dsn, waitfn):
 
 
 @pytest.mark.parametrize("timeout", timeouts)
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_wait_conn_async(dsn, timeout):
     gen = generators.connect(dsn)
     conn = await waiting.wait_conn_async(gen, **timeout)
     assert conn.status == ConnStatus.OK
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_wait_conn_async_bad(dsn):
     gen = generators.connect("dbname=nosuchdb")
     with pytest.raises(psycopg.OperationalError):
         await waiting.wait_conn_async(gen)
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 @pytest.mark.parametrize("wait, ready", zip(waiting.Wait, waiting.Ready))
 @skip_if_not_linux
 async def test_wait_ready_async(wait, ready):
@@ -141,7 +141,7 @@ async def test_wait_ready_async(wait, ready):
     assert r & ready
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_wait_async(pgconn):
     pgconn.send_query(b"select 1")
     gen = generators.execute(pgconn)
@@ -149,7 +149,7 @@ async def test_wait_async(pgconn):
     assert res.status == ExecStatus.TUPLES_OK
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_wait_async_bad(pgconn):
     pgconn.send_query(b"select 1")
     gen = generators.execute(pgconn)

--- a/tests/types/test_composite.py
+++ b/tests/types/test_composite.py
@@ -166,7 +166,6 @@ def test_fetch_info(conn, testcomp, name, fields):
         assert info.field_types[i] == builtins[t].oid
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("name, fields", fetch_cases)
 async def test_fetch_info_async(aconn, testcomp, name, fields):
     info = await CompositeInfo.fetch(aconn, name)

--- a/tests/types/test_enum.py
+++ b/tests/types/test_enum.py
@@ -68,7 +68,6 @@ def test_fetch_info(conn):
     assert info.labels == list(StrTestEnum.__members__)
 
 
-@pytest.mark.asyncio
 async def test_fetch_info_async(aconn):
     info = await EnumInfo.fetch(aconn, "PureTestEnum")
     assert info.name == "puretestenum"

--- a/tests/types/test_multirange.py
+++ b/tests/types/test_multirange.py
@@ -387,7 +387,6 @@ def test_fetch_info_not_found(conn):
     assert MultirangeInfo.fetch(conn, "nosuchrange") is None
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("name, subtype", fetch_cases)
 async def test_fetch_info_async(aconn, testmr, name, subtype):  # noqa: F811
     info = await MultirangeInfo.fetch(aconn, name)
@@ -397,7 +396,6 @@ async def test_fetch_info_async(aconn, testmr, name, subtype):  # noqa: F811
     assert info.subtype_oid == aconn.adapters.types[subtype].oid
 
 
-@pytest.mark.asyncio
 async def test_fetch_info_not_found_async(aconn):
     assert await MultirangeInfo.fetch(aconn, "nosuchrange") is None
 

--- a/tests/types/test_range.py
+++ b/tests/types/test_range.py
@@ -303,7 +303,6 @@ def test_fetch_info_not_found(conn):
     assert RangeInfo.fetch(conn, "nosuchrange") is None
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("name, subtype", fetch_cases)
 async def test_fetch_info_async(aconn, testrange, name, subtype):
     info = await RangeInfo.fetch(aconn, name)
@@ -313,7 +312,6 @@ async def test_fetch_info_async(aconn, testrange, name, subtype):
     assert info.subtype_oid == aconn.adapters.types[subtype].oid
 
 
-@pytest.mark.asyncio
 async def test_fetch_info_not_found_async(aconn):
     assert await RangeInfo.fetch(aconn, "nosuchrange") is None
 


### PR DESCRIPTION
Following comments from https://github.com/psycopg/psycopg/pull/146#issuecomment-1217852061, this is in preparation for #29 via #146.

* * *

This is in preparation for adding support for other async libraries,
through anyio. AnyIO pytest plugin is used in replacement for
pytest-asyncio:

- either the pytest.mark.asyncio is replaced by pytest.mark.anyio, or,
- we rely on the 'anyio_backend' fixture that is pulled in 'aconn_cls'
  fixture (and hence 'aconn') providing automatic detection for test
  functions using it.

The 'anyio_backend' fixture is parametrized to only use asyncio and
selects the event loop policy we need on Windows platform as previously
done in pytest_sessionstart(), but only for Python version 3.8 or
higher.

This fixture is defined in main conftest.py, as well as in
pool/conftest.py since we'll change the former to support more async
backend while keeping the later asyncio-only for now.

Some tests use asyncio explicitly so they would not run with another
backend; accordingly, we mark them with
@pytest.mark.parametrize('anyio_backend', ['asyncio']).

Function test_concurrency_async.py::test_ctrl_c is no longer 'async'
because its code does not directly use asyncio (it's done through a
subprocess); but the 'async def' was needed before in order for
pytest-asyncio to run it since the test module had a global
pytest.mark.asyncio (and we were using the "auto" mode).