### PR TITLE
row factories and connection pools 

### DIFF
--- a/docs/api/pool.rst
+++ b/docs/api/pool.rst
@@ -72,6 +72,11 @@ The `!ConnectionPool` class
 
    :type kwargs: `!dict`
 
+   :param row_factory: The :ref:`row factory <row-factories>` used when
+                       configuring connections in the pool.
+                       `kwargs["row_factory"]` and this parameter are mutually
+                       exclusive, the latter should be preferred.
+
    :param connection_class: The class of the connections to serve. It should
                             be a `!Connection` subclass.
    :type connection_class: `!type`, default: `~psycopg.Connection`

--- a/docs/news_pool.rst
+++ b/docs/news_pool.rst
@@ -15,6 +15,8 @@ psycopg_pool 3.2.0 (unreleased)
 
 - Add support for async `!reconnect_failed` callbacks in `AsyncConnectionPool`
   (:ticket:`#520`).
+- Fix the return type annotation of `!NullConnectionPool.__enter__()`
+  (:ticket:`#540`).
 
 
 Current release

--- a/docs/news_pool.rst
+++ b/docs/news_pool.rst
@@ -17,6 +17,8 @@ psycopg_pool 3.2.0 (unreleased)
   (:ticket:`#520`).
 - Fix the return type annotation of `!NullConnectionPool.__enter__()`
   (:ticket:`#540`).
+- Make connection pool classes generic on row type and add a `!row_factory` to
+  configure connections' :ref:`row factory <row-factories>` (:ticket:`#540`).
 
 
 Current release

--- a/psycopg/psycopg/_compat.py
+++ b/psycopg/psycopg/_compat.py
@@ -55,9 +55,9 @@ else:
     from typing_extensions import TypeGuard
 
 if sys.version_info >= (3, 11):
-    from typing import LiteralString
+    from typing import LiteralString, assert_type
 else:
-    from typing_extensions import LiteralString
+    from typing_extensions import LiteralString, assert_type
 
 if sys.version_info < (3, 8):
     import importlib_metadata as metadata
