### PR TITLE
fix: support solaris and derivatives (#632)

### DIFF
--- a/psycopg_c/psycopg_c/_psycopg/endian.pxd
+++ b/psycopg_c/psycopg_c/_psycopg/endian.pxd
@@ -131,6 +131,8 @@ cdef extern from * nogil:
 #	define __LITTLE_ENDIAN LITTLE_ENDIAN
 #	define __PDP_ENDIAN    PDP_ENDIAN
 
+#elif defined(__sun)
+#	include <endian.h>
 #else
 
 #	error platform not supported


### PR DESCRIPTION
Fix compilation on solaris-based platforms (tested on SmartOS, should work on Illumos as well).

Very minor compilation issue.

#632 