### PR TITLE
fix: don't reuse the same Transformer in composite dumper

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -21,6 +21,7 @@ Psycopg 3.1.9 (unreleased)
   (:ticket:`#543`).
 - Fix loading ROW values with different types in the same query using the
   binary protocol (:ticket:`#545`).
+- Fix dumping recursive composite types (:ticket:`#547`).
 
 
 Current release


### PR DESCRIPTION
We need different dumpers because, in case a composite contains another composite, we need to call `dump_sequence()` on different sequences, so we row dumpers must be distinct.

Close #547