@@ -71,6 +71,7 @@ __all__ = [
     "Protocol",
     "TypeGuard",
     "ZoneInfo",
+    "assert_type",
     "cache",
     "create_task",
     "prod",

--- a/psycopg/setup.cfg
+++ b/psycopg/setup.cfg
@@ -53,7 +53,7 @@ packages = find:
 zip_safe = False
 install_requires =
     backports.zoneinfo >= 0.2.0; python_version < "3.9"
-    typing-extensions >= 4.1
+    typing-extensions >= 4.2
     tzdata; sys_platform == "win32"
     importlib-metadata >= 1.4; python_version < "3.8"
 

--- a/psycopg_pool/psycopg_pool/base.py
+++ b/psycopg_pool/psycopg_pool/base.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, Generic, Optional, Tuple
 
 from psycopg import errors as e
 from psycopg.abc import ConnectionType
+from psycopg.rows import RowFactory
 
 from .errors import PoolClosed
 from ._compat import Counter, Deque
@@ -41,6 +42,7 @@ class BasePool(Generic[ConnectionType]):
         conninfo: str = "",
         *,
         kwargs: Optional[Dict[str, Any]],
+        row_factory: Optional[RowFactory[Any]],
         min_size: int,
         max_size: Optional[int],
         open: bool,
@@ -63,6 +65,12 @@ class BasePool(Generic[ConnectionType]):
 
         self.conninfo = conninfo
         self.kwargs: Dict[str, Any] = kwargs or {}
+        if row_factory:
+            if "row_factory" in self.kwargs:
+                raise ValueError(
+                    "kwargs['row_factory'] is incompatible with 'row_factory' argument"
+                )
+            self.kwargs["row_factory"] = row_factory
         self.name = name
         self._min_size = min_size
         self._max_size = max_size

--- a/psycopg_pool/psycopg_pool/null_pool.py
+++ b/psycopg_pool/psycopg_pool/null_pool.py
@@ -6,10 +6,11 @@ Psycopg null connection pools
 
 import logging
 import threading
-from typing import Any, Callable, Dict, Optional, Tuple, Type
+from typing import Any, Callable, Dict, Optional, Tuple, Type, overload
 
 from psycopg import Connection
 from psycopg.pq import TransactionStatus
+from psycopg.rows import Row, RowFactory
 
 from .pool import ConnectionPool, AddConnection, ConnectFailedCB
 from .errors import PoolTimeout, TooManyRequests
@@ -40,7 +41,55 @@ class _BaseNullConnectionPool:
         pass
 
 
-class NullConnectionPool(_BaseNullConnectionPool, ConnectionPool):
+class NullConnectionPool(_BaseNullConnectionPool, ConnectionPool[Row]):
+    @overload
+    def __init__(
+        self: "NullConnectionPool[Row]",
+        conninfo: str = ...,
+        *,
+        open: bool = ...,
+        connection_class: Type[Connection[Any]] = ...,
+        configure: Optional[Callable[[Connection[Any]], None]] = ...,
+        reset: Optional[Callable[[Connection[Any]], None]] = ...,
+        kwargs: Optional[Dict[str, Any]] = ...,
+        row_factory: RowFactory[Row],
+        min_size: int = ...,
+        max_size: Optional[int] = ...,
+        name: Optional[str] = ...,
+        timeout: float = ...,
+        max_waiting: int = ...,
+        max_lifetime: float = ...,
+        max_idle: float = ...,
+        reconnect_timeout: float = ...,
+        reconnect_failed: Optional[ConnectFailedCB] = ...,
+        num_workers: int = ...,
+    ):
+        ...
+
+    @overload
+    def __init__(
+        self: "NullConnectionPool[Any]",
+        conninfo: str = ...,
+        *,
+        open: bool = ...,
+        connection_class: Type[Connection[Any]] = ...,
+        configure: Optional[Callable[[Connection[Any]], None]] = ...,
+        reset: Optional[Callable[[Connection[Any]], None]] = ...,
+        kwargs: Optional[Dict[str, Any]] = ...,
+        row_factory: None = ...,
+        min_size: int = ...,
+        max_size: Optional[int] = ...,
+        name: Optional[str] = ...,
+        timeout: float = ...,
+        max_waiting: int = ...,
+        max_lifetime: float = ...,
+        max_idle: float = ...,
+        reconnect_timeout: float = ...,
+        reconnect_failed: Optional[ConnectFailedCB] = ...,
+        num_workers: int = ...,
+    ):
+        ...
+
     def __init__(
         self,
         conninfo: str = "",
@@ -50,6 +99,7 @@ class NullConnectionPool(_BaseNullConnectionPool, ConnectionPool):
         configure: Optional[Callable[[Connection[Any]], None]] = None,
         reset: Optional[Callable[[Connection[Any]], None]] = None,
         kwargs: Optional[Dict[str, Any]] = None,
+        row_factory: Optional[RowFactory[Any]] = None,
         # Note: default value changed to 0.
         min_size: int = 0,
         max_size: Optional[int] = None,
@@ -69,6 +119,7 @@ class NullConnectionPool(_BaseNullConnectionPool, ConnectionPool):
             configure=configure,
             reset=reset,
             kwargs=kwargs,
+            row_factory=row_factory,
             min_size=min_size,
             max_size=max_size,
             name=name,

--- a/psycopg_pool/psycopg_pool/null_pool_async.py
+++ b/psycopg_pool/psycopg_pool/null_pool_async.py
@@ -6,10 +6,11 @@ psycopg asynchronous null connection pool
 
 import asyncio
 import logging
-from typing import Any, Awaitable, Callable, Dict, Optional, Type
+from typing import Any, Awaitable, Callable, Dict, Optional, Type, overload
 
 from psycopg import AsyncConnection
 from psycopg.pq import TransactionStatus
+from psycopg.rows import Row, RowFactory
 
 from .errors import PoolTimeout, TooManyRequests
 from ._compat import ConnectionTimeout
@@ -19,7 +20,55 @@ from .pool_async import AsyncConnectionPool, AddConnection, AsyncConnectFailedCB
 logger = logging.getLogger("psycopg.pool")
 
 
-class AsyncNullConnectionPool(_BaseNullConnectionPool, AsyncConnectionPool):
+class AsyncNullConnectionPool(_BaseNullConnectionPool, AsyncConnectionPool[Row]):
+    @overload
+    def __init__(
+        self: "AsyncNullConnectionPool[Row]",
+        conninfo: str = ...,
+        *,
+        open: bool = ...,
+        connection_class: Type[AsyncConnection[Any]] = ...,
+        configure: Optional[Callable[[AsyncConnection[Any]], Awaitable[None]]] = ...,
+        reset: Optional[Callable[[AsyncConnection[Any]], Awaitable[None]]] = ...,
+        kwargs: Optional[Dict[str, Any]] = ...,
+        row_factory: RowFactory[Row],
+        min_size: int = ...,
+        max_size: Optional[int] = ...,
+        name: Optional[str] = ...,
+        timeout: float = ...,
+        max_waiting: int = ...,
+        max_lifetime: float = ...,
+        max_idle: float = ...,
+        reconnect_timeout: float = ...,
+        reconnect_failed: Optional[AsyncConnectFailedCB] = ...,
+        num_workers: int = ...,
+    ):
+        ...
+
+    @overload
+    def __init__(
+        self: "AsyncNullConnectionPool[Any]",
+        conninfo: str = ...,
+        *,
+        open: bool = ...,
+        connection_class: Type[AsyncConnection[Any]] = ...,
+        configure: Optional[Callable[[AsyncConnection[Any]], Awaitable[None]]] = ...,
+        reset: Optional[Callable[[AsyncConnection[Any]], Awaitable[None]]] = ...,
+        kwargs: Optional[Dict[str, Any]] = ...,
+        row_factory: None = ...,
+        min_size: int = ...,
+        max_size: Optional[int] = ...,
+        name: Optional[str] = ...,
+        timeout: float = ...,
+        max_waiting: int = ...,
+        max_lifetime: float = ...,
+        max_idle: float = ...,
+        reconnect_timeout: float = ...,
+        reconnect_failed: Optional[AsyncConnectFailedCB] = ...,
+        num_workers: int = ...,
+    ):
+        ...
+
     def __init__(
         self,
         conninfo: str = "",
@@ -29,6 +78,7 @@ class AsyncNullConnectionPool(_BaseNullConnectionPool, AsyncConnectionPool):
         configure: Optional[Callable[[AsyncConnection[Any]], Awaitable[None]]] = None,
         reset: Optional[Callable[[AsyncConnection[Any]], Awaitable[None]]] = None,
         kwargs: Optional[Dict[str, Any]] = None,
+        row_factory: Optional[RowFactory[Any]] = None,
         # Note: default value changed to 0.
         min_size: int = 0,
         max_size: Optional[int] = None,
@@ -48,6 +98,7 @@ class AsyncNullConnectionPool(_BaseNullConnectionPool, AsyncConnectionPool):
             configure=configure,
             reset=reset,
             kwargs=kwargs,
+            row_factory=row_factory,
             min_size=min_size,
             max_size=max_size,
             name=name,

--- a/psycopg_pool/psycopg_pool/pool.py
+++ b/psycopg_pool/psycopg_pool/pool.py
@@ -11,7 +11,7 @@ from time import monotonic
 from queue import Queue, Empty
 from types import TracebackType
 from typing import Any, Callable, Dict, Iterator, List
-from typing import Optional, Sequence, Type
+from typing import Optional, Sequence, Type, TypeVar
 from typing_extensions import TypeAlias
 from weakref import ref
 from contextlib import contextmanager
@@ -31,6 +31,8 @@ ConnectFailedCB: TypeAlias = Callable[["ConnectionPool"], None]
 
 
 class ConnectionPool(BasePool[Connection[Any]]):
+    _Self = TypeVar("_Self", bound="ConnectionPool")
+
     def __init__(
         self,
         conninfo: str = "",
@@ -388,7 +390,7 @@ class ConnectionPool(BasePool[Connection[Any]]):
                         timeout,
                     )
 
-    def __enter__(self) -> "ConnectionPool":
+    def __enter__(self: _Self) -> _Self:
         self.open()
         return self
 

--- a/psycopg_pool/psycopg_pool/pool_async.py
+++ b/psycopg_pool/psycopg_pool/pool_async.py
@@ -10,7 +10,7 @@ from abc import ABC, abstractmethod
 from time import monotonic
 from types import TracebackType
 from typing import Any, AsyncIterator, Awaitable, Callable
-from typing import Dict, List, Optional, Sequence, Type, Union
+from typing import Dict, List, Optional, Sequence, Type, TypeVar, Union
 from typing_extensions import TypeAlias
 from weakref import ref
 from contextlib import asynccontextmanager
@@ -33,6 +33,8 @@ AsyncConnectFailedCB: TypeAlias = Union[
 
 
 class AsyncConnectionPool(BasePool[AsyncConnection[Any]]):
+    _Self = TypeVar("_Self", bound="AsyncConnectionPool")
+
     def __init__(
         self,
         conninfo: str = "",
@@ -333,7 +335,7 @@ class AsyncConnectionPool(BasePool[AsyncConnection[Any]]):
                 timeout,
             )
 
-    async def __aenter__(self) -> "AsyncConnectionPool":
+    async def __aenter__(self: _Self) -> _Self:
         await self.open()
         return self
 

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -5,7 +5,7 @@
 
 # From install_requires
 backports.zoneinfo == 0.2.0
-typing-extensions == 4.1.0
+typing-extensions == 4.2.0
 importlib-metadata == 1.4
 
 # From the 'test' extra

--- a/tests/pool/test_null_pool_async.py
+++ b/tests/pool/test_null_pool_async.py
@@ -1,14 +1,15 @@
 import asyncio
 import logging
 from time import time
-from typing import Any, List, Tuple
+from typing import Any, Dict, List, Tuple
 
 import pytest
 from packaging.version import parse as ver  # noqa: F401  # used in skipif
 
 import psycopg
 from psycopg.pq import TransactionStatus
-from psycopg._compat import create_task
+from psycopg.rows import class_row
+from psycopg._compat import assert_type, create_task
 from .test_pool_async import delay_connection, ensure_waiting
 
 pytestmark = [pytest.mark.anyio]
@@ -54,6 +55,33 @@ async def test_kwargs(dsn):
     async with AsyncNullConnectionPool(dsn, kwargs={"autocommit": True}) as p:
         async with p.connection() as conn:
             assert conn.autocommit
+
+
+class MyRow(Dict[str, Any]):
+    ...
+
+
+async def test_row_factory(dsn):
+    async with AsyncNullConnectionPool(
+        dsn, row_factory=class_row(MyRow), name="null"
+    ) as p1, p1.connection() as conn1:
+        (row1,) = await (await conn1.execute("select 1 as x")).fetchall()
+    assert_type(p1, AsyncNullConnectionPool[MyRow])
+    assert_type(conn1, psycopg.connection_async.AsyncConnection[MyRow])
+    assert_type(row1, MyRow)
+    assert row1 == {"x": 1}
+
+    async with AsyncNullConnectionPool(dsn) as p2, p2.connection() as conn2:
+        (row2,) = await (await conn2.execute("select 2 as y")).fetchall()
+    assert_type(p2, AsyncNullConnectionPool[Any])
+    assert_type(conn2, psycopg.connection_async.AsyncConnection[Any])
+    assert_type(row2, Any)
+    assert row2 == (2,)
+
+    with pytest.raises(ValueError, match="incompatible with 'row_factory' argument"):
+        AsyncNullConnectionPool(
+            dsn, kwargs={"row_factory": object}, row_factory=class_row(dict)
+        )
 
 
 @pytest.mark.crdb_skip("backend pid")


### PR DESCRIPTION
Connection pools currently produces `Connection[Any]` type and there does not seem to be a way to tell the type system about the row type of connections in the pool. I've been thinking a bit about this and drafted a proposal for discussion. ~Best start is to read the documentation change, does this sound good from a user perspective?~