### PR TITLE
chore: bump mypy to 1.4.1

### DIFF
--- a/psycopg/psycopg/rows.py
+++ b/psycopg/psycopg/rows.py
@@ -121,8 +121,7 @@ def dict_row(cursor: "BaseCursor[Any, Any]") -> "RowMaker[DictRow]":
         return no_result
 
     def dict_row_(values: Sequence[Any]) -> Dict[str, Any]:
-        # https://github.com/python/mypy/issues/2608
-        return dict(zip(names, values))  # type: ignore[arg-type]
+        return dict(zip(names, values))
 
     return dict_row_
 
@@ -169,7 +168,7 @@ def class_row(cls: Type[T]) -> BaseRowFactory[T]:
             return no_result
 
         def class_row__(values: Sequence[Any]) -> T:
-            return cls(**dict(zip(names, values)))  # type: ignore[arg-type]
+            return cls(**dict(zip(names, values)))
 
         return class_row__
 
@@ -205,7 +204,7 @@ def kwargs_row(func: Callable[..., T]) -> BaseRowFactory[T]:
             return no_result
 
         def kwargs_row__(values: Sequence[Any]) -> T:
-            return func(**dict(zip(names, values)))  # type: ignore[arg-type]
+            return func(**dict(zip(names, values)))
 
         return kwargs_row__
 

--- a/psycopg/setup.cfg
+++ b/psycopg/setup.cfg
@@ -66,7 +66,7 @@ pool =
     psycopg-pool
 test =
     anyio >= 3.6.2
-    mypy >= 1.2.0
+    mypy >= 1.4.1
     pproxy >= 2.7
     pytest >= 6.2.5
     pytest-cov >= 3.0
@@ -75,7 +75,7 @@ dev =
     black >= 23.1.0
     dnspython >= 2.1
     flake8 >= 4.0
-    mypy >= 1.2.0
+    mypy >= 1.4.1
     types-setuptools >= 57.4
     wheel >= 0.37
 docs =

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -10,7 +10,7 @@ importlib-metadata == 1.4
 
 # From the 'test' extra
 anyio == 3.6.2
-mypy == 1.2.0
+mypy == 1.4.1
 pproxy == 2.7.0
 pytest == 6.2.5
 pytest-cov == 3.0.0

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -51,7 +51,7 @@ def test_pipeline_reenter(conn: psycopg.Connection[Any]) -> None:
         assert p2 is p1
         assert p2.status == pq.PipelineStatus.ON
     assert conn._pipeline is None
-    assert p1.status == pq.PipelineStatus.OFF
+    assert p1.status == pq.PipelineStatus.OFF  # type: ignore[comparison-overlap]
 
 
 def test_pipeline_broken_conn_exit(conn: psycopg.Connection[Any]) -> None:

--- a/tests/test_pipeline_async.py
+++ b/tests/test_pipeline_async.py
@@ -51,7 +51,7 @@ async def test_pipeline_reenter(aconn: psycopg.AsyncConnection[Any]) -> None:
         assert p2 is p1
         assert p2.status == pq.PipelineStatus.ON
     assert aconn._pipeline is None
-    assert p1.status == pq.PipelineStatus.OFF
+    assert p1.status == pq.PipelineStatus.OFF  # type: ignore[comparison-overlap]
 
 
 async def test_pipeline_broken_conn_exit(aconn: psycopg.AsyncConnection[Any]) -> None:


### PR DESCRIPTION
The issue previously mentioned about '# type: ignore[arg-type]' in rows.py got resolved.

The new '# type: ignore[comparison-overlap]' in test_pipeline*.py are due to https://github.com/python/mypy/issues/15509, a known regression from Mypy 1.4. We use the workaround documented in the release blog post https://mypy-lang.blogspot.com/2023/06/mypy-140-released.html (section "Narrowing Enum Values Using “==”").