### PR TITLE
Add raw query support with PostgreSQL native placeholders

### DIFF
--- a/docs/advanced/cursors.rst
+++ b/docs/advanced/cursors.rst
@@ -191,6 +191,7 @@ directly call the fetch methods, skipping the `~ServerCursor.execute()` call:
     for record in cur:  # or cur.fetchone(), cur.fetchmany()...
         # do something with record
 
+
 .. _raw-query-cursors:
 
 Raw Query Cursors
@@ -198,11 +199,12 @@ Raw Query Cursors
 
 .. versionadded:: 3.2
 
-Raw query cursors allow users to use PostgreSQL native placeholders ($1, $2,
-etc.) in their queries instead of the standard %s placeholder. This can be
-useful when it's desirable to pass the query unmodified to PostgreSQL and rely
-on PostgreSQL's placeholder functionality, such as when dealing with a very
-complex query containing %s inside strings, dollar-quoted strings or elsewhere.
+The `RawCursor` and `AsyncRawCursor` classes allow users to use PostgreSQL
+native placeholders (``$1``, ``$2``, etc.) in their queries instead of the
+standard ``%s`` placeholder. This can be useful when it's desirable to pass
+the query unmodified to PostgreSQL and rely on PostgreSQL's placeholder
+functionality, such as when dealing with a very complex query containing
+``%s`` inside strings, dollar-quoted strings or elsewhere.
 
 One important note is that raw query cursors only accept positional arguments
 in the form of a list or tuple. This means you cannot use named arguments

--- a/docs/advanced/cursors.rst
+++ b/docs/advanced/cursors.rst
@@ -190,3 +190,44 @@ directly call the fetch methods, skipping the `~ServerCursor.execute()` call:
     # no cur.execute()
     for record in cur:  # or cur.fetchone(), cur.fetchmany()...
         # do something with record
+
+.. _raw-query-cursors:
+
+Raw Query Cursors
+------------------
+
+.. versionadded:: 3.2
+
+Raw query cursors allow users to use PostgreSQL native placeholders ($1, $2,
+etc.) in their queries instead of the standard %s placeholder. This can be
+useful when it's desirable to pass the query unmodified to PostgreSQL and rely
+on PostgreSQL's placeholder functionality, such as when dealing with a very
+complex query containing %s inside strings, dollar-quoted strings or elsewhere.
+
+One important note is that raw query cursors only accept positional arguments
+in the form of a list or tuple. This means you cannot use named arguments
+(i.e., dictionaries).
+
+There are two ways to use raw query cursors:
+
+1. Using the cursor factory:
+
+.. code:: python
+
+    from psycopg import connect, RawCursor
+
+    with connect(dsn, cursor_factory=RawCursor) as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT $1, $2", [1, "Hello"])
+            assert cur.fetchone() == (1, "Hello")
+
+2. Instantiating a cursor:
+
+.. code:: python
+
+    from psycopg import connect, RawCursor
+
+    with connect(dsn) as conn:
+        with RawCursor(conn) as cur:
+            cur.execute("SELECT $1, $2", [1, "Hello"])
+            assert cur.fetchone() == (1, "Hello")

--- a/docs/api/cursors.rst
+++ b/docs/api/cursors.rst
@@ -315,6 +315,20 @@ The `!Cursor` class
           is text or binary.
 
 
+The `!RawCursor` class
+----------------------
+
+.. seealso:: See :ref:`raw-query-cursors` for details.
+
+.. autoclass:: RawCursor
+
+    This `Cursor` subclass has the same interface of the parent class but
+    supports placeholders in PostgreSQL format (``$1``, ``$2``...) rather than
+    in Python format (``%s``). Only positional parameters are supported.
+
+    .. versionadded:: 3.2
+
+
 The `!ClientCursor` class
 -------------------------
 
@@ -445,8 +459,13 @@ The `!ServerCursor` class
         .. _MOVE: https://www.postgresql.org/docs/current/sql-fetch.html
 
 
-The `!AsyncCursor` class
-------------------------
+Async cursor classes
+--------------------
+
+Every `Cursor` class has an equivalent `!Async` version exposing the same
+semantic with an `!async` interface. The main interface is described in
+`AsyncCursor`.
+
 
 .. autoclass:: AsyncCursor
 
@@ -506,20 +525,23 @@ The `!AsyncCursor` class
         to iterate on the async cursor results.
 
 
-The `!AsyncClientCursor` class
-------------------------------
+
+.. autoclass:: AsyncRawCursor
+
+    This class is the `!async` equivalent of `RawCursor`. The differences 
+    w.r.t. the sync counterpart are the same described in `AsyncCursor`.
+
+    .. versionadded:: 3.2
+
 
 .. autoclass:: AsyncClientCursor
 
-    This class is the `!async` equivalent of the `ClientCursor`. The
-    difference are the same shown in `AsyncCursor`.
+    This class is the `!async` equivalent of `ClientCursor`. The differences
+    w.r.t. the sync counterpart are the same described in `AsyncCursor`.
 
     .. versionadded:: 3.1
 
 
-
-The `!AsyncServerCursor` class
-------------------------------
 
 .. autoclass:: AsyncServerCursor
 

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -15,6 +15,8 @@ Psycopg 3.2 (unreleased)
 
 - Add support for integer, floating point, boolean `NumPy scalar types`__
   (:ticket:`#332`).
+- Add :ref:`raw-query-cursors` to execute queries using placeholders in
+  PostgreSQL format (`$1`, `$2`...) (:ticket:`#560`).
 - Add support for libpq functions to close prepared statements and portals
   introduced in libpq v17 (:ticket:`#603`).
 - Disable receiving more than one result on the same cursor in pipeline mode,

--- a/psycopg/psycopg/__init__.py
+++ b/psycopg/psycopg/__init__.py
@@ -24,6 +24,7 @@ from .transaction import Rollback, Transaction, AsyncTransaction
 from .cursor_async import AsyncCursor
 from .server_cursor import AsyncServerCursor, ServerCursor
 from .client_cursor import AsyncClientCursor, ClientCursor
+from .raw_cursor import AsyncRawCursor, RawCursor
 from .connection_async import AsyncConnection
 
 from . import dbapi20
