### PR TITLE
chore: upgrade to mypy 1.0.0

### DIFF
--- a/psycopg/psycopg/pq/__init__.py
+++ b/psycopg/psycopg/pq/__init__.py
@@ -86,7 +86,7 @@ def import_from_libpq() -> None:
     # Pure Python implementation, slow and requires the system libpq installed.
     if not module and (not impl or impl == "python"):
         try:
-            from . import pq_ctypes as module  # type: ignore[no-redef]
+            from . import pq_ctypes as module  # type: ignore[assignment]
         except Exception as e:
             handle_error("python", e)
 

--- a/psycopg/psycopg/types/numeric.py
+++ b/psycopg/psycopg/types/numeric.py
@@ -371,9 +371,9 @@ class NumericBinaryDumper(Dumper):
 
 def dump_decimal_to_numeric_binary(obj: Decimal) -> Union[bytearray, bytes]:
     sign, digits, exp = obj.as_tuple()
-    if exp == "n" or exp == "N":  # type: ignore[comparison-overlap]
+    if exp == "n" or exp == "N":
         return NUMERIC_NAN_BIN
-    elif exp == "F":  # type: ignore[comparison-overlap]
+    elif exp == "F":
         return NUMERIC_NINF_BIN if sign else NUMERIC_PINF_BIN
 
     # Weights of py digits into a pg digit according to their positions.

--- a/psycopg/setup.cfg
+++ b/psycopg/setup.cfg
@@ -66,7 +66,7 @@ pool =
     psycopg-pool
 test =
     anyio >= 3.6.2
-    mypy >= 0.990
+    mypy >= 1.0.0
     pproxy >= 2.7
     pytest >= 6.2.5
     pytest-cov >= 3.0
@@ -75,7 +75,7 @@ dev =
     black >= 23.1.0
     dnspython >= 2.1
     flake8 >= 4.0
-    mypy >= 0.990
+    mypy >= 1.0.0
     types-setuptools >= 57.4
     wheel >= 0.37
 docs =

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -10,7 +10,7 @@ importlib-metadata == 1.4
 
 # From the 'test' extra
 anyio == 3.6.2
-mypy == 0.990
+mypy == 1.0.0
 pproxy == 2.7.0
 pytest == 6.2.5
 pytest-cov == 3.0.0

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -320,7 +320,7 @@ def test_subclass_adapter(conn, format):
     if format == Format.TEXT:
         from psycopg.types.string import StrDumper as BaseDumper
     else:
-        from psycopg.types.string import (  # type: ignore[no-redef]
+        from psycopg.types.string import (  # type: ignore[assignment]
             StrBinaryDumper as BaseDumper,
         )
 

--- a/tests/test_copy_async.py
+++ b/tests/test_copy_async.py
@@ -312,7 +312,7 @@ async def test_subclass_adapter(aconn, format):
     if format == Format.TEXT:
         from psycopg.types.string import StrDumper as BaseDumper
     else:
-        from psycopg.types.string import (  # type: ignore[no-redef]
+        from psycopg.types.string import (  # type: ignore[assignment]
             StrBinaryDumper as BaseDumper,
         )
 

--- a/tests/test_server_cursor.py
+++ b/tests/test_server_cursor.py
@@ -17,7 +17,7 @@ def test_init_row_factory(conn):
 
     with psycopg.ServerCursor(conn, "bar") as cur:
         assert cur.name == "bar"
-        assert cur.row_factory is rows.dict_row  # type: ignore
+        assert cur.row_factory is rows.dict_row
 
     with psycopg.ServerCursor(conn, "baz", row_factory=rows.namedtuple_row) as cur:
         assert cur.name == "baz"

--- a/tests/test_server_cursor_async.py
+++ b/tests/test_server_cursor_async.py
@@ -19,7 +19,7 @@ async def test_init_row_factory(aconn):
 
     async with psycopg.AsyncServerCursor(aconn, "bar") as cur:
         assert cur.name == "bar"
-        assert cur.row_factory is rows.dict_row  # type: ignore
+        assert cur.row_factory is rows.dict_row
 
     async with psycopg.AsyncServerCursor(
         aconn, "baz", row_factory=rows.namedtuple_row


### PR DESCRIPTION
Some "type: ignore" no longer needed, some need a different kind.