### PR TITLE
High level generators

### DIFF
--- a/psycopg/psycopg/_queries.py
+++ b/psycopg/psycopg/_queries.py
@@ -136,12 +136,10 @@ class PostgresClientQuery(PostgresQuery):
         """
         if vars is not None:
             params = _validate_and_reorder_params(self._parts, vars, self._order)
-            self.params = tuple(
+            params = tuple(
                 self._tx.as_literal(p) if p is not None else b"NULL" for p in params
             )
-            self.query = self.template % self.params
-        else:
-            self.params = None
+            self.query = self.template % params
 
 
 @lru_cache()

--- a/psycopg/psycopg/connection.py
+++ b/psycopg/psycopg/connection.py
@@ -448,10 +448,9 @@ class BaseConnection(Generic[Row]):
         elif isinstance(command, Composable):
             command = command.as_bytes(self)
 
-        results = yield from generators.execute_command(
+        result = yield from generators.execute_command(
             self.pgconn, command, result_format=result_format
         )
-        result = results[-1]
         if result.status != COMMAND_OK and result.status != TUPLES_OK:
             if result.status == FATAL_ERROR:
                 raise e.error_from_result(result, encoding=pgconn_encoding(self.pgconn))

--- a/psycopg/psycopg/cursor_async.py
+++ b/psycopg/psycopg/cursor_async.py
@@ -216,6 +216,7 @@ class AsyncCursor(BaseCursor["AsyncConnection[Any]", Row]):
             yield row
 
     async def scroll(self, value: int, mode: str = "relative") -> None:
+        await self._fetch_pipeline()
         self._scroll(value, mode)
 
     @asynccontextmanager

--- a/psycopg/psycopg/generators.py
+++ b/psycopg/psycopg/generators.py
@@ -92,7 +92,7 @@ def _connect(conninfo: str) -> PQGenConn[PGconn]:
 
 def execute_command(
     pgconn: PGconn, command: bytes, *, result_format: pq.Format = TEXT
-) -> PQGen[List[PGresult]]:
+) -> PQGen[PGresult]:
     """
     Execute a command as a string and fetch the results back from the server.
 
