### PR TITLE
Better _as_python_identifier()

### DIFF
--- a/psycopg/psycopg/_encodings.py
+++ b/psycopg/psycopg/_encodings.py
@@ -146,12 +146,16 @@ def _as_python_identifier(s: str, prefix: str = "f") -> str:
     Replace all non-valid chars with '_' and prefix the value with *prefix* if
     the first letter is an '_'.
     """
-    s = _re_clean.sub("_", s)
-    # Python identifier cannot start with numbers, namedtuple fields
-    # cannot start with underscore. So...
-    if s[0] == "_" or "0" <= s[0] <= "9":
+    if not s.isidentifier():
+        if s[0] in '1234567890':
+            s = prefix + s
+        if not s.isidentifier():
+            s = _re_clean.sub("_", s)
+    # namedtuple fields cannot start with underscore. So...
+    if s[0] == "_":
         s = prefix + s
     return s
+
 
 
 _re_clean = re.compile(

--- a/tests/test_rows.py
+++ b/tests/test_rows.py
@@ -56,6 +56,13 @@ def test_namedtuple_row(conn):
     assert r2.number == 1
     assert not cur.nextset()
     assert type(r1) is not type(r2)
+    
+    cur.execute("select 1 as üåäö, 1 as _, 1 as "123"")
+    (r3,) = cur.fetchall()
+    assert 'üåäö' in r3._fields
+    assert 'f_' in r3._fields
+    assert 'f123' in r3._fields
+
 
 
 def test_class_row(conn):


### PR DESCRIPTION
Let more valid identifiers through _as_python_identifier(). Also 2.5x faster if no change is needed