### PR TITLE
Pipeline nextset error and clobbering behaviour

### DIFF
--- a/docs/advanced/pipeline.rst
+++ b/docs/advanced/pipeline.rst
@@ -185,26 +185,8 @@ several operations, using `Connection.execute()`, `Cursor.execute()` and
 
 Unlike in normal mode, Psycopg will not wait for the server to receive the
 result of each query; the client will receive results in batches when the
-server flushes it output buffer.
-
-When a flush (or a sync) is performed, all pending results are sent back to
-the cursors which executed them. If a cursor had run more than one query, it
-will receive more than one result; results after the first will be available,
-in their execution order, using `~Cursor.nextset()`:
-
-.. code:: python
-
-    >>> with conn.pipeline():
-    ...     with conn.cursor() as cur:
-    ...        cur.execute("INSERT INTO mytable (data) VALUES (%s) RETURNING *", ["hello"])
-    ...        cur.execute("INSERT INTO mytable (data) VALUES (%s) RETURNING *", ["world"])
-    ...        while True:
-    ...            print(cur.fetchall())
-    ...            if not cur.nextset():
-    ...                break
-
-    [(1, 'hello')]
-    [(2, 'world')]
+server flushes it output buffer. You can receive more than a single result
+by using more than one cursor in the same pipeline.
 
 If any statement encounters an error, the server aborts the current
 transaction and will not execute any subsequent command in the queue until the

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -18,6 +18,8 @@ Psycopg 3.2 (unreleased)
 - Disable receiving more than one result on the same cursor in pipeline mode,
   to iterate through `~Cursor.nextset()`. The behaviour was different than
   in non-pipeline mode and not totally reliable (:ticket:`#604`).
+  The `Cursor` now only preserves the results set of the last
+  `~Cursor.execute()`, consistently with non-pipeline mode.
 
 
 Psycopg 3.1.10 (unreleased)

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -15,6 +15,9 @@ Psycopg 3.2 (unreleased)
 
 - Add support for libpq functions to close prepared statements and portals
   introduced in libpq v17 (:ticket:`#603`).
+- Disable receiving more than one result on the same cursor in pipeline mode,
+  to iterate through `~Cursor.nextset()`. The behaviour was different than
+  in non-pipeline mode and not totally reliable (:ticket:`#604`).
 
 
 Psycopg 3.1.10 (unreleased)

--- a/psycopg/psycopg/cursor.py
+++ b/psycopg/psycopg/cursor.py
@@ -9,7 +9,6 @@ from types import TracebackType
 from typing import Any, Generic, Iterable, Iterator, List
 from typing import Optional, NoReturn, Sequence, Tuple, Type, TypeVar
 from typing import overload, TYPE_CHECKING
-from warnings import warn
 from contextlib import contextmanager
 
 from . import pq
@@ -157,16 +156,17 @@ class BaseCursor(Generic[ConnectionType, Row]):
         Return `!True` if a new result is available, which will be the one
         methods `!fetch*()` will operate on.
         """
-        # Raise a warning if people is calling nextset() in pipeline mode
-        # after a sequence of execute() in pipeline mode. Pipeline accumulating
-        # execute() results in the cursor is an unintended difference w.r.t.
-        # non-pipeline mode.
+        # Python 3.1 would accumulate execute() results in the cursor, but it
+        # was an undesired difference with non-pipeline mode, so it was
+        # deprecated in 3.1.10; in 3.2 we moved to clobber previous execute()
+        # results and, because running multiple statements in the same
+        # execute() is not supported in pipeline mode, there is no reason to
+        # support nextset(). This error replaces the previous warning.
         if self._execmany_returning is None and self._conn._pipeline:
-            warn(
+            raise e.NotSupportedError(
                 "using nextset() in pipeline mode for several execute() is"
-                " deprecated and will be dropped in 3.2; please use different"
-                " cursors to receive more than one result",
-                DeprecationWarning,
+                " not supported. Please use several cursors to receive more"
+                " than one result"
             )
 
         if self._iresult < len(self._results) - 1:

--- a/psycopg/psycopg/cursor.py
+++ b/psycopg/psycopg/cursor.py
@@ -156,19 +156,6 @@ class BaseCursor(Generic[ConnectionType, Row]):
         Return `!True` if a new result is available, which will be the one
         methods `!fetch*()` will operate on.
         """
-        # Python 3.1 would accumulate execute() results in the cursor, but it
-        # was an undesired difference with non-pipeline mode, so it was
-        # deprecated in 3.1.10; in 3.2 we moved to clobber previous execute()
-        # results and, because running multiple statements in the same
-        # execute() is not supported in pipeline mode, there is no reason to
-        # support nextset(). This error replaces the previous warning.
-        if self._execmany_returning is None and self._conn._pipeline:
-            raise e.NotSupportedError(
-                "using nextset() in pipeline mode for several execute() is"
-                " not supported. Please use several cursors to receive more"
-                " than one result"
-            )
-
         if self._iresult < len(self._results) - 1:
             self._select_current_result(self._iresult + 1)
             return True

