### PR TITLE
fix!: only keep results of last execute() by a cursor in pipeline mode

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -16,6 +16,8 @@ Psycopg 3.2 (unreleased)
 - Disable receiving more than one result on the same cursor in pipeline mode,
   to iterate through `~Cursor.nextset()`. The behaviour was different than
   in non-pipeline mode and not totally reliable (:ticket:`#604`).
+  The `Cursor` now only preserves the results set of the last
+  `~Cursor.execute()`, consistently with non-pipeline mode.
 
 
 Psycopg 3.1.10 (unreleased)

--- a/psycopg/psycopg/cursor.py
+++ b/psycopg/psycopg/cursor.py
@@ -529,17 +529,15 @@ class BaseCursor(Generic[ConnectionType, Row]):
         self._make_row = self._make_row_maker()
 
     def _set_results(self, results: List["PGresult"]) -> None:
-        first_batch = not self._results
-
         if self._execmany_returning is None:
             # Received from execute()
-            self._results.extend(results)
-            if first_batch:
-                self._select_current_result(0)
+            self._results[:] = results
+            self._select_current_result(0)
 
         else:
             # Received from executemany()
             if self._execmany_returning:
+                first_batch = not self._results
                 self._results.extend(results)
                 if first_batch:
                     self._select_current_result(0)


### PR DESCRIPTION
The assertion on fetchall() in 'test_execute_nextset_error' now passes.

Fixes #604.

Based on #614.