### PR TITLE
tests: skip test_sql::test_invalid_name if not a super-user

### DIFF
--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -366,6 +366,8 @@ class TestLiteral:
     @pytest.mark.crdb_skip("composite")  # create type, actually
     @pytest.mark.parametrize("name", ["a-b", f"{eur}", "order", "foo bar"])
     def test_invalid_name(self, conn, name):
+        if conn.info.parameter_status("is_superuser") != "on":
+            pytest.skip("not a superuser")
         conn.execute(
             f"""
             set client_encoding to utf8;


### PR DESCRIPTION
Creating a base type, as done in that test, requires being a superuser.

It's annoying to me while running the test suite as the user I'm using on some machines is not a super-user.