@@ -64,6 +65,7 @@ __all__ = [
     "AsyncCopy",
     "AsyncCursor",
     "AsyncPipeline",
+    "AsyncRawCursor",
     "AsyncServerCursor",
     "AsyncTransaction",
     "BaseConnection",
@@ -76,6 +78,7 @@ __all__ = [
     "IsolationLevel",
     "Notify",
     "Pipeline",
+    "RawCursor",
     "Rollback",
     "ServerCursor",
     "Transaction",

--- a/psycopg/psycopg/_queries.py
+++ b/psycopg/psycopg/_queries.py
@@ -72,7 +72,7 @@ class PostgresQuery:
                 self._want_formats,
                 self._order,
                 self._parts,
-            ) = _query2pg(bquery, self._encoding)
+            ) = self.query2pg(bquery, self._encoding)
         else:
             self.query = bquery
             self._want_formats = self._order = None
@@ -86,8 +86,11 @@ class PostgresQuery:
         This method updates `params` and `types`.
         """
         if vars is not None:
-            params = _validate_and_reorder_params(self._parts, vars, self._order)
-            assert self._want_formats is not None
+            params = self.validate_and_reorder_params(self._parts, vars, self._order)
+            num_params = len(params)
+            if self._want_formats is None:
+                self._want_formats = [PyFormat.AUTO] * num_params
+            assert len(self._want_formats) == num_params
             self.params = self._tx.dump_sequence(params, self._want_formats)
             self.types = self._tx.types or ()
             self.formats = self._tx.formats
@@ -95,6 +98,110 @@ class PostgresQuery:
             self.params = None
             self.types = ()
             self.formats = None
+
+    @staticmethod
+    def is_params_sequence(vars: Params) -> bool:
+        # Try concrete types, then abstract types
+        t = type(vars)
+        if t is list or t is tuple:
+            sequence = True
+        elif t is dict:
+            sequence = False
+        elif isinstance(vars, Sequence) and not isinstance(vars, (bytes, str)):
+            sequence = True
+        elif isinstance(vars, Mapping):
+            sequence = False
+        else:
+            raise TypeError(
+                "query parameters should be a sequence or a mapping,"
+                f" got {type(vars).__name__}"
+            )
+        return sequence
+
+    @staticmethod
+    def validate_and_reorder_params(
+        parts: List[QueryPart], vars: Params, order: Optional[List[str]]
+    ) -> Sequence[Any]:
+        """
+        Verify the compatibility between a query and a set of params.
+        """
+        sequence = PostgresQuery.is_params_sequence(vars)
+
+        if sequence:
+            if len(vars) != len(parts) - 1:
+                raise e.ProgrammingError(
+                    f"the query has {len(parts) - 1} placeholders but"
+                    f" {len(vars)} parameters were passed"
+                )
+            if vars and not isinstance(parts[0].item, int):
+                raise TypeError("named placeholders require a mapping of parameters")
+            return vars  # type: ignore[return-value]
+
+        else:
+            if vars and len(parts) > 1 and not isinstance(parts[0][1], str):
+                raise TypeError(
+                    "positional placeholders (%s) require a sequence of parameters"
+                )
+            try:
+                return [
+                    vars[item] for item in order or ()  # type: ignore[call-overload]
+                ]
+            except KeyError:
+                raise e.ProgrammingError(
+                    "query parameter missing:"
+                    f" {', '.join(sorted(i for i in order or () if i not in vars))}"
+                )
+
+    @staticmethod
+    @lru_cache()
+    def query2pg(
+        query: bytes, encoding: str
+    ) -> Tuple[bytes, Optional[List[PyFormat]], Optional[List[str]], List[QueryPart]]:
+        """
+        Convert Python query and params into something Postgres understands.
+
+        - Convert Python placeholders (``%s``, ``%(name)s``) into Postgres
+        format (``$1``, ``$2``)
+        - placeholders can be %s, %t, or %b (auto, text or binary)
+        - return ``query`` (bytes), ``formats`` (list of formats) ``order``
+        (sequence of names used in the query, in the position they appear)
+        ``parts`` (splits of queries and placeholders).
+        """
+        parts = _split_query(query, encoding)
+        order: Optional[List[str]] = None
+        chunks: List[bytes] = []
+        formats = []
+
+        if isinstance(parts[0].item, int):
+            for part in parts[:-1]:
+                assert isinstance(part.item, int)
+                chunks.append(part.pre)
+                chunks.append(b"$%d" % (part.item + 1))
+                formats.append(part.format)
+
+        elif isinstance(parts[0].item, str):
+            seen: Dict[str, Tuple[bytes, PyFormat]] = {}
+            order = []
+            for part in parts[:-1]:
+                assert isinstance(part.item, str)
+                chunks.append(part.pre)
+                if part.item not in seen:
+                    ph = b"$%d" % (len(seen) + 1)
+                    seen[part.item] = (ph, part.format)
+                    order.append(part.item)
+                    chunks.append(ph)
+                    formats.append(part.format)
+                else:
+                    if seen[part.item][1] != part.format:
+                        raise e.ProgrammingError(
+                            f"placeholder '{part.item}' cannot have different formats"
+                        )
+                    chunks.append(seen[part.item][0])
+
+        # last part
+        chunks.append(parts[-1].pre)
+
+        return b"".join(chunks), formats, order, parts
 
 
 class PostgresClientQuery(PostgresQuery):
@@ -119,7 +226,7 @@ class PostgresClientQuery(PostgresQuery):
             bquery = query
 
         if vars is not None:
-            (self.template, self._order, self._parts) = _query2pg_client(
+            (self.template, _, self._order, self._parts) = PostgresClientQuery.query2pg(
                 bquery, self._encoding
             )
         else:
@@ -135,7 +242,7 @@ class PostgresClientQuery(PostgresQuery):
         This method updates `params` and `types`.
         """
         if vars is not None:
-            params = _validate_and_reorder_params(self._parts, vars, self._order)
+            params = self.validate_and_reorder_params(self._parts, vars, self._order)
             self.params = tuple(
                 self._tx.as_literal(p) if p is not None else b"NULL" for p in params
             )
@@ -143,140 +250,43 @@ class PostgresClientQuery(PostgresQuery):
         else:
             self.params = None
 
+    @staticmethod
+    @lru_cache()
+    def query2pg(
+        query: bytes, encoding: str
+    ) -> Tuple[bytes, Optional[List[PyFormat]], Optional[List[str]], List[QueryPart]]:
+        """
+        Convert Python query and params into a template to perform client-side binding
+        """
+        parts = _split_query(query, encoding, collapse_double_percent=False)
+        order: Optional[List[str]] = None
+        chunks: List[bytes] = []
 
