### PR TITLE
Document psycopg concepts and features in prose

### DIFF
--- a/docs/basic/transactions.rst
+++ b/docs/basic/transactions.rst
@@ -224,6 +224,8 @@ manage a proper transaction. In essence, a transaction context tries to leave
 a connection in the state it found it, and leaves you to deal with the wider
 context.
 
+.. _common-transaction-idiom:
+
 .. hint::
     The interaction between non-autocommit transactions and transaction
     contexts is probably surprising. Although the non-autocommit default is

--- a/docs/basic/usage.rst
+++ b/docs/basic/usage.rst
@@ -119,14 +119,14 @@ cursor attributes are available to obtain information on the status of
 the SQL statement just executed; such as `~Cursor.rowcount`, which
 contains the number of database rows the statement affected.
 
-.. index::
-    single: Adaptation
-            Data types; Adaptation
-
 Should an :ref:`error <dbapi-exceptions>` occur, at any time, `an
 exception`__ is raised.
 
 .. __: https://docs.python.org/3/tutorial/errors.html#exceptions
+
+.. index::
+    single: Adaptation
+            Data types; Adaptation
 
 :ref:`Adapters <types-adaptation>` are responsible for converting
 between PostgreSQL data types and Python data types, and between the

--- a/docs/basic/usage.rst
+++ b/docs/basic/usage.rst
@@ -5,12 +5,186 @@
 Basic module usage
 ==================
 
-The basic Psycopg usage is common to all the database adapters implementing
-the `DB-API`__ protocol. Other database adapters, such as the builtin
-`sqlite3` or `psycopg2`, have roughly the same pattern of interaction.
+The basic Psycopg usage is common to all the database adapters
+implementing the `DB-API`_ protocol.
+Other database adapters, such as the builtin `sqlite3` or `psycopg2`,
+have roughly the same pattern of interaction.
 
-.. __: https://www.python.org/dev/peps/pep-0249/
+.. _DB-API: https://www.python.org/dev/peps/pep-0249/
 
+.. index:: concepts
+
+.. _concepts:
+
+Concepts and Vocabulary
+-----------------------
+
+.. index::
+    single: connection string
+            connection object
+            cursor
+
+The parameters needed to interact with `Postgres`__ are
+:ref:`assembled <psycopg.conninfo>` into a `connection string`__\.
+This value is given to a connection method, typically the `~psycopg`
+module's `~psycopg.connect()` method, the `database server`__ is
+contacted, and a database `Connection` object is returned.
+Each connection object represents a communication channel to a
+Postgres database.
+Alternately, connections may be obtained from a :ref:`pool
+<connection-pools>` of pre-established connections, to mitigate
+connection startup delay.
+A connection's `~Connection.cursor()` method is used to obtain (one,
+often, or more) `~Cursor` objects, which are then used to interact
+with the connected database.
+
+.. __: https://www.postgresql.org
+.. __: https://www.postgresql.org/docs/current/
+       libpq-connect.html#LIBPQ-CONNSTRING
+.. __: https://www.postgresql.org/docs/current/tutorial-arch.html
+
+.. index::
+    single: SQL
+            query parameters
+    pair: SQL; substituting data values
+          SQL; construction
+          SQL; escaping
+          SQL; quoting
+          SQL; dynamic
+
+The `~psycopg.sql` module may be used to construct `~psycopg.sql.SQL`
+objects, which represent `SQL`__ statements into which data values can
+be substituted at run time.
+When properly constructed these are impervious to `SQL injection`__
+attacks.
+:ref:`Other techniques <query-parameters>`, which involve :ref:`less
+code <usage>`, are also available to safely put dynamic data into SQL.
+Relying on Psycopg, using `~psycopg.sql` in particular, for safe SQL
+construction means that the application need not concern itself with
+either quoting and escaping data values and `identifiers`__, or
+handling similar subtle aspects of SQL syntax and parsing.
+
+.. __: https://en.wikibooks.org/wiki/SQL
+.. __: https://en.wikipedia.org/wiki/Sql_injection
+.. __: https://www.postgresql.org/docs/current/
+       sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
+
+.. index::
+    single: efficiency
+    single: performance
+    pair: SQL; execution
+
+The `~Cursor.execute()` cursor method takes SQL and sends it to the
+Postgres server for execution.
+It may optionally be given data values to be (safely) incorporated
+into the text of the SQL upon execution.
+For network efficiency, or for other reasons, the SQL supplied to
+`~Cursor.execute()` may consist of more than one SQL statement.
+In a similar vein, `~Cursor.executemany()` may be used to efficiently
+re-execute the same SQL, incorporating different data values into the
+SQL on each execution.
+
+Psycopg supports other features which improve performance.
+Among these are:
+:ref:`Prepared statements <prepared-statements>`, which reduce server parsing
+and planning load;
+:ref:`Pipeline mode <pipeline-mode>`, which mitigates problems with network
+latency;
+and :ref:`COPY <copy>` methods, for efficient bulk data transfer in
+and out of the database.
+
+.. index::
+    single: result set
+    pair: cursor; returning rows
+          SQL; returning rows
+
+SQL statements which produce results do so in `result sets`__\.
+Psycopg provides `~Cursor` methods to retrieve one or more rows from
+result sets but the usual approach is to retrieve rows by iterating on
+the cursor.
+This can be seen in the :ref:`usage <usage>` example below.
+After retrieving all of a result set's rows, calling the
+`~Cursor.nextset()` cursor method switches to the next result set.
+
+.. __: https://www.postgresql.org/docs/current/
+       glossary.html#GLOSSARY-RESULT-SET
+
+.. index::
+    pair:: SQL; result status
+           execution; result status
+
+Once all rows in a result set are retrieved from the Postgres server
+(which some kinds of cursors do automatically upon SQL execution)
+cursor attributes are available to obtain information on the status of
+the SQL statement just executed; such as `~Cursor.rowcount`, which
+contains the number of database rows the statement affected.
+
+.. index::
+    single: Adaptation
+            Data types; Adaptation
+
+Should an :ref:`error <dbapi-exceptions>` occur, at any time, `an
+exception`__ is raised.
+
+.. __: https://docs.python.org/3/tutorial/errors.html#exceptions
+
+:ref:`Adapters <types-adaptation>` are responsible for converting
+between PostgreSQL data types and Python data types, and between the
+data types used in the various communication protocols and related
+data structures.
+Adapters may be customized.
+
+.. index::
+    single: Transactions management
+    single: database changes are discarded
+    single: failure to change database content
+    single: updates fail
+    single: writes fail
+
+`Transactions`__ are, by default, :ref:`managed by Psycopg
+<transactions>`\.
+They are a property of database connections; a connection is either in
+a transaction or is not.
+The Python `DB-API`_ demands particular default behaviors.
+By default, any change made to database content begins a transaction.
+Absent transaction management on the part of your code, further
+content changes become part of the same transaction.
+Again, by default, closing the connection (or exiting your Python
+program without closing) does not commit an ongoing transaction;
+database content changes are lost unless the `~Connection.commit()`
+method is explicitly called.
+As shown in the :ref:`example below <usage>`, automatic commit upon
+connection close can be obtained by using a connection object as a
+context manager.
+
+.. __: https://www.postgresql.org/docs/current/tutorial-transactions.html
+
+.. index::
+    single: autocommit
+
+To obtain a more intuitive transaction handling, some experienced
+developers prefer using :ref:`a particular <common-transaction-idiom>`
+software design pattern employing the Psycopg :ref:`autocommit
+<autocommit>` feature.
+A variety of transaction design patterns are possible.
+
+.. index::
+   pair: context manager; cursor
+         context manager; connection
+         cursor; closing
+         connection; closing
+
+When the server has finished executing all the SQL statements sent to
+it and there are no more result sets available to a cursor, the cursor
+may be re-used.
+When a cursor, or a connection, is no longer needed it should be
+closed.
+This is usually accomplished, :ref:`as shown <usage>` below, by using
+the cursor or connection object as the context manager in a Python
+`!with` statement.
+
+There are various kinds of connection objects, cursor objects, SQL
+representations, and so forth, to be used as needed.
 
 .. index::
     pair: Example; Usage
