### PR TITLE
fix: also sync nested pipeline when a transaction is active

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -16,6 +16,8 @@ Psycopg 3.1.2 (unreleased)
 - Fix handling of certain invalid time zones causing problems on Windows
   (:ticket:`#371`).
 - Fix segfault occurring when a loader fails initialization (:ticket:`#372`).
+- Fix invalid SAVEPOINT issued when entering `Connection.transaction()` within
+  a pipeline using an implicit transaction (:ticket:`#374`).
 
 
 Current release


### PR DESCRIPTION
Upon enter, transaction() checks the in-transaction status to determine if a BEGIN (when IDLE) or a SAVEPOINT (otherwise) should be inserted. However, in pipeline mode, if the pipeline is in "implicit transaction" (i.e. it has no active BEGIN) and statements have been sent, the in-transaction status might be ACTIVE if those statements have not yet completed (typically, when results have not been fetched).

By issuing a sync() before entering a nested pipeline (which will happen when entering transaction(), if already within a pipeline), we force completion of those statements, and thus get a predictable in-transaction status before entering the transaction() block.

Closes #374.