-@lru_cache()
-def _query2pg(
-    query: bytes, encoding: str
-) -> Tuple[bytes, List[PyFormat], Optional[List[str]], List[QueryPart]]:
-    """
-    Convert Python query and params into something Postgres understands.
+        if isinstance(parts[0].item, int):
+            for part in parts[:-1]:
+                assert isinstance(part.item, int)
+                chunks.append(part.pre)
+                chunks.append(b"%s")
 
-    - Convert Python placeholders (``%s``, ``%(name)s``) into Postgres
-      format (``$1``, ``$2``)
-    - placeholders can be %s, %t, or %b (auto, text or binary)
-    - return ``query`` (bytes), ``formats`` (list of formats) ``order``
-      (sequence of names used in the query, in the position they appear)
-      ``parts`` (splits of queries and placeholders).
-    """
-    parts = _split_query(query, encoding)
-    order: Optional[List[str]] = None
-    chunks: List[bytes] = []
-    formats = []
+        elif isinstance(parts[0].item, str):
+            seen: Dict[str, Tuple[bytes, PyFormat]] = {}
+            order = []
+            for part in parts[:-1]:
+                assert isinstance(part.item, str)
+                chunks.append(part.pre)
+                if part.item not in seen:
+                    ph = b"%s"
+                    seen[part.item] = (ph, part.format)
+                    order.append(part.item)
+                    chunks.append(ph)
+                else:
+                    chunks.append(seen[part.item][0])
+                    order.append(part.item)
 
-    if isinstance(parts[0].item, int):
-        for part in parts[:-1]:
-            assert isinstance(part.item, int)
-            chunks.append(part.pre)
-            chunks.append(b"$%d" % (part.item + 1))
-            formats.append(part.format)
+        # last part
+        chunks.append(parts[-1].pre)
 
