### PR TITLE
Use to_regtype instead of ::regtype in type info queries

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -7,6 +7,15 @@
 ``psycopg`` release notes
 =========================
 
+Future releases
+---------------
+
+Psycopg 3.1.8 (unreleased)
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Don't pollute server logs when types looked for by `TypeInfo.fetch()` 
+  are not found (:ticket:`#473`).
+
 Current release
 ---------------
 

--- a/tests/fix_crdb.py
+++ b/tests/fix_crdb.py
@@ -122,6 +122,7 @@ _crdb_reasons = {
     "server-side cursor": 41412,
     "severity_nonlocalized": 81794,
     "stored procedure": 1751,
+    "to_regtype": None,
 }
 
 _crdb_reason_version = {
@@ -130,4 +131,5 @@ _crdb_reason_version = {
     "cancel": "skip < 22",
     "server-side cursor": "skip < 22.1.3",
     "severity_nonlocalized": "skip < 22.1.3",
+    "to_regtype": "skip < 22.2",
 }


### PR DESCRIPTION
Fixes #473

I haven't modified the test, but it seems that the case of not existing type was already tested. Let me know if you thing additional tests are needed