### PR TITLE
fix: Pass encoding to bytes() when argument is a string

### DIFF
--- a/psycopg/psycopg/pq/pq_ctypes.py
+++ b/psycopg/psycopg/pq/pq_ctypes.py
@@ -18,7 +18,7 @@ from ctypes import addressof, c_char_p, c_int, c_size_t, c_ulong, c_void_p, py_o
 from typing import Any, Callable, List, Optional, Sequence, Tuple
 from typing import cast as t_cast, TYPE_CHECKING
 
-from .. import errors as e
+from .. import errors as e, _encodings
 from . import _pq_ctypes as impl
 from .misc import PGnotify, ConninfoOption, PGresAttDesc
 from .misc import error_message, connection_summary
@@ -961,7 +961,9 @@ class Escaping:
 
         self.conn._ensure_pgconn()
         # TODO: might be done without copy (however C does that)
-        if not isinstance(data, bytes):
+        if isinstance(data, str):
+            data = bytes(data, encoding=_encodings.pgconn_encoding(self.conn))
+        elif not isinstance(data, bytes):
             data = bytes(data)
         out = impl.PQescapeLiteral(self.conn._pgconn_ptr, data, len(data))
         if not out:


### PR DESCRIPTION
This line:
https://github.com/psycopg/psycopg/blob/b8027b2481b49b87c4b1344d4b098e6f04531ea0/psycopg/psycopg/pq/pq_ctypes.py#L965
raises a `TypeError` when `data` is a `str` object, as the `bytes` builtin must be passed the `encoding` parameter if the first parameter is a string. Example:
```python
>>> import psycopg
>>> from psycopg.pq import Escaping
>>> db = psycopg.connect("dbname=eolica user=postgres host=localhost")
>>> Escaping(db.pgconn).escape_identifier('hello')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/pyenv/versions/3.10.6/lib/python3.10/site-packages/psycopg/pq/pq_ctypes.py", line 960, in escape_identifier
    data = bytes(data)
TypeError: string argument without an encoding
```
I think that this should fix the error, but I haven't been able to test it.