### PR TITLE
Include py312 in binary builds

### DIFF
--- a/.github/workflows/packages-bin.yml
+++ b/.github/workflows/packages-bin.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: [x86_64, i686, ppc64le, aarch64]
-        pyver: [cp37, cp38, cp39, cp310, cp311]
+        pyver: [cp37, cp38, cp39, cp310, cp311, cp312]
         platform: [manylinux, musllinux]
 
     steps:
@@ -101,7 +101,7 @@ jobs:
       matrix:
         # These archs require an Apple M1 runner: [arm64, universal2]
         arch: [x86_64]
-        pyver: [cp37, cp38, cp39, cp310, cp311]
+        pyver: [cp37, cp38, cp39, cp310, cp311, cp312]
 
     steps:
       - uses: actions/checkout@v3
@@ -142,7 +142,7 @@ jobs:
       matrix:
         # Might want to add win32, untested at the moment.
         arch: [win_amd64]
-        pyver: [cp37, cp38, cp39, cp310, cp311]
+        pyver: [cp37, cp38, cp39, cp310, cp311, cp312]
 
     steps:
       - uses: actions/checkout@v3

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -24,6 +24,7 @@ Psycopg 3.2 (unreleased)
   in non-pipeline mode and not totally reliable (:ticket:`#604`).
   The `Cursor` now only preserves the results set of the last
   `~Cursor.execute()`, consistently with non-pipeline mode.
+- Add support for psycopg[binary] for Python 3.12.
 
 .. __: https://numpy.org/doc/stable/reference/arrays.scalars.html#built-in-scalar-types
 


### PR DESCRIPTION
~~This also updates tests to use RC1 for Python 3.12~~ I dropped this change as it broke the build.

Closes #626