### PR TITLE
test: use Windows asyncio policy in "non-asyncio" pool tests

### DIFF
--- a/tests/pool/test_pool_async_noasyncio.py
+++ b/tests/pool/test_pool_async_noasyncio.py
@@ -61,12 +61,18 @@ def test_cant_create_open_outside_loop(dsn):
 
 
 @pytest.fixture
-def asyncio_run(recwarn):
+def asyncio_run(anyio_backend_options, recwarn):
     """Fixture reuturning asyncio.run, but managing resources at exit.
 
     In certain runs, fd objects are leaked and the error will only be caught
     downstream, by some innocent test calling gc_collect().
     """
+    try:
+        policy = anyio_backend_options["policy"]
+    except KeyError:
+        pass
+    else:
+        asyncio.set_event_loop_policy(policy)
     recwarn.clear()
     try:
         yield asyncio.run


### PR DESCRIPTION
In commit b6cc8343159fc0a27365e09a3beef06433f3f1b5, we drop the global asyncio.set_event_loop_policy() for Windows in conftest.py, replacing it with asyncio_options to be used by the anyio test runner. However, test cases in test_pool_async_noasyncio.py are not "async def" so they would not use that anyio runner (nor did they use pytest-asyncio's runner before); but they need the event loop policy for Windows still. Accordingly, we configure the loop from "anyio_backend_options" in asyncio_run() fixture.

Hopefully fixing problems described in https://github.com/psycopg/psycopg/pull/352#issuecomment-1417965803. 