### PR TITLE
refactor: handle exit exception in BasePipeline._exit()

### DIFF
--- a/psycopg/psycopg/version.py
+++ b/psycopg/psycopg/version.py
@@ -8,7 +8,7 @@ psycopg distribution version file.
 # https://www.python.org/dev/peps/pep-0440/
 
 # STOP AND READ! if you change:
-__version__ = "3.1.3"
+__version__ = "3.1.4.dev0"
 # also change:
 # - `docs/news.rst` to declare this as the current version or an unreleased one
 # - `psycopg_c/psycopg_c/version.py` to the same version.

--- a/psycopg_c/psycopg_c/version.py
+++ b/psycopg_c/psycopg_c/version.py
@@ -6,6 +6,6 @@ psycopg-c distribution version file.
 
 # Use a versioning scheme as defined in
 # https://www.python.org/dev/peps/pep-0440/
-__version__ = "3.1.3"
+__version__ = "3.1.4.dev0"
 
 # also change psycopg/psycopg/version.py accordingly.


### PR DESCRIPTION
We remove repeated code in `__(a)exit__()` method of `(Async)Pipeline` by passing the exception value to `_exit()` method of `BasePipeline`.