-    elif isinstance(parts[0].item, str):
-        seen: Dict[str, Tuple[bytes, PyFormat]] = {}
-        order = []
-        for part in parts[:-1]:
-            assert isinstance(part.item, str)
-            chunks.append(part.pre)
-            if part.item not in seen:
-                ph = b"$%d" % (len(seen) + 1)
-                seen[part.item] = (ph, part.format)
-                order.append(part.item)
-                chunks.append(ph)
-                formats.append(part.format)
-            else:
-                if seen[part.item][1] != part.format:
-                    raise e.ProgrammingError(
-                        f"placeholder '{part.item}' cannot have different formats"
-                    )
-                chunks.append(seen[part.item][0])
-
-    # last part
-    chunks.append(parts[-1].pre)
-
-    return b"".join(chunks), formats, order, parts
-
-
-@lru_cache()
-def _query2pg_client(
-    query: bytes, encoding: str
-) -> Tuple[bytes, Optional[List[str]], List[QueryPart]]:
-    """
-    Convert Python query and params into a template to perform client-side binding
-    """
-    parts = _split_query(query, encoding, collapse_double_percent=False)
-    order: Optional[List[str]] = None
-    chunks: List[bytes] = []
-
-    if isinstance(parts[0].item, int):
-        for part in parts[:-1]:
-            assert isinstance(part.item, int)
-            chunks.append(part.pre)
-            chunks.append(b"%s")
-
-    elif isinstance(parts[0].item, str):
-        seen: Dict[str, Tuple[bytes, PyFormat]] = {}
-        order = []
-        for part in parts[:-1]:
-            assert isinstance(part.item, str)
-            chunks.append(part.pre)
-            if part.item not in seen:
-                ph = b"%s"
-                seen[part.item] = (ph, part.format)
-                order.append(part.item)
-                chunks.append(ph)
-            else:
-                chunks.append(seen[part.item][0])
-                order.append(part.item)
-
-    # last part
-    chunks.append(parts[-1].pre)
-
-    return b"".join(chunks), order, parts
-
-
-def _validate_and_reorder_params(
-    parts: List[QueryPart], vars: Params, order: Optional[List[str]]
-) -> Sequence[Any]:
-    """
-    Verify the compatibility between a query and a set of params.
-    """
-    # Try concrete types, then abstract types
-    t = type(vars)
-    if t is list or t is tuple:
-        sequence = True
-    elif t is dict:
-        sequence = False
-    elif isinstance(vars, Sequence) and not isinstance(vars, (bytes, str)):
-        sequence = True
-    elif isinstance(vars, Mapping):
-        sequence = False
-    else:
-        raise TypeError(
-            "query parameters should be a sequence or a mapping,"
-            f" got {type(vars).__name__}"
-        )
-
-    if sequence:
-        if len(vars) != len(parts) - 1:
-            raise e.ProgrammingError(
-                f"the query has {len(parts) - 1} placeholders but"
-                f" {len(vars)} parameters were passed"
-            )
-        if vars and not isinstance(parts[0].item, int):
-            raise TypeError("named placeholders require a mapping of parameters")
-        return vars  # type: ignore[return-value]
-
-    else:
-        if vars and len(parts) > 1 and not isinstance(parts[0][1], str):
-            raise TypeError(
-                "positional placeholders (%s) require a sequence of parameters"
-            )
-        try:
-            return [vars[item] for item in order or ()]  # type: ignore[call-overload]
-        except KeyError:
-            raise e.ProgrammingError(
-                "query parameter missing:"
-                f" {', '.join(sorted(i for i in order or () if i not in vars))}"
-            )
+        return b"".join(chunks), None, order, parts
 
 
 _re_placeholder = re.compile(

--- a/psycopg/psycopg/raw_cursor.py
+++ b/psycopg/psycopg/raw_cursor.py
@@ -38,10 +38,9 @@ class RawPostgresQuery(PostgresQuery):
         """
         Verify the compatibility; params must be a sequence for raw query.
         """
-        sequence = PostgresQuery.is_params_sequence(vars)
-        if not sequence:
+        if not PostgresQuery.is_params_sequence(vars):
             raise TypeError("raw query require a sequence of parameters")
-        return vars  # type: ignore[return-value]
+        return vars
 
 
 class RawCursorMixin(BaseCursor[ConnectionType, Row]):

--- a/psycopg/psycopg/raw_cursor.py
+++ b/psycopg/psycopg/raw_cursor.py
@@ -1,0 +1,61 @@
+"""
+psycopg raw queries cursors
+"""
+
+# Copyright (C) 2023 The Psycopg Team
+
+from typing import Any, Optional, Sequence, Tuple, List, TYPE_CHECKING
+from functools import lru_cache
+
+from ._queries import PostgresQuery, QueryPart
+
+from .abc import ConnectionType, Query, Params
+from .rows import Row
+from .cursor import BaseCursor, Cursor
+from ._enums import PyFormat
+from .cursor_async import AsyncCursor
+
+if TYPE_CHECKING:
+    from .connection import Connection  # noqa: F401
+    from .connection_async import AsyncConnection  # noqa: F401
+
+
+class RawPostgresQuery(PostgresQuery):
+    @staticmethod
+    @lru_cache()
+    def query2pg(
+        query: bytes, encoding: str
+    ) -> Tuple[bytes, Optional[List[PyFormat]], Optional[List[str]], List[QueryPart]]:
+        """
+        Noop; Python raw query is already in the format Postgres understands.
+        """
+        return query, None, None, []
+
+    @staticmethod
+    def validate_and_reorder_params(
+        parts: List[QueryPart], vars: Params, order: Optional[List[str]]
+    ) -> Sequence[Any]:
+        """
+        Verify the compatibility; params must be a sequence for raw query.
+        """
+        sequence = PostgresQuery.is_params_sequence(vars)
+        if not sequence:
+            raise TypeError("raw query require a sequence of parameters")
+        return vars  # type: ignore[return-value]
+
+
+class RawCursorMixin(BaseCursor[ConnectionType, Row]):
+    def _convert_query(
+        self, query: Query, params: Optional[Params] = None
+    ) -> PostgresQuery:
+        pgq = RawPostgresQuery(self._tx)
+        pgq.convert(query, params)
+        return pgq
+
+
+class RawCursor(RawCursorMixin["Connection[Any]", Row], Cursor[Row]):
+    __module__ = "psycopg"
+
+
+class AsyncRawCursor(RawCursorMixin["AsyncConnection[Any]", Row], AsyncCursor[Row]):
+    __module__ = "psycopg"

--- a/tests/fix_faker.py
+++ b/tests/fix_faker.py
@@ -146,7 +146,7 @@ class Faker:
             with conn.transaction():
                 yield
         except psycopg.DatabaseError:
-            cur = conn.cursor()
+            cur = psycopg.Cursor(conn)
             # Repeat insert one field at time, until finding the wrong one
             cur.execute(self.drop_stmt)
             cur.execute(self.create_stmt)
@@ -171,7 +171,7 @@ class Faker:
             async with aconn.transaction():
                 yield
         except psycopg.DatabaseError:
-            acur = aconn.cursor()
+            acur = psycopg.AsyncCursor(aconn)
             # Repeat insert one field at time, until finding the wrong one
             await acur.execute(self.drop_stmt)
             await acur.execute(self.create_stmt)

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -21,7 +21,7 @@ from .utils import gc_collect, raiseif
 from .fix_crdb import is_crdb, crdb_encoding, crdb_time_precision
 
 
-@pytest.fixture(params=[psycopg.Cursor, psycopg.ClientCursor])
+@pytest.fixture(params=[psycopg.Cursor, psycopg.ClientCursor, psycopg.RawCursor])
 def conn(conn, request):
     conn.cursor_factory = request.param
     return conn

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -2,10 +2,11 @@
 Tests common to psycopg.Cursor and its subclasses.
 """
 
+import re
 import pickle
 import weakref
 import datetime as dt
-from typing import List, Union
+from typing import Any, List, Match, Union
 from contextlib import closing
 
 import pytest
@@ -25,6 +26,25 @@ from .fix_crdb import is_crdb, crdb_encoding, crdb_time_precision
 def conn(conn, request):
     conn.cursor_factory = request.param
     return conn
+
+
+def ph(cur: Any, query: str) -> str:
+    """Change placeholders in a query from %s to $n if testing  a raw cursor"""
+    if not isinstance(cur, (psycopg.RawCursor, psycopg.AsyncRawCursor)):
+        return query
+
+    if "%(" in query:
+        raise pytest.skip("RawCursor only supports positional placeholders")
+
+    n = 1
+
+    def s(m: Match[str]) -> str:
+        nonlocal n
+        rv = f"${n}"
+        n += 1
+        return rv
+
+    return re.sub(r"(?<!%)(%[bst])", s, query)
 
 
 def test_init(conn):
@@ -168,7 +188,7 @@ def test_execute_many_results(conn):
 
 def test_execute_sequence(conn):
     cur = conn.cursor()
-    rv = cur.execute("select %s::int, %s::text, %s::text", [1, "foo", None])
+    rv = cur.execute(ph(cur, "select %s::int, %s::text, %s::text"), [1, "foo", None])
     assert rv is cur
     assert len(cur._results) == 1
     assert cur.pgresult.get_value(0, 0) == b"1"
@@ -189,8 +209,8 @@ def test_execute_empty_query(conn, query):
 def test_execute_type_change(conn):
     # issue #112
     conn.execute("create table bug_112 (num integer)")
-    sql = "insert into bug_112 (num) values (%s)"
     cur = conn.cursor()
+    sql = ph(cur, "insert into bug_112 (num) values (%s)")
     cur.execute(sql, (1,))
     cur.execute(sql, (100_000,))
     cur.execute("select num from bug_112 order by num")
@@ -199,8 +219,8 @@ def test_execute_type_change(conn):
 
 def test_executemany_type_change(conn):
     conn.execute("create table bug_112 (num integer)")
-    sql = "insert into bug_112 (num) values (%s)"
     cur = conn.cursor()
+    sql = ph(cur, "insert into bug_112 (num) values (%s)")
     cur.executemany(sql, [(1,), (100_000,)])
     cur.execute("select num from bug_112 order by num")
     assert cur.fetchall() == [(1,), (100_000,)]
@@ -218,7 +238,7 @@ def test_execute_copy(conn, query):
 
 def test_fetchone(conn):
     cur = conn.cursor()
-    cur.execute("select %s::int, %s::text, %s::text", [1, "foo", None])
+    cur.execute(ph(cur, "select %s::int, %s::text, %s::text"), [1, "foo", None])
     assert cur.pgresult.fformat(0) == 0
 
     row = cur.fetchone()
@@ -232,7 +252,7 @@ def test_binary_cursor_execute(conn):
         conn.cursor_factory is psycopg.ClientCursor, psycopg.NotSupportedError
     ) as ex:
         cur = conn.cursor(binary=True)
-        cur.execute("select %s, %s", [1, None])
+        cur.execute(ph(cur, "select %s, %s"), [1, None])
     if ex:
         return
 
@@ -246,7 +266,7 @@ def test_execute_binary(conn):
     with raiseif(
         conn.cursor_factory is psycopg.ClientCursor, psycopg.NotSupportedError
     ) as ex:
-        cur.execute("select %s, %s", [1, None], binary=True)
+        cur.execute(ph(cur, "select %s, %s"), [1, None], binary=True)
     if ex:
         return
 
@@ -257,7 +277,7 @@ def test_execute_binary(conn):
 
 def test_binary_cursor_text_override(conn):
     cur = conn.cursor(binary=True)
-    cur.execute("select %s, %s", [1, None], binary=False)
+    cur.execute(ph(cur, "select %s, %s"), [1, None], binary=False)
     assert cur.fetchone() == (1, None)
     assert cur.pgresult.fformat(0) == 0
     assert cur.pgresult.get_value(0, 0) == b"1"
@@ -299,7 +319,7 @@ def execmany(svcconn, _execmany):
 def test_executemany(conn, execmany):
     cur = conn.cursor()
     cur.executemany(
-        "insert into execmany(num, data) values (%s, %s)",
+        ph(cur, "insert into execmany(num, data) values (%s, %s)"),
         [(10, "hello"), (20, "world")],
     )
     cur.execute("select num, data from execmany order by 1")
@@ -309,7 +329,7 @@ def test_executemany(conn, execmany):
 def test_executemany_name(conn, execmany):
     cur = conn.cursor()
     cur.executemany(
-        "insert into execmany(num, data) values (%(num)s, %(data)s)",
+        ph(cur, "insert into execmany(num, data) values (%(num)s, %(data)s)"),
         [{"num": 11, "data": "hello", "x": 1}, {"num": 21, "data": "world"}],
     )
     cur.execute("select num, data from execmany order by 1")
@@ -318,14 +338,14 @@ def test_executemany_name(conn, execmany):
 
 def test_executemany_no_data(conn, execmany):
     cur = conn.cursor()
-    cur.executemany("insert into execmany(num, data) values (%s, %s)", [])
+    cur.executemany(ph(cur, "insert into execmany(num, data) values (%s, %s)"), [])
     assert cur.rowcount == 0
 
 
 def test_executemany_rowcount(conn, execmany):
     cur = conn.cursor()
     cur.executemany(
-        "insert into execmany(num, data) values (%s, %s)",
+        ph(cur, "insert into execmany(num, data) values (%s, %s)"),
         [(10, "hello"), (20, "world")],
     )
     assert cur.rowcount == 2
@@ -334,7 +354,7 @@ def test_executemany_rowcount(conn, execmany):
 def test_executemany_returning(conn, execmany):
     cur = conn.cursor()
     cur.executemany(
-        "insert into execmany(num, data) values (%s, %s) returning num",
+        ph(cur, "insert into execmany(num, data) values (%s, %s) returning num"),
         [(10, "hello"), (20, "world")],
         returning=True,
     )
@@ -349,7 +369,7 @@ def test_executemany_returning(conn, execmany):
 def test_executemany_returning_discard(conn, execmany):
     cur = conn.cursor()
     cur.executemany(
-        "insert into execmany(num, data) values (%s, %s) returning num",
+        ph(cur, "insert into execmany(num, data) values (%s, %s) returning num"),
         [(10, "hello"), (20, "world")],
     )
     assert cur.rowcount == 2
@@ -361,7 +381,7 @@ def test_executemany_returning_discard(conn, execmany):
 def test_executemany_no_result(conn, execmany):
     cur = conn.cursor()
     cur.executemany(
-        "insert into execmany(num, data) values (%s, %s)",
+        ph(cur, "insert into execmany(num, data) values (%s, %s)"),
         [(10, "hello"), (20, "world")],
         returning=True,
     )
@@ -379,11 +399,13 @@ def test_executemany_no_result(conn, execmany):
 
 def test_executemany_rowcount_no_hit(conn, execmany):
     cur = conn.cursor()
-    cur.executemany("delete from execmany where id = %s", [(-1,), (-2,)])
+    cur.executemany(ph(cur, "delete from execmany where id = %s"), [(-1,), (-2,)])
     assert cur.rowcount == 0
-    cur.executemany("delete from execmany where id = %s", [])
+    cur.executemany(ph(cur, "delete from execmany where id = %s"), [])
     assert cur.rowcount == 0
-    cur.executemany("delete from execmany where id = %s returning num", [(-1,), (-2,)])
+    cur.executemany(
+        ph(cur, "delete from execmany where id = %s returning num"), [(-1,), (-2,)]
+    )
     assert cur.rowcount == 0
 
 
@@ -398,7 +420,7 @@ def test_executemany_rowcount_no_hit(conn, execmany):
 def test_executemany_badquery(conn, query):
     cur = conn.cursor()
     with pytest.raises(psycopg.DatabaseError):
-        cur.executemany(query, [(10, "hello"), (20, "world")])
+        cur.executemany(ph(cur, query), [(10, "hello"), (20, "world")])
 
 
 @pytest.mark.parametrize("fmt_in", PyFormat)
@@ -406,7 +428,7 @@ def test_executemany_null_first(conn, fmt_in):
     cur = conn.cursor()
     cur.execute("create table testmany (a bigint, b bigint)")
     cur.executemany(
-        f"insert into testmany values (%{fmt_in.value}, %{fmt_in.value})",
+        ph(cur, f"insert into testmany values (%{fmt_in.value}, %{fmt_in.value})"),
         [[1, None], [3, 4]],
     )
     with pytest.raises((psycopg.DataError, psycopg.ProgrammingError)):
@@ -610,7 +632,7 @@ def test_scroll(conn):
 )
 def test_execute_params_named(conn, query, params, want):
     cur = conn.cursor()
-    cur.execute(query, params)
+    cur.execute(ph(cur, query), params)
     rec = cur.fetchone()
     assert rec == want
 
@@ -619,7 +641,7 @@ def test_stream(conn):
     cur = conn.cursor()
     recs = []
     for rec in cur.stream(
-        "select i, '2021-01-01'::date + i from generate_series(1, %s) as i",
+        ph(cur, "select i, '2021-01-01'::date + i from generate_series(1, %s) as i"),
         [2],
     ):
         recs.append(rec)

--- a/tests/test_cursor_async.py
+++ b/tests/test_cursor_async.py
@@ -16,7 +16,9 @@ from .fix_crdb import crdb_encoding
 execmany = execmany  # avoid F811 underneath
 
 
-@pytest.fixture(params=[psycopg.AsyncCursor, psycopg.AsyncClientCursor])
+@pytest.fixture(
+    params=[psycopg.AsyncCursor, psycopg.AsyncClientCursor, psycopg.AsyncRawCursor]
+)
 def aconn(aconn, request, anyio_backend):
     aconn.cursor_factory = request.param
     return aconn

--- a/tests/test_cursor_async.py
+++ b/tests/test_cursor_async.py
@@ -9,7 +9,7 @@ from psycopg.adapt import PyFormat
 from psycopg.types import TypeInfo
 
 from .utils import alist, gc_collect, raiseif
-from .test_cursor import my_row_factory
+from .test_cursor import my_row_factory, ph
 from .test_cursor import execmany, _execmany  # noqa: F401
 from .fix_crdb import crdb_encoding
 
@@ -165,7 +165,9 @@ async def test_execute_many_results(aconn):
 
 async def test_execute_sequence(aconn):
     cur = aconn.cursor()
-    rv = await cur.execute("select %s::int, %s::text, %s::text", [1, "foo", None])
+    rv = await cur.execute(
+        ph(cur, "select %s::int, %s::text, %s::text"), [1, "foo", None]
+    )
     assert rv is cur
     assert len(cur._results) == 1
     assert cur.pgresult.get_value(0, 0) == b"1"
@@ -186,8 +188,8 @@ async def test_execute_empty_query(aconn, query):
 async def test_execute_type_change(aconn):
     # issue #112
     await aconn.execute("create table bug_112 (num integer)")
-    sql = "insert into bug_112 (num) values (%s)"
     cur = aconn.cursor()
+    sql = ph(cur, "insert into bug_112 (num) values (%s)")
     await cur.execute(sql, (1,))
     await cur.execute(sql, (100_000,))
     await cur.execute("select num from bug_112 order by num")
@@ -196,8 +198,8 @@ async def test_execute_type_change(aconn):
 
 async def test_executemany_type_change(aconn):
     await aconn.execute("create table bug_112 (num integer)")
-    sql = "insert into bug_112 (num) values (%s)"
     cur = aconn.cursor()
+    sql = ph(cur, "insert into bug_112 (num) values (%s)")
     await cur.executemany(sql, [(1,), (100_000,)])
     await cur.execute("select num from bug_112 order by num")
     assert (await cur.fetchall()) == [(1,), (100_000,)]
@@ -215,7 +217,7 @@ async def test_execute_copy(aconn, query):
 
 async def test_fetchone(aconn):
     cur = aconn.cursor()
-    await cur.execute("select %s::int, %s::text, %s::text", [1, "foo", None])
+    await cur.execute(ph(cur, "select %s::int, %s::text, %s::text"), [1, "foo", None])
     assert cur.pgresult.fformat(0) == 0
 
     row = await cur.fetchone()
@@ -229,7 +231,7 @@ async def test_binary_cursor_execute(aconn):
         aconn.cursor_factory is psycopg.AsyncClientCursor, psycopg.NotSupportedError
     ) as ex:
         cur = aconn.cursor(binary=True)
-        await cur.execute("select %s, %s", [1, None])
+        await cur.execute(ph(cur, "select %s, %s"), [1, None])
     if ex:
         return
 
@@ -243,7 +245,7 @@ async def test_execute_binary(aconn):
     with raiseif(
         aconn.cursor_factory is psycopg.AsyncClientCursor, psycopg.NotSupportedError
     ) as ex:
-        await cur.execute("select %s, %s", [1, None], binary=True)
+        await cur.execute(ph(cur, "select %s, %s"), [1, None], binary=True)
     if ex:
         return
 
@@ -254,7 +256,7 @@ async def test_execute_binary(aconn):
 
 async def test_binary_cursor_text_override(aconn):
     cur = aconn.cursor(binary=True)
-    await cur.execute("select %s, %s", [1, None], binary=False)
+    await cur.execute(ph(cur, "select %s, %s"), [1, None], binary=False)
     assert (await cur.fetchone()) == (1, None)
     assert cur.pgresult.fformat(0) == 0
     assert cur.pgresult.get_value(0, 0) == b"1"
@@ -280,7 +282,7 @@ async def test_query_badenc(aconn, encoding):
 async def test_executemany(aconn, execmany):
     cur = aconn.cursor()
     await cur.executemany(
-        "insert into execmany(num, data) values (%s, %s)",
+        ph(cur, "insert into execmany(num, data) values (%s, %s)"),
         [(10, "hello"), (20, "world")],
     )
     await cur.execute("select num, data from execmany order by 1")
@@ -291,7 +293,7 @@ async def test_executemany(aconn, execmany):
 async def test_executemany_name(aconn, execmany):
     cur = aconn.cursor()
     await cur.executemany(
-        "insert into execmany(num, data) values (%(num)s, %(data)s)",
+        ph(cur, "insert into execmany(num, data) values (%(num)s, %(data)s)"),
         [{"num": 11, "data": "hello", "x": 1}, {"num": 21, "data": "world"}],
     )
     await cur.execute("select num, data from execmany order by 1")
@@ -301,14 +303,16 @@ async def test_executemany_name(aconn, execmany):
 
 async def test_executemany_no_data(aconn, execmany):
     cur = aconn.cursor()
-    await cur.executemany("insert into execmany(num, data) values (%s, %s)", [])
+    await cur.executemany(
+        ph(cur, "insert into execmany(num, data) values (%s, %s)"), []
+    )
     assert cur.rowcount == 0
 
 
 async def test_executemany_rowcount(aconn, execmany):
     cur = aconn.cursor()
     await cur.executemany(
-        "insert into execmany(num, data) values (%s, %s)",
+        ph(cur, "insert into execmany(num, data) values (%s, %s)"),
         [(10, "hello"), (20, "world")],
     )
     assert cur.rowcount == 2
@@ -317,7 +321,7 @@ async def test_executemany_rowcount(aconn, execmany):
 async def test_executemany_returning(aconn, execmany):
     cur = aconn.cursor()
     await cur.executemany(
-        "insert into execmany(num, data) values (%s, %s) returning num",
+        ph(cur, "insert into execmany(num, data) values (%s, %s) returning num"),
         [(10, "hello"), (20, "world")],
         returning=True,
     )
@@ -332,7 +336,7 @@ async def test_executemany_returning(aconn, execmany):
 async def test_executemany_returning_discard(aconn, execmany):
     cur = aconn.cursor()
     await cur.executemany(
-        "insert into execmany(num, data) values (%s, %s) returning num",
+        ph(cur, "insert into execmany(num, data) values (%s, %s) returning num"),
         [(10, "hello"), (20, "world")],
     )
     assert cur.rowcount == 2
@@ -344,7 +348,7 @@ async def test_executemany_returning_discard(aconn, execmany):
 async def test_executemany_no_result(aconn, execmany):
     cur = aconn.cursor()
     await cur.executemany(
-        "insert into execmany(num, data) values (%s, %s)",
+        ph(cur, "insert into execmany(num, data) values (%s, %s)"),
         [(10, "hello"), (20, "world")],
         returning=True,
     )
@@ -362,12 +366,12 @@ async def test_executemany_no_result(aconn, execmany):
 
 async def test_executemany_rowcount_no_hit(aconn, execmany):
     cur = aconn.cursor()
-    await cur.executemany("delete from execmany where id = %s", [(-1,), (-2,)])
+    await cur.executemany(ph(cur, "delete from execmany where id = %s"), [(-1,), (-2,)])
     assert cur.rowcount == 0
-    await cur.executemany("delete from execmany where id = %s", [])
+    await cur.executemany(ph(cur, "delete from execmany where id = %s"), [])
     assert cur.rowcount == 0
     await cur.executemany(
-        "delete from execmany where id = %s returning num", [(-1,), (-2,)]
+        ph(cur, "delete from execmany where id = %s returning num"), [(-1,), (-2,)]
     )
     assert cur.rowcount == 0
 
@@ -383,7 +387,7 @@ async def test_executemany_rowcount_no_hit(aconn, execmany):
 async def test_executemany_badquery(aconn, query):
     cur = aconn.cursor()
     with pytest.raises(psycopg.DatabaseError):
-        await cur.executemany(query, [(10, "hello"), (20, "world")])
+        await cur.executemany(ph(cur, query), [(10, "hello"), (20, "world")])
 
 
 @pytest.mark.parametrize("fmt_in", PyFormat)
@@ -391,12 +395,12 @@ async def test_executemany_null_first(aconn, fmt_in):
     cur = aconn.cursor()
     await cur.execute("create table testmany (a bigint, b bigint)")
     await cur.executemany(
-        f"insert into testmany values (%{fmt_in.value}, %{fmt_in.value})",
+        ph(cur, f"insert into testmany values (%{fmt_in.value}, %{fmt_in.value})"),
         [[1, None], [3, 4]],
     )
     with pytest.raises((psycopg.DataError, psycopg.ProgrammingError)):
         await cur.executemany(
-            f"insert into testmany values (%{fmt_in.value}, %{fmt_in.value})",
+            ph(cur, f"insert into testmany values (%{fmt_in.value}, %{fmt_in.value})"),
             [[1, ""], [3, 4]],
         )
 
@@ -599,7 +603,7 @@ async def test_scroll(aconn):
 )
 async def test_execute_params_named(aconn, query, params, want):
     cur = aconn.cursor()
-    await cur.execute(query, params)
+    await cur.execute(ph(cur, query), params)
     rec = await cur.fetchone()
     assert rec == want
 
@@ -608,7 +612,7 @@ async def test_stream(aconn):
     cur = aconn.cursor()
     recs = []
     async for rec in cur.stream(
-        "select i, '2021-01-01'::date + i from generate_series(1, %s) as i",
+        ph(cur, "select i, '2021-01-01'::date + i from generate_series(1, %s) as i"),
         [2],
     ):
         recs.append(rec)

--- a/tests/test_raw_cursor.py
+++ b/tests/test_raw_cursor.py
@@ -1,0 +1,112 @@
+import pytest
+import psycopg
+from psycopg import pq, rows, errors as e
+from psycopg.adapt import PyFormat
+
+from .test_cursor import ph
+from .utils import gc_collect, gc_count
+
+
+@pytest.fixture
+def conn(conn):
+    conn.cursor_factory = psycopg.RawCursor
+    return conn
+
+
+def test_default_cursor(conn):
+    cur = conn.cursor()
+    assert type(cur) is psycopg.RawCursor
+
+
+def test_str(conn):
+    cur = conn.cursor()
+    assert "psycopg.RawCursor" in str(cur)
+
+
+def test_sequence_only(conn):
+    cur = conn.cursor()
+    cur.execute("select 1", ())
+    assert cur.fetchone() == (1,)
+
+    with pytest.raises(TypeError, match="sequence"):
+        cur.execute("select 1", {})
+
+
+def test_execute_many_results_param(conn):
+    cur = conn.cursor()
+    # Postgres raises SyntaxError, CRDB raises InvalidPreparedStatementDefinition
+    with pytest.raises((e.SyntaxError, e.InvalidPreparedStatementDefinition)):
+        cur.execute("select $1; select generate_series(1, $2)", ("foo", 3))
+
+
+def test_query_params_execute(conn):
+    cur = conn.cursor()
+    assert cur._query is None
+
+    cur.execute("select $1, $2::text", [1, None])
+    assert cur._query is not None
+    assert cur._query.query == b"select $1, $2::text"
+    assert cur._query.params == [b"\x00\x01", None]
+
+    cur.execute("select 1")
+    assert cur._query.query == b"select 1"
+    assert not cur._query.params
+
+    with pytest.raises(psycopg.DataError):
+        cur.execute("select $1::int", ["wat"])
+
+    assert cur._query.query == b"select $1::int"
+    assert cur._query.params == [b"wat"]
+
+
+def test_query_params_executemany(conn):
+    cur = conn.cursor()
+
+    cur.executemany("select $1, $2", [[1, 2], [3, 4]])
+    assert cur._query.query == b"select $1, $2"
+    assert cur._query.params == [b"\x00\x03", b"\x00\x04"]
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("fmt", PyFormat)
+@pytest.mark.parametrize("fmt_out", pq.Format)
+@pytest.mark.parametrize("fetch", ["one", "many", "all", "iter"])
+@pytest.mark.parametrize("row_factory", ["tuple_row", "dict_row", "namedtuple_row"])
+def test_leak(conn_cls, dsn, faker, fmt, fmt_out, fetch, row_factory):
+    faker.format = fmt
+    faker.choose_schema(ncols=5)
+    faker.make_records(10)
+    row_factory = getattr(rows, row_factory)
+
+    def work():
+        with conn_cls.connect(dsn) as conn, conn.transaction(force_rollback=True):
+            with conn.cursor(binary=fmt_out, row_factory=row_factory) as cur:
+                cur.execute(faker.drop_stmt)
+                cur.execute(faker.create_stmt)
+                with faker.find_insert_problem(conn):
+                    cur.executemany(faker.insert_stmt, faker.records)
+                cur.execute(ph(cur, faker.select_stmt))
+
+                if fetch == "one":
+                    while True:
+                        tmp = cur.fetchone()
+                        if tmp is None:
+                            break
+                elif fetch == "many":
+                    while True:
+                        tmp = cur.fetchmany(3)
+                        if not tmp:
+                            break
+                elif fetch == "all":
+                    cur.fetchall()
+                elif fetch == "iter":
+                    for rec in cur:
+                        pass
+
+    n = []
+    gc_collect()
+    for i in range(3):
+        work()
+        gc_collect()
+        n.append(gc_count())
+    assert n[0] == n[1] == n[2], f"objects leaked: {n[1] - n[0]}, {n[2] - n[1]}"

--- a/tests/test_raw_cursor_async.py
+++ b/tests/test_raw_cursor_async.py
@@ -1,0 +1,113 @@
+import pytest
+import psycopg
+from psycopg import pq, rows, errors as e
+from psycopg.adapt import PyFormat
+
+from .test_cursor import ph
+from .utils import gc_collect, gc_count
+
+
+@pytest.fixture
+async def aconn(aconn, anyio_backend):
+    aconn.cursor_factory = psycopg.AsyncRawCursor
+    return aconn
+
+
+async def test_default_cursor(aconn):
+    cur = aconn.cursor()
+    assert type(cur) is psycopg.AsyncRawCursor
+
+
+async def test_str(aconn):
+    cur = aconn.cursor()
+    assert "psycopg.AsyncRawCursor" in str(cur)
+
+
+async def test_sequence_only(aconn):
+    cur = aconn.cursor()
+    await cur.execute("select 1", ())
+    assert await cur.fetchone() == (1,)
+
+    with pytest.raises(TypeError, match="sequence"):
+        await cur.execute("select 1", {})
+
+
+async def test_execute_many_results_param(aconn):
+    cur = aconn.cursor()
+    # Postgres raises SyntaxError, CRDB raises InvalidPreparedStatementDefinition
+    with pytest.raises((e.SyntaxError, e.InvalidPreparedStatementDefinition)):
+        await cur.execute("select $1; select generate_series(1, $2)", ("foo", 3))
+
+
+async def test_query_params_execute(aconn):
+    cur = aconn.cursor()
+    assert cur._query is None
+
+    await cur.execute("select $1, $2::text", [1, None])
+    assert cur._query is not None
+    assert cur._query.query == b"select $1, $2::text"
+    assert cur._query.params == [b"\x00\x01", None]
+
+    await cur.execute("select 1")
+    assert cur._query.query == b"select 1"
+    assert not cur._query.params
+
+    with pytest.raises(psycopg.DataError):
+        await cur.execute("select $1::int", ["wat"])
+
+    assert cur._query.query == b"select $1::int"
+    assert cur._query.params == [b"wat"]
+
+
+async def test_query_params_executemany(aconn):
+    cur = aconn.cursor()
+
+    await cur.executemany("select $1, $2", [[1, 2], [3, 4]])
+    assert cur._query.query == b"select $1, $2"
+    assert cur._query.params == [b"\x00\x03", b"\x00\x04"]
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("fmt", PyFormat)
+@pytest.mark.parametrize("fmt_out", pq.Format)
+@pytest.mark.parametrize("fetch", ["one", "many", "all", "iter"])
+@pytest.mark.parametrize("row_factory", ["tuple_row", "dict_row", "namedtuple_row"])
+async def test_leak(aconn_cls, dsn, faker, fmt, fmt_out, fetch, row_factory):
+    faker.format = fmt
+    faker.choose_schema(ncols=5)
+    faker.make_records(10)
+    row_factory = getattr(rows, row_factory)
+
+    async def work():
+        async with await aconn_cls.connect(dsn) as aconn:
+            async with aconn.transaction(force_rollback=True):
+                async with aconn.cursor(binary=fmt_out, row_factory=row_factory) as cur:
+                    await cur.execute(faker.drop_stmt)
+                    await cur.execute(faker.create_stmt)
+                    async with faker.find_insert_problem_async(aconn):
+                        await cur.executemany(faker.insert_stmt, faker.records)
+                    await cur.execute(ph(cur, faker.select_stmt))
+
+                    if fetch == "one":
+                        while True:
+                            tmp = await cur.fetchone()
+                            if tmp is None:
+                                break
+                    elif fetch == "many":
+                        while True:
+                            tmp = await cur.fetchmany(3)
+                            if not tmp:
+                                break
+                    elif fetch == "all":
+                        await cur.fetchall()
+                    elif fetch == "iter":
+                        async for rec in cur:
+                            pass
+
+    n = []
+    gc_collect()
+    for i in range(3):
+        await work()
+        gc_collect()
+        n.append(gc_count())
+    assert n[0] == n[1] == n[2], f"objects leaked: {n[1] - n[0]}, {n[2] - n[1]}"


### PR DESCRIPTION
This commit introduces support for raw queries with PostgreSQL's native placeholders ($1, $2, etc.) in psycopg3. By setting the use_raw_query attribute to True in a custom cursor class, users can enable the use of raw queries with native placeholders.

The code demonstrates how to create a custom RawQueryCursor class that sets the use_raw_query attribute to True. This custom cursor class can be set as the cursor_factory when connecting to the database, allowing users to choose between PostgreSQL's native placeholders or the standard %s placeholder in their queries. The code also demonstrates how both styles of placeholders can coexist. Test cases are included to verify the correct behavior of the new feature.

Modifications include changes to the PostgresQuery class, BaseCursor class, and the addition of a new test file test_use_raw_query.py. The documentation has been updated as well to reflect the new feature.