### PR TITLE
Fixed TypeInfo for ClientCursor.

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -17,6 +17,7 @@ Psycopg 3.1.8 (unreleased)
   are not found (:ticket:`#473`).
 - Set `Cursor.rowcount` to the number of rows of each result set from
   `~Cursor.executemany()` when called with `!returning=True` (:ticket:`#479`).
+- Fix `TypeInfo.fetch()` when used with `ClientCursor` (:ticket:`#484`).
 
 Current release
 ---------------

--- a/psycopg/psycopg/_typeinfo.py
+++ b/psycopg/psycopg/_typeinfo.py
@@ -93,7 +93,7 @@ class TypeInfo:
         # or intrans)
         try:
             with conn.transaction():
-                with conn.cursor(binary=True, row_factory=dict_row) as cur:
+                with conn.cursor(row_factory=dict_row) as cur:
                     cur.execute(cls._get_info_query(conn), {"name": name})
                     recs = cur.fetchall()
         except e.UndefinedObject:
@@ -107,7 +107,7 @@ class TypeInfo:
     ) -> Optional[T]:
         try:
             async with conn.transaction():
-                async with conn.cursor(binary=True, row_factory=dict_row) as cur:
+                async with conn.cursor(row_factory=dict_row) as cur:
                     await cur.execute(cls._get_info_query(conn), {"name": name})
                     recs = await cur.fetchall()
         except e.UndefinedObject:

--- a/tests/test_client_cursor.py
+++ b/tests/test_client_cursor.py
@@ -9,6 +9,7 @@ import psycopg
 from psycopg import sql, rows
 from psycopg.adapt import PyFormat
 from psycopg.postgres import types as builtins
+from psycopg.types import TypeInfo
 
 from .utils import gc_collect, gc_count
 from .test_cursor import my_row_factory
@@ -855,3 +856,8 @@ def test_message_0x33(conn):
         assert cur.fetchone() == ("test",)
 
     assert not notices
+
+
+def test_typeinfo(conn):
+    info = TypeInfo.fetch(conn, "jsonb")
+    assert info is not None

--- a/tests/test_client_cursor_async.py
+++ b/tests/test_client_cursor_async.py
@@ -6,6 +6,7 @@ from typing import List
 import psycopg
 from psycopg import sql, rows
 from psycopg.adapt import PyFormat
+from psycopg.types import TypeInfo
 
 from .utils import alist, gc_collect, gc_count
 from .test_cursor import my_row_factory
@@ -727,3 +728,8 @@ async def test_message_0x33(aconn):
         assert (await cur.fetchone()) == ("test",)
 
     assert not notices
+
+
+async def test_typeinfo(aconn):
+    info = await TypeInfo.fetch(aconn, "jsonb")
+    assert info is not None


### PR DESCRIPTION
TypeInfo had a hardcoded binary=True which doesn't work to well for ClientCursor.

Without this change we'd get:
```
Traceback (most recent call last):
  File "/home/florian/sources/django.git/test.py", line 5, in <module>
    print(TypeInfo.fetch(conn, "geometry"))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/florian/.local/share/virtualenvs/django/lib/python3.11/site-packages/psycopg/_typeinfo.py", line 93, in fetch
    cur.execute(cls._get_info_query(conn), {"name": name})
  File "/home/florian/.local/share/virtualenvs/django/lib/python3.11/site-packages/psycopg/cursor.py", line 728, in execute
    raise ex.with_traceback(None)
psycopg.NotSupportedError: client-side cursors don't support binary results
```