### PR TITLE
feat: allow to disable pipeline mode from the environment

### DIFF
--- a/psycopg/psycopg/_pipeline.py
+++ b/psycopg/psycopg/_pipeline.py
@@ -5,6 +5,7 @@ commands pipeline management
 # Copyright (C) 2021 The Psycopg Team
 
 import logging
+import os
 from types import TracebackType
 from typing import Any, List, Optional, Union, Tuple, Type, TypeVar, TYPE_CHECKING
 from typing_extensions import TypeAlias
@@ -35,6 +36,7 @@ BAD = pq.ConnStatus.BAD
 ACTIVE = pq.TransactionStatus.ACTIVE
 
 logger = logging.getLogger("psycopg")
+disabled = "PSYCOPG_NO_PIPELINE" in os.environ
 
 
 class BasePipeline:
@@ -62,6 +64,8 @@ class BasePipeline:
     @classmethod
     def is_supported(cls) -> bool:
         """Return `!True` if the psycopg libpq wrapper supports pipeline mode."""
+        if disabled:
+            return False
         if BasePipeline._is_supported is None:
             BasePipeline._is_supported = not cls._not_supported_reason()
         return BasePipeline._is_supported

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -62,6 +62,10 @@ Test options
 - ``pytest`` option ``--pq-debug`` can be used to log access to libpq's
   ``PGconn`` functions.
 
+- Some features, such as ``executemany()``, uses the pipeline mode
+  automatically when a recent libpq (>= 14) is used. To disable this, set
+  ``PSYCOPG_NO_PIPELINE`` environment variable.
+
 
 Testing in docker
 -----------------


### PR DESCRIPTION
This can be useful in development when testing code paths with automatic pipeline mode, such as executemany(), while still using a recent libpq.