@@ -100,7 +100,9 @@ def execute_command(
     parameter.
     """
     pgconn.send_query_params(command, None, result_format=result_format)
-    return (yield from _flush_and_fetch(pgconn))
+    yield from flush(pgconn)
+    results = yield from fetch_many(pgconn)
+    return results[0]
 
 
 def execute_query(

--- a/psycopg/psycopg/generators.py
+++ b/psycopg/psycopg/generators.py
@@ -90,6 +90,19 @@ def _connect(conninfo: str) -> PQGenConn[PGconn]:
     return conn
 
 
+def execute_command(
+    pgconn: PGconn, command: bytes, *, result_format: pq.Format = TEXT
+) -> PQGen[List[PGresult]]:
+    """
+    Execute a command as a string and fetch the results back from the server.
+
+    Always send the command using the extended protocol, even if it has no
+    parameter.
+    """
+    pgconn.send_query_params(command, None, result_format=result_format)
+    return (yield from _execute(pgconn))
+
+
 def execute_query(
     pgconn: PGconn,
     query: PostgresQuery,

--- a/psycopg/psycopg/generators.py
+++ b/psycopg/psycopg/generators.py
@@ -399,7 +399,6 @@ def copy_end(pgconn: PGconn, error: Optional[bytes]) -> PQGen[PGresult]:
 # Override functions with fast versions if available
 if _psycopg:
     connect = _psycopg.connect
-    execute = _psycopg.execute
     send = _psycopg.send
     fetch_many = _psycopg.fetch_many
     fetch = _psycopg.fetch
@@ -407,7 +406,6 @@ if _psycopg:
 
 else:
     connect = _connect
-    execute = _execute
     send = _send
     fetch_many = _fetch_many
     fetch = _fetch

--- a/psycopg/psycopg/server_cursor.py
+++ b/psycopg/psycopg/server_cursor.py
@@ -114,7 +114,7 @@ class ServerCursorMixin(BaseCursor[ConnectionType, Row]):
             self._raise_for_result(results[-1])
 
         # Set the format, which will be used by describe and fetch operations
-        self._format = self.format if binary is None else (BINARY if binary else TEXT)
+        self._format = self._get_result_format(binary)
 
         # The above result only returned COMMAND_OK. Get the cursor shape
         yield from self._describe_gen()

--- a/psycopg_c/psycopg_c/_psycopg.pyi
+++ b/psycopg_c/psycopg_c/_psycopg.pyi
@@ -16,6 +16,7 @@ from psycopg.adapt import AdaptersMap, PyFormat
 from psycopg.pq.abc import PGconn, PGresult
 from psycopg.connection import BaseConnection
 from psycopg._compat import Deque
+from psycopg._queries import PostgresQuery
 
 class Transformer(abc.AdaptContext):
     types: Optional[Tuple[int, ...]]
@@ -54,8 +55,28 @@ class Transformer(abc.AdaptContext):
 
 # Generators
 def connect(conninfo: str) -> abc.PQGenConn[PGconn]: ...
-def execute(pgconn: PGconn) -> abc.PQGen[List[PGresult]]: ...
-def send(pgconn: PGconn) -> abc.PQGen[None]: ...
+def execute_command(
+    pgconn: PGconn, command: bytes, *, result_format: pq.Format = pq.Format.TEXT
+) -> abc.PQGen[PGresult]: ...
+def execute_query(
+    pgconn: PGconn,
+    query: PostgresQuery,
+    *,
+    result_format: pq.Format = pq.Format.TEXT,
+    force_extended: bool = False,
+) -> abc.PQGen[List[PGresult]]: ...
+def prepare_query(
+    pgconn: PGconn, name: bytes, query: PostgresQuery
+) -> abc.PQGen[None]: ...
+def execute_prepared_query(
+    pgconn: PGconn,
+    name: bytes,
+    query: PostgresQuery,
+    *,
+    result_format: pq.Format = pq.Format.TEXT,
+) -> abc.PQGen[List[PGresult]]: ...
+def flush_and_fetch(pgconn: PGconn) -> abc.PQGen[List[PGresult]]: ...
+def flush(pgconn: PGconn) -> abc.PQGen[None]: ...
 def fetch_many(pgconn: PGconn) -> abc.PQGen[List[PGresult]]: ...
 def fetch(pgconn: PGconn) -> abc.PQGen[Optional[PGresult]]: ...
 def pipeline_communicate(

--- a/psycopg_c/psycopg_c/_psycopg/waiting.pyx
+++ b/psycopg_c/psycopg_c/_psycopg/waiting.pyx
@@ -72,11 +72,8 @@ wait_c_impl(int fileno, int wait, float timeout)
     select_rv = poll(&input_fd, 1, timeout_ms);
     Py_END_ALLOW_THREADS
 
+    if (select_rv < 0) { goto error; }
     if (PyErr_CheckSignals()) { goto finally; }
-
-    if (select_rv < 0) {
-        goto error;
-    }
 
     if (input_fd.events & POLLIN) { rv |= SELECT_EV_READ; }
     if (input_fd.events & POLLOUT) { rv |= SELECT_EV_WRITE; }
@@ -120,11 +117,8 @@ wait_c_impl(int fileno, int wait, float timeout)
     select_rv = select(fileno + 1, &ifds, &ofds, &efds, tvptr);
     Py_END_ALLOW_THREADS
 
+    if (select_rv < 0) { goto error; }
     if (PyErr_CheckSignals()) { goto finally; }
-
-    if (select_rv < 0) {
-        goto error;
-    }
 
     if (FD_ISSET(fileno, &ifds)) { rv |= SELECT_EV_READ; }
     if (FD_ISSET(fileno, &ofds)) { rv |= SELECT_EV_WRITE; }

--- a/psycopg_c/psycopg_c/pq.pxd
+++ b/psycopg_c/psycopg_c/pq.pxd
@@ -27,6 +27,28 @@ cdef class PGconn:
     @staticmethod
     cdef PGconn _from_ptr(libpq.PGconn *ptr)
 
+    cpdef object send_query(self, const char *command)
+    cpdef object send_query_params(
+        self,
+        const char *command,
+        param_values: Optional[Sequence[Optional[bytes]]],
+        param_types: Optional[Sequence[int]] = *,
+        param_formats: Optional[Sequence[int]] = *,
+        int result_format = *,
+    )
+    cpdef object send_prepare(
+        self,
+        const char *name,
+        const char *command,
+        param_types: Optional[Sequence[int]] = *,
+    )
+    cpdef object send_query_prepared(
+        self,
+        const char *name,
+        param_values: Optional[Sequence[Optional[bytes]]],
+        param_formats: Optional[Sequence[int]] = *,
+        int result_format = *,
+    )
     cpdef int flush(self) except -1
     cpdef object notifies(self)
 

--- a/psycopg_c/psycopg_c/pq/pgconn.pyx
+++ b/psycopg_c/psycopg_c/pq/pgconn.pyx
@@ -435,10 +435,7 @@ cdef class PGconn:
             raise e.OperationalError(f"consuming input failed: {error_message(self)}")
 
     def is_busy(self) -> int:
-        cdef int rv
-        with nogil:
-            rv = libpq.PQisBusy(self._pgconn_ptr)
-        return rv
+        return libpq.PQisBusy(self._pgconn_ptr)
 
     @property
     def nonblocking(self) -> int:
@@ -469,8 +466,7 @@ cdef class PGconn:
 
     cpdef object notifies(self):
         cdef libpq.PGnotify *ptr
-        with nogil:
-            ptr = libpq.PQnotifies(self._pgconn_ptr)
+        ptr = libpq.PQnotifies(self._pgconn_ptr)
         if ptr:
             ret = PGnotify(ptr.relname, ptr.be_pid, ptr.extra)
             libpq.PQfreemem(ptr)

--- a/psycopg_c/psycopg_c/pq/pgconn.pyx
+++ b/psycopg_c/psycopg_c/pq/pgconn.pyx
@@ -214,7 +214,7 @@ cdef class PGconn:
 
         return PGresult._from_ptr(pgresult)
 
-    def send_query(self, const char *command) -> None:
+    cpdef object send_query(self, const char *command):
         _ensure_pgconn(self)
         cdef int rv
         with nogil:
@@ -250,14 +250,14 @@ cdef class PGconn:
             raise e.OperationalError(f"executing query failed: {error_message(self)}")
         return PGresult._from_ptr(pgresult)
 
-    def send_query_params(
+    cpdef object send_query_params(
         self,
         const char *command,
         param_values: Optional[Sequence[Optional[bytes]]],
         param_types: Optional[Sequence[int]] = None,
         param_formats: Optional[Sequence[int]] = None,
         int result_format = PqFormat.TEXT,
-    ) -> None:
+    ):
         _ensure_pgconn(self)
 
         cdef libpq.Oid *ctypes = NULL
@@ -279,12 +279,12 @@ cdef class PGconn:
                 f"sending query and params failed: {error_message(self)}"
             )
 
-    def send_prepare(
+    cpdef object send_prepare(
         self,
         const char *name,
         const char *command,
         param_types: Optional[Sequence[int]] = None,
-    ) -> None:
+    ):
         _ensure_pgconn(self)
 
         cdef int i
@@ -306,13 +306,13 @@ cdef class PGconn:
                 f"sending query and params failed: {error_message(self)}"
             )
 
-    def send_query_prepared(
+    cpdef object send_query_prepared(
         self,
         const char *name,
         param_values: Optional[Sequence[Optional[bytes]]],
         param_formats: Optional[Sequence[int]] = None,
         int result_format = PqFormat.TEXT,
-    ) -> None:
+    ):
         _ensure_pgconn(self)
 
         cdef libpq.Oid *ctypes = NULL

--- a/tests/pq/test_async.py
+++ b/tests/pq/test_async.py
@@ -3,12 +3,12 @@ from select import select
 import pytest
 
 import psycopg
-from psycopg import pq
-from psycopg.generators import execute
+from psycopg import pq, generators
 
 
 def execute_wait(pgconn):
-    return psycopg.waiting.wait(execute(pgconn), pgconn.socket)
+    psycopg.waiting.wait(generators.send(pgconn), pgconn.socket)
+    return psycopg.waiting.wait(generators.fetch_many(pgconn), pgconn.socket)
 
 
 def test_send_query(pgconn):

--- a/tests/pq/test_async.py
+++ b/tests/pq/test_async.py
@@ -7,8 +7,7 @@ from psycopg import pq, generators
 
 
 def execute_wait(pgconn):
-    psycopg.waiting.wait(generators.send(pgconn), pgconn.socket)
-    return psycopg.waiting.wait(generators.fetch_many(pgconn), pgconn.socket)
+    return psycopg.waiting.wait(generators.flush_and_fetch(pgconn), pgconn.socket)
 
 
 def test_send_query(pgconn):

--- a/tests/pq/test_pgconn.py
+++ b/tests/pq/test_pgconn.py
@@ -8,8 +8,7 @@ from select import select
 import pytest
 
 import psycopg
-from psycopg import pq
-import psycopg.generators
+from psycopg import pq, generators
 
 from ..utils import gc_collect
 
@@ -263,7 +262,7 @@ def test_transaction_status(pgconn):
     assert pgconn.transaction_status == pq.TransactionStatus.INTRANS
     pgconn.send_query(b"select 1")
     assert pgconn.transaction_status == pq.TransactionStatus.ACTIVE
-    psycopg.waiting.wait(psycopg.generators.execute(pgconn), pgconn.socket)
+    psycopg.waiting.wait(generators.flush_and_fetch(pgconn), pgconn.socket)
     assert pgconn.transaction_status == pq.TransactionStatus.INTRANS
     pgconn.finish()
     assert pgconn.transaction_status == pq.TransactionStatus.UNKNOWN

--- a/tests/test_client_cursor.py
+++ b/tests/test_client_cursor.py
@@ -564,17 +564,17 @@ def test_query_params_execute(conn):
     cur.execute("select %t, %s::text", [1, None])
     assert cur._query is not None
     assert cur._query.query == b"select 1, NULL::text"
-    assert cur._query.params == (b"1", b"NULL")
+    assert cur._query.params is None
 
     cur.execute("select 1")
     assert cur._query.query == b"select 1"
-    assert not cur._query.params
+    assert cur._query.params is None
 
     with pytest.raises(psycopg.DataError):
         cur.execute("select %t::int", ["wat"])
 
     assert cur._query.query == b"select 'wat'::int"
-    assert cur._query.params == (b"'wat'",)
+    assert cur._query.params is None
 
 
 @pytest.mark.parametrize(
@@ -597,7 +597,7 @@ def test_query_params_executemany(conn):
 
     cur.executemany("select %t, %t", [[1, 2], [3, 4]])
     assert cur._query.query == b"select 3, 4"
-    assert cur._query.params == (b"3", b"4")
+    assert cur._query.params is None
 
 
 @pytest.mark.crdb_skip("copy")

--- a/tests/test_client_cursor_async.py
+++ b/tests/test_client_cursor_async.py
@@ -559,17 +559,17 @@ async def test_query_params_execute(aconn):
     await cur.execute("select %t, %s::text", [1, None])
     assert cur._query is not None
     assert cur._query.query == b"select 1, NULL::text"
-    assert cur._query.params == (b"1", b"NULL")
+    assert cur._query.params is None
 
     await cur.execute("select 1")
     assert cur._query.query == b"select 1"
-    assert not cur._query.params
+    assert cur._query.params is None
 
     with pytest.raises(psycopg.DataError):
         await cur.execute("select %t::int", ["wat"])
 
     assert cur._query.query == b"select 'wat'::int"
-    assert cur._query.params == (b"'wat'",)
+    assert cur._query.params is None
 
 
 @pytest.mark.parametrize(
@@ -592,7 +592,7 @@ async def test_query_params_executemany(aconn):
 
     await cur.executemany("select %t, %t", [[1, 2], [3, 4]])
     assert cur._query.query == b"select 3, 4"
-    assert cur._query.params == (b"3", b"4")
+    assert cur._query.params is None
 
 
 @pytest.mark.crdb_skip("copy")

--- a/tests/test_waiting.py
+++ b/tests/test_waiting.py
@@ -63,7 +63,7 @@ def test_wait(pgconn, waitfn, timeout):
     waitfn = getattr(waiting, waitfn)
 
     pgconn.send_query(b"select 1")
-    gen = generators.execute(pgconn)
+    gen = generators.flush_and_fetch(pgconn)
     (res,) = waitfn(gen, pgconn.socket, **timeout)
     assert res.status == ExecStatus.TUPLES_OK
 
@@ -73,7 +73,7 @@ def test_wait_bad(pgconn, waitfn):
     waitfn = getattr(waiting, waitfn)
 
     pgconn.send_query(b"select 1")
-    gen = generators.execute(pgconn)
+    gen = generators.flush_and_fetch(pgconn)
     pgconn.finish()
     with pytest.raises(psycopg.OperationalError):
         waitfn(gen, pgconn.socket)
@@ -99,7 +99,7 @@ def test_wait_large_fd(dsn, waitfn):
         try:
             assert pgconn.socket > 1024
             pgconn.send_query(b"select 1")
-            gen = generators.execute(pgconn)
+            gen = generators.flush_and_fetch(pgconn)
             if waitfn is waiting.wait_select:
                 with pytest.raises(ValueError):
                     waitfn(gen, pgconn.socket)
@@ -144,7 +144,7 @@ async def test_wait_ready_async(wait, ready):
 @pytest.mark.asyncio
 async def test_wait_async(pgconn):
     pgconn.send_query(b"select 1")
-    gen = generators.execute(pgconn)
+    gen = generators.flush_and_fetch(pgconn)
     (res,) = await waiting.wait_async(gen, pgconn.socket)
     assert res.status == ExecStatus.TUPLES_OK
 
@@ -152,7 +152,7 @@ async def test_wait_async(pgconn):
 @pytest.mark.asyncio
 async def test_wait_async_bad(pgconn):
     pgconn.send_query(b"select 1")
-    gen = generators.execute(pgconn)
+    gen = generators.flush_and_fetch(pgconn)
     socket = pgconn.socket
     pgconn.finish()
     with pytest.raises(psycopg.OperationalError):


### PR DESCRIPTION
This MR is a refactoring of the generators module, with the idea of having generators doing more high-level work. For instance a public generator would take care of a whole execute-fetch cycle (similar to e.g. what `PQexecParams()` does) whereas, until 3.1, generators take care separately of flushing and receiving data.

The idea is that, using this organization, we can, at a later stage, release the GIL for the whole duration of the send/fetch cycle and avoid the GIL thrashing that might be causing #448. This will also need to actually drop the use of generators and use a blocking function to wait, so we will have to build #415 on top of this in order to really address #448.