### PR TITLE
Mark test_ctrl_c_handler as timing sensitive

### DIFF
--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -241,6 +241,7 @@ def test_identify_closure(conn_cls, dsn):
 @pytest.mark.skipif(
     sys.platform == "win32", reason="don't know how to Ctrl-C on Windows"
 )
+@pytest.mark.timing
 @pytest.mark.crdb_skip("cancel")
 def test_ctrl_c_handler(dsn):
     if sys.platform == "win32":

--- a/tests/test_concurrency_async.py
+++ b/tests/test_concurrency_async.py
@@ -192,6 +192,7 @@ async def test_identify_closure(aconn_cls, dsn):
 @pytest.mark.skipif(
     sys.platform == "win32", reason="don't know how to Ctrl-C on Windows"
 )
+@pytest.mark.timing
 @pytest.mark.crdb_skip("cancel")
 def test_ctrl_c_handler(dsn):
     script = f"""\


### PR DESCRIPTION
ref https://github.com/NixOS/nixpkgs/pull/236281

```
psycopg> =================================== FAILURES =================================== psycopg> _____________________________ test_ctrl_c_handler ______________________________
psycopg>         t0 = time.time()
psycopg>         proc = sp.Popen([sys.executable, "-s", "-c", script], creationflags=creationflags)
psycopg>         proc.communicate()
psycopg>         t = time.time() - t0
psycopg>         assert proc.returncode == 0
psycopg> >       assert 1 < t < 2
psycopg> E       assert 3.7456982135772705 < 2
psycopg>
psycopg> tests/test_concurrency.py:293: AssertionError
```