### PR TITLE
Fix resetting read_only and deferrable to default using None

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -23,6 +23,8 @@ Psycopg 3.1.10 (unreleased)
 - Fix possible (ignored) exception on objects deletion (:ticket:`#591`).
 - Don't clobber a Python exception raised during COPY FROM with the resulting
   `!QueryCanceled` raised as a consequence (:ticket:`#593`).
+- Fix resetting `Connection.read_only` and `~Connection.deferrable` to their
+  default value using `!None` (:ticket:`#612`).
 
 
 Current release

--- a/psycopg/psycopg/connection.py
+++ b/psycopg/psycopg/connection.py
@@ -231,7 +231,7 @@ class BaseConnection(Generic[Row]):
 
     def _set_read_only_gen(self, value: Optional[bool]) -> PQGen[None]:
         yield from self._check_intrans_gen("read_only")
-        self._read_only = bool(value)
+        self._read_only = bool(value) if value is not None else None
         self._begin_statement = b""
 
     @property
@@ -250,7 +250,7 @@ class BaseConnection(Generic[Row]):
 
     def _set_deferrable_gen(self, value: Optional[bool]) -> PQGen[None]:
         yield from self._check_intrans_gen("deferrable")
-        self._deferrable = bool(value)
+        self._deferrable = bool(value) if value is not None else None
         self._begin_statement = b""
 
     def _check_intrans_gen(self, attribute: str) -> PQGen[None]:


### PR DESCRIPTION
Reported by David Raymond in a private message:

> With the read_only and deferrable attributes of a connection it says in the docs
"None means use the default set in the default_transaction_<attribute> configuration parameter of the server."
>
> However, while they start out as None, you cannot explicitly change those to None. When you try, it explicitly turns your value into a bool, and bool(None) is False.
>
> In the pure python version this is in connection.py, lines 233 and 252.
>
> So there's no way to reset these attributes of a connection "back to the server default". Once you set it to anything it will always be True or False, and thus explicitly start each transaction with either "BEGIN READ ONLY" or "BEGIN READ WRITE", and never again with just "BEGIN".

Bug confirmed and reproduced in the test suite. Opening a Pull Request to assign it a number.