### PR TITLE
Remove warning about missing binary package for M1

### DIFF
--- a/docs/basic/install.rst
+++ b/docs/basic/install.rst
@@ -57,10 +57,6 @@ to update it beforehand.
 The above package should work in most situations. It **will not work** in
 some cases though.
 
-.. warning::
-    At the time of writing we don't distribute binary packages for Apple M1
-    (ARM) processors.
-
 If your platform is not supported you should proceed to a :ref:`local
 installation <local-installation>` or a :ref:`pure Python installation
 <pure-python-installation>`.


### PR DESCRIPTION
Saw this warning, and I think it's outdated now, after #162, so I thought I'd just remove it.