--- a/psycopg/psycopg/cursor.py
+++ b/psycopg/psycopg/cursor.py
@@ -529,17 +529,15 @@ class BaseCursor(Generic[ConnectionType, Row]):
         self._make_row = self._make_row_maker()
 
     def _set_results(self, results: List["PGresult"]) -> None:
-        first_batch = not self._results
-
         if self._execmany_returning is None:
             # Received from execute()
-            self._results.extend(results)
-            if first_batch:
-                self._select_current_result(0)
+            self._results[:] = results
+            self._select_current_result(0)
 
         else:
             # Received from executemany()
             if self._execmany_returning:
+                first_batch = not self._results
                 self._results.extend(results)
                 if first_batch:
                     self._select_current_result(0)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -595,7 +595,7 @@ def test_concurrency(conn):
     assert after > before
 
 
-def test_execute_nextset_warning(conn):
+def test_execute_nextset_error(conn):
     cur = conn.cursor()
     cur.execute("select 1")
     cur.execute("select 2")
@@ -608,8 +608,6 @@ def test_execute_nextset_warning(conn):
         cur.execute("select 1")
         cur.execute("select 2")
 
-        # WARNING: this behavior is unintentional and will be changed in 3.2
-        assert cur.fetchall() == [(1,)]
-        with pytest.warns(DeprecationWarning, match="nextset"):
-            assert cur.nextset()
         assert cur.fetchall() == [(2,)]
+        with pytest.raises(psycopg.NotSupportedError, match="nextset"):
+            assert cur.nextset()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -595,19 +595,12 @@ def test_concurrency(conn):
     assert after > before
 
 
-def test_execute_nextset_error(conn):
+def test_execute_nextset(conn):
     cur = conn.cursor()
-    cur.execute("select 1")
-    cur.execute("select 2")
-
-    assert cur.fetchall() == [(2,)]
-    assert not cur.nextset()
-    assert cur.fetchall() == []
-
     with conn.pipeline():
         cur.execute("select 1")
         cur.execute("select 2")
 
         assert cur.fetchall() == [(2,)]
-        with pytest.raises(psycopg.NotSupportedError, match="nextset"):
-            assert cur.nextset()
+        assert not cur.nextset()
+        assert cur.fetchall() == []

--- a/tests/test_pipeline_async.py
+++ b/tests/test_pipeline_async.py
@@ -603,7 +603,7 @@ async def test_concurrency(aconn):
     assert after > before
 
 
-async def test_execute_nextset_warning(aconn):
+async def test_execute_nextset_error(aconn):
     cur = aconn.cursor()
     await cur.execute("select 1")
     await cur.execute("select 2")
@@ -616,8 +616,6 @@ async def test_execute_nextset_warning(aconn):
         await cur.execute("select 1")
         await cur.execute("select 2")
 
-        # WARNING: this behavior is unintentional and will be changed in 3.2
-        assert (await cur.fetchall()) == [(1,)]
-        with pytest.warns(DeprecationWarning, match="nextset"):
-            assert cur.nextset()
         assert (await cur.fetchall()) == [(2,)]
+        with pytest.raises(psycopg.NotSupportedError, match="nextset"):
+            assert cur.nextset()

--- a/tests/test_pipeline_async.py
+++ b/tests/test_pipeline_async.py
@@ -603,19 +603,12 @@ async def test_concurrency(aconn):
     assert after > before
 
 
-async def test_execute_nextset_error(aconn):
+async def test_execute_nextset(aconn):
     cur = aconn.cursor()
-    await cur.execute("select 1")
-    await cur.execute("select 2")
-
-    assert (await cur.fetchall()) == [(2,)]
-    assert not cur.nextset()
-    assert (await cur.fetchall()) == []
-
     async with aconn.pipeline():
         await cur.execute("select 1")
         await cur.execute("select 2")
 
         assert (await cur.fetchall()) == [(2,)]
-        with pytest.raises(psycopg.NotSupportedError, match="nextset"):
-            assert cur.nextset()
+        assert not cur.nextset()
+        assert (await cur.fetchall()) == []


### PR DESCRIPTION
As described in #604, we want to replace the accumulation behaviour of cursors in pipeline mode with the normal clobbering behaviour.

This MR, at this moment, only replaces the `nextset()` warning introduced in #613 with an error.

The clobbering behaviour is not implemented yet. @dlax, is it something you could contribute?