### PR TITLE
Mark two more tests as timing-sensitive

### DIFF
--- a/tests/pool/test_pool.py
+++ b/tests/pool/test_pool.py
@@ -845,6 +845,7 @@ def test_shrink(dsn, monkeypatch):
 
 
 @pytest.mark.slow
+@pytest.mark.timing
 def test_reconnect(proxy, caplog, monkeypatch):
     caplog.set_level(logging.WARNING, logger="psycopg.pool")
 

--- a/tests/pool/test_pool_async.py
+++ b/tests/pool/test_pool_async.py
@@ -797,6 +797,7 @@ async def test_shrink(dsn, monkeypatch):
 
 
 @pytest.mark.slow
+@pytest.mark.timing
 async def test_reconnect(proxy, caplog, monkeypatch):
     caplog.set_level(logging.WARNING, logger="psycopg.pool")
 


### PR DESCRIPTION
We have pretty busy builders it seems.

```
FAILED tests/pool/test_pool_async.py::test_reconnect[asyncio] - AssertionError: [0.11509847640991211, 0.2041318416595459, 0.40631914138793945]
FAILED tests/pool/test_pool.py::test_reconnect - ValueError: the proxy didn't start listening in time
```

Full log: https://gist.github.com/mweinelt/046825bd23758ba799459077f117d1ba