@@ -53,11 +227,19 @@ Here is an interactive session showing some of the basic commands:
             # will return (1, 100, "abc'def")
 
             # You can use `cur.fetchmany()`, `cur.fetchall()` to return a list
-            # of several records, or even iterate on the cursor
+            # of several records, or even iterate on the cursor.
             for record in cur:
                 print(record)
+            # As is usual when an iterable is used in an iteration context,
+            # Python creates a new iterator from the iterable.  In this
+            # case, from `cur`, the cursor object.  So the row inserted
+            # above is printed.
 
-            # Make the changes to the database persistent
+            # Make the changes to the database persistent.
+            # Assuming this listing shows the entirety of this program,
+            # this statement is unnecessary.  The transaction is
+            # automatically commmited when the connection's `with`
+            # statement completes.  That said, it does not hurt to commit.
             conn.commit()
 
 


### PR DESCRIPTION
Hello,

Add a section to the documentation that introduces psycopg features and vocabulary in narrative prose.  Nothing wrong with what's there, which introduces by way of dissecting an example.  But sometimes narration gives a better overview.  Different people have different learning styles (and "the php way" of documenting by example drives me nuts!)

This patch puts each sentence on a new line, in order to make future patches easier to scan.

Some of the index entries may seem to show up too early in the prose, but I believe that they catch the earliest mention of the indexed terms.

I'm not really familiar with the content of the index, so some of the index entry pairs might be able to be improved.

I have also introduced some new comments into the example code presented in the "Basic Module Usage".  There is little that is not explained in the subsequent text, where the code is dissected.  But I think it's important, because people don't read.  Especially people who look at examples for understanding.  I suppose this part could be a separate patch.  But some of the narrative I've added explicitly says "go look at the example below", and without some of the new code comments the example appears to contradict the new narrative.

Started looking at documenting how literal strings interact with execute() and wound up writing this instead. (!)

P.S.  I don't like the "Transactions management" index entry, or section title.  I believe both should be "Transaction management".  But that's for somebody else to fix.