### PR TITLE
* fix integer overflow for oids > 2^31

### DIFF
--- a/psycopg_c/psycopg_c/_psycopg/adapt.pyx
+++ b/psycopg_c/psycopg_c/_psycopg/adapt.pyx
@@ -148,7 +148,7 @@ cdef class CLoader:
     cdef public libpq.Oid oid
     cdef pq.PGconn _pgconn
 
-    def __cinit__(self, int oid, context: Optional[AdaptContext] = None):
+    def __cinit__(self, libpq.Oid oid, context: Optional[AdaptContext] = None):
         self.oid = oid
         conn = context.connection if context is not None else None
         self._pgconn = conn.pgconn if conn is not None else None


### PR DESCRIPTION
In the current production release of psycopg3 (3.1.10), when a database has user defined types for which the assigned oid is > 2^31, the below stack trace is produced when processing rows which contain columns of said type:

```  
  ...
  ...
  ...
  File "psycopg_c/_psycopg/transform.pyx", line 133, in psycopg_c._psycopg.Transformer.set_pgresult
  File "psycopg_c/_psycopg/transform.pyx", line 168, in psycopg_c._psycopg.Transformer.set_pgresult
  File "psycopg_c/_psycopg/transform.pyx", line 609, in psycopg_c._psycopg.Transformer._c_get_loader
  File "psycopg_c/_psycopg/adapt.pyx", line 151, in psycopg_c._psycopg.CLoader.__cinit__
OverflowError: value too large to convert to int
```

This appears to be due to the incorrect use of (signed) int for the `__cinit__` oid parameter. Changing this to libpq.Oid (alias for unsigned int which is what the oid type is documented as in the official postgres documentation) fixes the issue.

https://www.postgresql.org/docs/current/datatype-oid.html
`The oid type is currently implemented as an unsigned four-byte integer.`

Please advise if this can be merged for future releases, as well as into any 3.1.x maintenance release, and thanks for the great work on psycopg3!

I could not find documentation on how to submit this report and fix, so I forked the repo and am opening this PR.
