### PR TITLE
None returning dumper

### DIFF
--- a/docs/advanced/adapt.rst
+++ b/docs/advanced/adapt.rst
@@ -146,6 +146,34 @@ you only need to implement the `~psycopg.abc.Dumper.dump()` method::
         <TypeInfo: hstore (oid: 770082, array oid: 770087)>
 
 
+.. _adapt-example-null-str:
+
+Example: converting empty strings to NULL
+-----------------------------------------
+
+.. versionchanged:: 3.2
+
+    The `dump()` method can also return `!None`, which will be stored as
+    :sql:`NULL` in the database.
+
+If you prefer to store missing values as :sql:`NULL`, in the database, but
+your input may contain empty strings, you can subclass the stock string dumper
+to return `!None` upon empty or whitespace-only strings::
+
+    >>> from psycopg.types.string import StrDumper
+
+    >>> class NullStrDumper(StrDumper):
+    ...     def dump(self, obj):
+    ...         if not obj or obj.isspace():
+    ...             return None
+    ...         return super().dump(obj)
+
+    >>> conn.adapters.register_dumper(str, NullStrDumper)
+
+    >>> conn.execute("select %s, %s, %s, %s", ("foo", "", "bar", "  ")).fetchone()
+    ('foo', None, 'bar', None)
+
+
 .. _adapt-example-float:
 
 Example: PostgreSQL numeric to Python float

--- a/docs/api/abc.rst
+++ b/docs/api/abc.rst
@@ -25,6 +25,11 @@ checking.
         The format returned by dump shouldn't contain quotes or escaped
         values.
 
+        .. versionchanged:: 3.2
+
+            `!dump()` can also return `!None`, to represent a :sql:`NULL` in
+            the database.
+
     .. automethod:: quote
 
         .. tip::

--- a/docs/api/adapt.rst
+++ b/docs/api/adapt.rst
@@ -28,6 +28,11 @@ Dumpers and loaders
 
     .. automethod:: dump
 
+        .. versionchanged:: 3.2
+
+            `!dump()` can also return `!None`, to represent a :sql:`NULL` in
+            the database.
+
     .. attribute:: format
         :type: psycopg.pq.Format
         :value: TEXT

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -17,6 +17,7 @@ Psycopg 3.2 (unreleased)
   (:ticket:`#332`).
 - Add `!timeout` and `!stop_after` parameters to `Connection.notifies()`
   (:ticket:`340`).
+- Allow dumpers to return `!None`, to be converted to NULL (:ticket:`#377`).
 - Add :ref:`raw-query-cursors` to execute queries using placeholders in
   PostgreSQL format (`$1`, `$2`...) (:ticket:`#560`).
 - Add `psycopg.capabilities` object to :ref:`inspect the libpq capabilities

--- a/psycopg/psycopg/abc.py
+++ b/psycopg/psycopg/abc.py
@@ -62,7 +62,7 @@ class WaitFunc(Protocol):
 
 # Adaptation types
 
-DumpFunc: TypeAlias = Callable[[Any], Buffer]
+DumpFunc: TypeAlias = Callable[[Any], Optional[Buffer]]
 LoadFunc: TypeAlias = Callable[[Buffer], Any]
 
 
@@ -110,7 +110,7 @@ class Dumper(Protocol):
 
     def __init__(self, cls: type, context: Optional[AdaptContext] = None): ...
 
-    def dump(self, obj: Any) -> Buffer:
+    def dump(self, obj: Any) -> Optional[Buffer]:
         """Convert the object `!obj` to PostgreSQL representation.
 
         :param obj: the object to convert.

--- a/psycopg/psycopg/adapt.py
+++ b/psycopg/psycopg/adapt.py
@@ -56,6 +56,8 @@ class Dumper(abc.Dumper, ABC):
         subclass.
         """
         value = self.dump(obj)
+        if value is None:
+            return b"NULL"
 
         if self.connection:
             esc = pq.Escaping(self.connection.pgconn)

--- a/psycopg/psycopg/adapt.py
+++ b/psycopg/psycopg/adapt.py
@@ -46,7 +46,7 @@ class Dumper(abc.Dumper, ABC):
         )
 
     @abstractmethod
-    def dump(self, obj: Any) -> Buffer: ...
+    def dump(self, obj: Any) -> Optional[Buffer]: ...
 
     def quote(self, obj: Any) -> Buffer:
         """

--- a/psycopg/psycopg/dbapi20.py
+++ b/psycopg/psycopg/dbapi20.py
@@ -7,7 +7,7 @@ Compatibility objects with DBAPI 2.0
 import time
 import datetime as dt
 from math import floor
-from typing import Any, Sequence, Union
+from typing import Any, Optional, Sequence, Union
 
 from . import _oids
 from .abc import AdaptContext, Buffer
@@ -76,7 +76,7 @@ class Binary:
 
 
 class BinaryBinaryDumper(BytesBinaryDumper):
-    def dump(self, obj: Union[Buffer, Binary]) -> Buffer:
+    def dump(self, obj: Union[Buffer, Binary]) -> Optional[Buffer]:
         if isinstance(obj, Binary):
             return super().dump(obj.obj)
         else:
@@ -84,7 +84,7 @@ class BinaryBinaryDumper(BytesBinaryDumper):
 
 
 class BinaryTextDumper(BytesDumper):
-    def dump(self, obj: Union[Buffer, Binary]) -> Buffer:
+    def dump(self, obj: Union[Buffer, Binary]) -> Optional[Buffer]:
         if isinstance(obj, Binary):
             return super().dump(obj.obj)
         else:

--- a/psycopg/psycopg/types/array.py
+++ b/psycopg/psycopg/types/array.py
@@ -153,7 +153,7 @@ class ListDumper(BaseListDumper):
     # backslash-escaped.
     _re_esc = re.compile(rb'(["\\])')
 
-    def dump(self, obj: List[Any]) -> bytes:
+    def dump(self, obj: List[Any]) -> Optional[Buffer]:
         tokens: List[Buffer] = []
         needs_quotes = _get_needs_quotes_regexp(self.delimiter).search
 
@@ -245,7 +245,7 @@ class ListBinaryDumper(BaseListDumper):
 
         return dumper
 
-    def dump(self, obj: List[Any]) -> bytes:
+    def dump(self, obj: List[Any]) -> Optional[Buffer]:
         # Postgres won't take unknown for element oid: fall back on text
         sub_oid = self.sub_dumper and self.sub_dumper.oid or TEXT_OID
 

--- a/psycopg/psycopg/types/bool.py
+++ b/psycopg/psycopg/types/bool.py
@@ -5,6 +5,7 @@ Adapters for booleans.
 # Copyright (C) 2020 The Psycopg Team
 
 from .. import _oids
+from typing import Optional
 from ..pq import Format
 from ..abc import AdaptContext
 from ..adapt import Buffer, Dumper, Loader
@@ -13,10 +14,10 @@ from ..adapt import Buffer, Dumper, Loader
 class BoolDumper(Dumper):
     oid = _oids.BOOL_OID
 
-    def dump(self, obj: bool) -> bytes:
+    def dump(self, obj: bool) -> Optional[Buffer]:
         return b"t" if obj else b"f"
 
-    def quote(self, obj: bool) -> bytes:
+    def quote(self, obj: bool) -> Buffer:
         return b"true" if obj else b"false"
 
 
@@ -24,7 +25,7 @@ class BoolBinaryDumper(Dumper):
     format = Format.BINARY
     oid = _oids.BOOL_OID
 
-    def dump(self, obj: bool) -> bytes:
+    def dump(self, obj: bool) -> Optional[Buffer]:
         return b"\x01" if obj else b"\x00"
 
 

--- a/psycopg/psycopg/types/composite.py
+++ b/psycopg/psycopg/types/composite.py
@@ -97,7 +97,9 @@ class SequenceDumper(RecursiveDumper):
 
             dumper = self._tx.get_dumper(item, PyFormat.from_pq(self.format))
             ad = dumper.dump(item)
-            if not ad:
+            if ad is None:
+                ad = b""
+            elif not ad:
                 ad = b'""'
             elif self._re_needs_quotes.search(ad):
                 ad = b'"' + self._re_esc.sub(rb"\1\1", ad) + b'"'

--- a/psycopg/psycopg/types/composite.py
+++ b/psycopg/psycopg/types/composite.py
@@ -14,7 +14,7 @@ from .. import pq
 from .. import abc
 from .. import sql
 from .. import postgres
-from ..adapt import Transformer, PyFormat, RecursiveDumper, Loader, Dumper
+from ..adapt import Transformer, PyFormat, RecursiveDumper, Loader, Dumper, Buffer
 from .._oids import TEXT_OID
 from .._compat import cache
 from .._struct import pack_len, unpack_len
@@ -117,7 +117,7 @@ class TupleDumper(SequenceDumper):
     # Should be this, but it doesn't work
     # oid = _oids.RECORD_OID
 
-    def dump(self, obj: Tuple[Any, ...]) -> bytes:
+    def dump(self, obj: Tuple[Any, ...]) -> Optional[Buffer]:
         return self._dump_sequence(obj, b"(", b")", b",")
 
 
@@ -140,7 +140,7 @@ class TupleBinaryDumper(Dumper):
         nfields = len(self._field_types)
         self._formats = (PyFormat.from_pq(self.format),) * nfields
 
-    def dump(self, obj: Tuple[Any, ...]) -> bytearray:
+    def dump(self, obj: Tuple[Any, ...]) -> Optional[Buffer]:
         out = bytearray(pack_len(len(obj)))
         adapted = self._tx.dump_sequence(obj, self._formats)
         for i in range(len(obj)):

--- a/psycopg/psycopg/types/datetime.py
+++ b/psycopg/psycopg/types/datetime.py
@@ -40,7 +40,7 @@ _py_date_min_days = date.min.toordinal()
 class DateDumper(Dumper):
     oid = _oids.DATE_OID
 
-    def dump(self, obj: date) -> bytes:
+    def dump(self, obj: date) -> Optional[Buffer]:
         # NOTE: whatever the PostgreSQL DateStyle input format (DMY, MDY, YMD)
         # the YYYY-MM-DD is always understood correctly.
         return str(obj).encode()
@@ -50,7 +50,7 @@ class DateBinaryDumper(Dumper):
     format = Format.BINARY
     oid = _oids.DATE_OID
 
-    def dump(self, obj: date) -> bytes:
+    def dump(self, obj: date) -> Optional[Buffer]:
         days = obj.toordinal() - _pg_date_epoch_days
         return pack_int4(days)
 
@@ -77,7 +77,7 @@ class _BaseTimeDumper(Dumper):
 
 
 class _BaseTimeTextDumper(_BaseTimeDumper):
-    def dump(self, obj: time) -> bytes:
+    def dump(self, obj: time) -> Optional[Buffer]:
         return str(obj).encode()
 
 
@@ -94,7 +94,7 @@ class TimeDumper(_BaseTimeTextDumper):
 class TimeTzDumper(_BaseTimeTextDumper):
     oid = _oids.TIMETZ_OID
 
-    def dump(self, obj: time) -> bytes:
+    def dump(self, obj: time) -> Optional[Buffer]:
         self._get_offset(obj)
         return super().dump(obj)
 
@@ -103,7 +103,7 @@ class TimeBinaryDumper(_BaseTimeDumper):
     format = Format.BINARY
     oid = _oids.TIME_OID
 
-    def dump(self, obj: time) -> bytes:
+    def dump(self, obj: time) -> Optional[Buffer]:
         us = obj.microsecond + 1_000_000 * (
             obj.second + 60 * (obj.minute + 60 * obj.hour)
         )
@@ -120,7 +120,7 @@ class TimeTzBinaryDumper(_BaseTimeDumper):
     format = Format.BINARY
     oid = _oids.TIMETZ_OID
 
-    def dump(self, obj: time) -> bytes:
+    def dump(self, obj: time) -> Optional[Buffer]:
         us = obj.microsecond + 1_000_000 * (
             obj.second + 60 * (obj.minute + 60 * obj.hour)
         )
@@ -142,7 +142,7 @@ class _BaseDatetimeDumper(Dumper):
 
 
 class _BaseDatetimeTextDumper(_BaseDatetimeDumper):
-    def dump(self, obj: datetime) -> bytes:
+    def dump(self, obj: datetime) -> Optional[Buffer]:
         # NOTE: whatever the PostgreSQL DateStyle input format (DMY, MDY, YMD)
         # the YYYY-MM-DD is always understood correctly.
         return str(obj).encode()
@@ -166,7 +166,7 @@ class DatetimeBinaryDumper(_BaseDatetimeDumper):
     format = Format.BINARY
     oid = _oids.TIMESTAMPTZ_OID
 
-    def dump(self, obj: datetime) -> bytes:
+    def dump(self, obj: datetime) -> Optional[Buffer]:
         delta = obj - _pg_datetimetz_epoch
         micros = delta.microseconds + 1_000_000 * (86_400 * delta.days + delta.seconds)
         return pack_int8(micros)
@@ -182,7 +182,7 @@ class DatetimeNoTzBinaryDumper(_BaseDatetimeDumper):
     format = Format.BINARY
     oid = _oids.TIMESTAMP_OID
 
-    def dump(self, obj: datetime) -> bytes:
+    def dump(self, obj: datetime) -> Optional[Buffer]:
         delta = obj - _pg_datetime_epoch
         micros = delta.microseconds + 1_000_000 * (86_400 * delta.days + delta.seconds)
         return pack_int8(micros)
@@ -198,7 +198,7 @@ class TimedeltaDumper(Dumper):
         else:
             self._dump_method = self._dump_any
 
-    def dump(self, obj: timedelta) -> bytes:
+    def dump(self, obj: timedelta) -> Optional[Buffer]:
         return self._dump_method(self, obj)
 
     @staticmethod
@@ -222,7 +222,7 @@ class TimedeltaBinaryDumper(Dumper):
     format = Format.BINARY
     oid = _oids.INTERVAL_OID
 
-    def dump(self, obj: timedelta) -> bytes:
+    def dump(self, obj: timedelta) -> Optional[Buffer]:
         micros = 1_000_000 * obj.seconds + obj.microseconds
         return _pack_interval(micros, obj.days, 0)
 

--- a/psycopg/psycopg/types/enum.py
+++ b/psycopg/psycopg/types/enum.py
@@ -98,7 +98,7 @@ class _BaseEnumDumper(Dumper, Generic[E]):
     enum: Type[E]
     _dump_map: EnumDumpMap[E]
 
-    def dump(self, value: E) -> Buffer:
+    def dump(self, value: E) -> Optional[Buffer]:
         return self._dump_map[value]
 
 
@@ -111,7 +111,7 @@ class EnumDumper(Dumper):
         super().__init__(cls, context)
         self._encoding = conn_encoding(self.connection)
 
-    def dump(self, value: E) -> Buffer:
+    def dump(self, value: E) -> Optional[Buffer]:
         return value.name.encode(self._encoding)
 
 

--- a/psycopg/psycopg/types/hstore.py
+++ b/psycopg/psycopg/types/hstore.py
@@ -39,7 +39,7 @@ Hstore: TypeAlias = Dict[str, Optional[str]]
 
 
 class BaseHstoreDumper(RecursiveDumper):
-    def dump(self, obj: Hstore) -> Buffer:
+    def dump(self, obj: Hstore) -> Optional[Buffer]:
         if not obj:
             return b""
 

--- a/psycopg/psycopg/types/json.py
+++ b/psycopg/psycopg/types/json.py
@@ -142,7 +142,7 @@ class _JsonDumper(Dumper):
         super().__init__(cls, context)
         self.dumps = self.__class__._dumps
 
-    def dump(self, obj: Any) -> bytes:
+    def dump(self, obj: Any) -> Optional[Buffer]:
         if isinstance(obj, _JsonWrapper):
             dumps = obj.dumps or self.dumps
             obj = obj.obj
@@ -171,7 +171,7 @@ class JsonbBinaryDumper(_JsonDumper):
     format = Format.BINARY
     oid = _oids.JSONB_OID
 
-    def dump(self, obj: Any) -> bytes:
+    def dump(self, obj: Any) -> Optional[Buffer]:
         return b"\x01" + super().dump(obj)
 
 

--- a/psycopg/psycopg/types/json.py
+++ b/psycopg/psycopg/types/json.py
@@ -172,7 +172,11 @@ class JsonbBinaryDumper(_JsonDumper):
     oid = _oids.JSONB_OID
 
     def dump(self, obj: Any) -> Optional[Buffer]:
-        return b"\x01" + super().dump(obj)
+        obj_bytes = super().dump(obj)
+        if obj_bytes is not None:
+            return b"\x01" + obj_bytes
+        else:
+            return None
 
 
 class _JsonLoader(Loader):

--- a/psycopg/psycopg/types/multirange.py
+++ b/psycopg/psycopg/types/multirange.py
@@ -256,7 +256,7 @@ class MultirangeDumper(BaseMultirangeDumper):
     The dumper can upgrade to one specific for a different range type.
     """
 
-    def dump(self, obj: Multirange[Any]) -> Buffer:
+    def dump(self, obj: Multirange[Any]) -> Optional[Buffer]:
         if not obj:
             return b"{}"
 
@@ -277,7 +277,7 @@ class MultirangeDumper(BaseMultirangeDumper):
 class MultirangeBinaryDumper(BaseMultirangeDumper):
     format = Format.BINARY
 
-    def dump(self, obj: Multirange[Any]) -> Buffer:
+    def dump(self, obj: Multirange[Any]) -> Optional[Buffer]:
         item = self._get_item(obj)
         if item is not None:
             dump = self._tx.get_dumper(item, self._adapt_format).dump

--- a/psycopg/psycopg/types/net.py
+++ b/psycopg/psycopg/types/net.py
@@ -52,14 +52,14 @@ class _LazyIpaddress:
 class InterfaceDumper(Dumper):
     oid = _oids.INET_OID
 
-    def dump(self, obj: Interface) -> bytes:
+    def dump(self, obj: Interface) -> Optional[Buffer]:
         return str(obj).encode()
 
 
 class NetworkDumper(Dumper):
     oid = _oids.CIDR_OID
 
-    def dump(self, obj: Network) -> bytes:
+    def dump(self, obj: Network) -> Optional[Buffer]:
         return str(obj).encode()
 
 
@@ -69,7 +69,7 @@ class _AIBinaryDumper(Dumper):
 
 
 class AddressBinaryDumper(_AIBinaryDumper):
-    def dump(self, obj: Address) -> bytes:
+    def dump(self, obj: Address) -> Optional[Buffer]:
         packed = obj.packed
         family = PGSQL_AF_INET if obj.version == 4 else PGSQL_AF_INET6
         head = bytes((family, obj.max_prefixlen, 0, len(packed)))
@@ -77,7 +77,7 @@ class AddressBinaryDumper(_AIBinaryDumper):
 
 
 class InterfaceBinaryDumper(_AIBinaryDumper):
-    def dump(self, obj: Interface) -> bytes:
+    def dump(self, obj: Interface) -> Optional[Buffer]:
         packed = obj.packed
         family = PGSQL_AF_INET if obj.version == 4 else PGSQL_AF_INET6
         head = bytes((family, obj.network.prefixlen, 0, len(packed)))
@@ -94,7 +94,7 @@ class InetBinaryDumper(_AIBinaryDumper, _LazyIpaddress):
         super().__init__(cls, context)
         self._ensure_module()
 
-    def dump(self, obj: Union[Address, Interface]) -> bytes:
+    def dump(self, obj: Union[Address, Interface]) -> Optional[Buffer]:
         packed = obj.packed
         family = PGSQL_AF_INET if obj.version == 4 else PGSQL_AF_INET6
         if isinstance(obj, (IPv4Interface, IPv6Interface)):
@@ -110,7 +110,7 @@ class NetworkBinaryDumper(Dumper):
     format = Format.BINARY
     oid = _oids.CIDR_OID
 
-    def dump(self, obj: Network) -> bytes:
+    def dump(self, obj: Network) -> Optional[Buffer]:
         packed = obj.network_address.packed
         family = PGSQL_AF_INET if obj.version == 4 else PGSQL_AF_INET6
         head = bytes((family, obj.prefixlen, 1, len(packed)))

--- a/psycopg/psycopg/types/none.py
+++ b/psycopg/psycopg/types/none.py
@@ -4,7 +4,9 @@ Adapters for None.
 
 # Copyright (C) 2020 The Psycopg Team
 
-from ..abc import AdaptContext, NoneType
+from typing import Optional
+
+from ..abc import AdaptContext, NoneType, Buffer
 from ..adapt import Dumper
 
 
@@ -14,10 +16,10 @@ class NoneDumper(Dumper):
     quote(), so it can be used in sql composition.
     """
 
-    def dump(self, obj: None) -> bytes:
+    def dump(self, obj: None) -> Optional[Buffer]:
         raise NotImplementedError("NULL is passed to Postgres in other ways")
 
-    def quote(self, obj: None) -> bytes:
+    def quote(self, obj: None) -> Buffer:
         return b"NULL"
 
 

--- a/psycopg/psycopg/types/numeric.py
+++ b/psycopg/psycopg/types/numeric.py
@@ -38,16 +38,18 @@ if TYPE_CHECKING:
 
 
 class _IntDumper(Dumper):
-    def dump(self, obj: Any) -> Buffer:
+    def dump(self, obj: Any) -> Optional[Buffer]:
         return str(obj).encode()
 
     def quote(self, obj: Any) -> Buffer:
         value = self.dump(obj)
+        if value is None:
+            return b"NULL"
         return value if obj >= 0 else b" " + value
 
 
 class _IntOrSubclassDumper(_IntDumper):
-    def dump(self, obj: Any) -> Buffer:
+    def dump(self, obj: Any) -> Optional[Buffer]:
         t = type(obj)
         # Convert to int in order to dump IntEnum or numpy.integer correctly
         if t is not int:
@@ -59,12 +61,16 @@ class _IntOrSubclassDumper(_IntDumper):
 class _SpecialValuesDumper(Dumper):
     _special: Dict[bytes, bytes] = {}
 
-    def dump(self, obj: Any) -> bytes:
+    def dump(self, obj: Any) -> Optional[Buffer]:
         return str(obj).encode()
 
-    def quote(self, obj: Any) -> bytes:
+    def quote(self, obj: Any) -> Buffer:
         value = self.dump(obj)
 
+        if value is None:
+            return b"NULL"
+        if not isinstance(value, bytes):
+            value = bytes(value)
         if value in self._special:
             return self._special[value]
 
@@ -89,21 +95,21 @@ class FloatBinaryDumper(Dumper):
     format = Format.BINARY
     oid = _oids.FLOAT8_OID
 
-    def dump(self, obj: float) -> bytes:
+    def dump(self, obj: float) -> Optional[Buffer]:
         return pack_float8(obj)
 
 
 class Float4BinaryDumper(FloatBinaryDumper):
     oid = _oids.FLOAT4_OID
 
-    def dump(self, obj: float) -> bytes:
+    def dump(self, obj: float) -> Optional[Buffer]:
         return pack_float4(obj)
 
 
 class DecimalDumper(_SpecialValuesDumper):
     oid = _oids.NUMERIC_OID
 
-    def dump(self, obj: Decimal) -> bytes:
+    def dump(self, obj: Decimal) -> Optional[Buffer]:
         return dump_decimal_to_text(obj)
 
     _special = {
@@ -134,7 +140,7 @@ class OidDumper(_IntOrSubclassDumper):
 
 
 class IntDumper(Dumper):
-    def dump(self, obj: Any) -> bytes:
+    def dump(self, obj: Any) -> Optional[Buffer]:
         raise TypeError(
             f"{type(self).__name__} is a dispatcher to other dumpers:"
             " dump() is not supposed to be called"
@@ -164,21 +170,21 @@ class IntDumper(Dumper):
 class Int2BinaryDumper(Int2Dumper):
     format = Format.BINARY
 
-    def dump(self, obj: int) -> bytes:
+    def dump(self, obj: int) -> Optional[Buffer]:
         return pack_int2(obj)
 
 
 class Int4BinaryDumper(Int4Dumper):
     format = Format.BINARY
 
-    def dump(self, obj: int) -> bytes:
+    def dump(self, obj: int) -> Optional[Buffer]:
         return pack_int4(obj)
 
 
 class Int8BinaryDumper(Int8Dumper):
     format = Format.BINARY
 
-    def dump(self, obj: int) -> bytes:
+    def dump(self, obj: int) -> Optional[Buffer]:
         return pack_int8(obj)
 
 
@@ -190,14 +196,14 @@ BIT_PER_PGDIGIT = log(2) / log(10_000)
 class IntNumericBinaryDumper(IntNumericDumper):
     format = Format.BINARY
 
-    def dump(self, obj: int) -> Buffer:
+    def dump(self, obj: int) -> Optional[Buffer]:
         return dump_int_to_numeric_binary(obj)
 
 
 class OidBinaryDumper(OidDumper):
     format = Format.BINARY
 
-    def dump(self, obj: int) -> bytes:
+    def dump(self, obj: int) -> Optional[Buffer]:
         return pack_uint4(obj)
 
 
@@ -350,7 +356,7 @@ class DecimalBinaryDumper(Dumper):
     format = Format.BINARY
     oid = _oids.NUMERIC_OID
 
-    def dump(self, obj: Decimal) -> Buffer:
+    def dump(self, obj: Decimal) -> Optional[Buffer]:
         return dump_decimal_to_numeric_binary(obj)
 
 
@@ -379,11 +385,13 @@ class _MixedNumericDumper(Dumper, ABC):
                 _MixedNumericDumper.int_classes = int
 
     @abstractmethod
-    def dump(self, obj: Union[Decimal, int, "numpy.integer[Any]"]) -> Buffer: ...
+    def dump(
+        self, obj: Union[Decimal, int, "numpy.integer[Any]"]
+    ) -> Optional[Buffer]: ...
 
 
 class NumericDumper(_MixedNumericDumper):
-    def dump(self, obj: Union[Decimal, int, "numpy.integer[Any]"]) -> Buffer:
+    def dump(self, obj: Union[Decimal, int, "numpy.integer[Any]"]) -> Optional[Buffer]:
         if isinstance(obj, self.int_classes):
             return str(obj).encode()
         elif isinstance(obj, Decimal):
@@ -397,7 +405,7 @@ class NumericDumper(_MixedNumericDumper):
 class NumericBinaryDumper(_MixedNumericDumper):
     format = Format.BINARY
 
-    def dump(self, obj: Union[Decimal, int, "numpy.integer[Any]"]) -> Buffer:
+    def dump(self, obj: Union[Decimal, int, "numpy.integer[Any]"]) -> Optional[Buffer]:
         if type(obj) is int:
             return dump_int_to_numeric_binary(obj)
         elif isinstance(obj, Decimal):

--- a/psycopg/psycopg/types/range.py
+++ b/psycopg/psycopg/types/range.py
@@ -372,7 +372,9 @@ def dump_range_text(obj: Range[Any], dump: DumpFunc) -> Buffer:
 
     def dump_item(item: Any) -> Buffer:
         ad = dump(item)
-        if not ad:
+        if ad is None:
+            return b""
+        elif not ad:
             return b'""'
         elif _re_needs_quotes.search(ad):
             return b'"' + _re_esc.sub(rb"\1\1", ad) + b'"'

--- a/psycopg/psycopg/types/range.py
+++ b/psycopg/psycopg/types/range.py
@@ -354,7 +354,7 @@ class RangeDumper(BaseRangeDumper):
     The dumper can upgrade to one specific for a different range type.
     """
 
-    def dump(self, obj: Range[Any]) -> Buffer:
+    def dump(self, obj: Range[Any]) -> Optional[Buffer]:
         item = self._get_item(obj)
         if item is not None:
             dump = self._tx.get_dumper(item, self._adapt_format).dump
@@ -399,7 +399,7 @@ _re_esc = re.compile(rb"([\\\"])")
 class RangeBinaryDumper(BaseRangeDumper):
     format = Format.BINARY
 
-    def dump(self, obj: Range[Any]) -> Buffer:
+    def dump(self, obj: Range[Any]) -> Optional[Buffer]:
         item = self._get_item(obj)
         if item is not None:
             dump = self._tx.get_dumper(item, self._adapt_format).dump

--- a/psycopg/psycopg/types/shapely.py
+++ b/psycopg/psycopg/types/shapely.py
@@ -43,12 +43,12 @@ class GeometryLoader(Loader):
 class BaseGeometryBinaryDumper(Dumper):
     format = Format.BINARY
 
-    def dump(self, obj: "BaseGeometry") -> bytes:
+    def dump(self, obj: "BaseGeometry") -> Optional[Buffer]:
         return dumps(obj)  # type: ignore
 
 
 class BaseGeometryDumper(Dumper):
-    def dump(self, obj: "BaseGeometry") -> bytes:
+    def dump(self, obj: "BaseGeometry") -> Optional[Buffer]:
         return dumps(obj, hex=True).encode()  # type: ignore
 
 

--- a/psycopg/psycopg/types/uuid.py
+++ b/psycopg/psycopg/types/uuid.py
@@ -21,14 +21,14 @@ UUID: Callable[..., "uuid.UUID"] = None  # type: ignore[assignment]
 class UUIDDumper(Dumper):
     oid = _oids.UUID_OID
 
-    def dump(self, obj: "uuid.UUID") -> bytes:
+    def dump(self, obj: "uuid.UUID") -> Optional[Buffer]:
         return obj.hex.encode()
 
 
 class UUIDBinaryDumper(UUIDDumper):
     format = Format.BINARY
 
-    def dump(self, obj: "uuid.UUID") -> bytes:
+    def dump(self, obj: "uuid.UUID") -> Optional[Buffer]:
         return obj.bytes
 
 

--- a/psycopg_c/psycopg_c/_psycopg/adapt.pyx
+++ b/psycopg_c/psycopg_c/_psycopg/adapt.pyx
@@ -58,14 +58,14 @@ cdef class CDumper:
         """
         raise NotImplementedError()
 
-    def dump(self, obj):
+    def dump(self, obj) -> Optional[Buffer]:
         """Return the Postgres representation of *obj* as Python array of bytes"""
         cdef rv = PyByteArray_FromStringAndSize("", 0)
         cdef Py_ssize_t length = self.cdump(obj, rv, 0)
         PyByteArray_Resize(rv, length)
         return rv
 
-    def quote(self, obj):
+    def quote(self, obj) -> Buffer:
         cdef char *ptr
         cdef char *ptr_out
         cdef Py_ssize_t length

--- a/psycopg_c/psycopg_c/types/bool.pyx
+++ b/psycopg_c/psycopg_c/types/bool.pyx
@@ -28,7 +28,7 @@ cdef class BoolDumper(CDumper):
 
         return 1
 
-    def quote(self, obj: bool) -> bytes:
+    def quote(self, obj: bool) -> Optional[Buffer]:
         if obj is True:
             return b"true"
         elif obj is False:

--- a/psycopg_c/psycopg_c/types/numeric.pyx
+++ b/psycopg_c/psycopg_c/types/numeric.pyx
@@ -55,7 +55,7 @@ cdef class _IntDumper(CDumper):
     cdef Py_ssize_t cdump(self, obj, bytearray rv, Py_ssize_t offset) except -1:
         return dump_int_to_text(obj, rv, offset)
 
-    def quote(self, obj) -> bytearray:
+    def quote(self, obj) -> Optional[Buffer]:
         cdef Py_ssize_t length
 
         rv = PyByteArray_FromStringAndSize("", 0)
@@ -311,7 +311,7 @@ cdef class _FloatDumper(CDumper):
         PyMem_Free(out)
         return length
 
-    def quote(self, obj) -> bytes:
+    def quote(self, obj) -> Optional[Buffer]:
         value = bytes(self.dump(obj))
         cdef PyObject *ptr = PyDict_GetItem(_special_float, value)
         if ptr != NULL:
@@ -417,7 +417,7 @@ cdef class DecimalDumper(CDumper):
     cdef Py_ssize_t cdump(self, obj, bytearray rv, Py_ssize_t offset) except -1:
         return dump_decimal_to_text(obj, rv, offset)
 
-    def quote(self, obj) -> bytes:
+    def quote(self, obj) -> Optional[Buffer]:
         value = bytes(self.dump(obj))
         cdef PyObject *ptr = PyDict_GetItem(_special_decimal, value)
         if ptr != NULL:

--- a/psycopg_c/psycopg_c/types/string.pyx
+++ b/psycopg_c/psycopg_c/types/string.pyx
@@ -215,7 +215,7 @@ cdef class BytesDumper(CDumper):
         libpq.PQfreemem(out)
         return len_out
 
-    def quote(self, obj):
+    def quote(self, obj) -> Buffer:
         cdef size_t len_out
         cdef unsigned char *out
         cdef char *ptr

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -308,7 +308,9 @@ def test_subclass_adapter(conn, format):
     class MyStrDumper(BaseDumper):
 
         def dump(self, obj):
-            return super().dump(obj) * 2
+            rv = super().dump(obj)
+            assert rv
+            return bytes(rv) * 2
 
     conn.adapters.register_dumper(str, MyStrDumper)
 

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -24,6 +24,7 @@ from .utils import eur
 from ._test_copy import sample_text, sample_binary, sample_binary_rows  # noqa
 from ._test_copy import sample_values, sample_records, sample_tabledef
 from ._test_copy import ensure_table, py_to_raw, special_chars, FileWriter
+from .test_adapt import StrNoneDumper, StrNoneBinaryDumper
 
 pytestmark = pytest.mark.crdb_skip("copy")
 
@@ -323,6 +324,29 @@ def test_subclass_adapter(conn, format):
     cur.execute("select data from copy_in")
     rec = cur.fetchone()
     assert rec[0] == "hellohello"
+
+
+@pytest.mark.parametrize("format", Format)
+def test_subclass_nulling_dumper(conn, format):
+    Base: type = StrNoneDumper if format == Format.TEXT else StrNoneBinaryDumper
+
+    class MyStrDumper(Base):  # type: ignore
+
+        def dump(self, obj):
+            return super().dump(obj) if obj else None
+
+    conn.adapters.register_dumper(str, MyStrDumper)
+
+    cur = conn.cursor()
+    ensure_table(cur, sample_tabledef)
+
+    with cur.copy(f"copy copy_in (data) from stdin (format {format.name})") as copy:
+        copy.write_row(("hello",))
+        copy.write_row(("",))
+
+    cur.execute("select data from copy_in order by col1")
+    recs = cur.fetchall()
+    assert recs == [("hello",), (None,)]
 
 
 @pytest.mark.parametrize("format", Format)

--- a/tests/test_copy_async.py
+++ b/tests/test_copy_async.py
@@ -317,7 +317,9 @@ async def test_subclass_adapter(aconn, format):
 
     class MyStrDumper(BaseDumper):
         def dump(self, obj):
-            return super().dump(obj) * 2
+            rv = super().dump(obj)
+            assert rv
+            return bytes(rv) * 2
 
     aconn.adapters.register_dumper(str, MyStrDumper)
 

--- a/tests/types/test_array.py
+++ b/tests/types/test_array.py
@@ -13,6 +13,7 @@ from psycopg.types import TypeInfo
 from psycopg.postgres import types as builtins
 from psycopg.types.array import register_array
 
+from ..test_adapt import StrNoneDumper, StrNoneBinaryDumper
 
 tests_str = [
     ([[[[[["a"]]]]]], "{{{{{{a}}}}}}"),
@@ -47,6 +48,16 @@ def test_dump_list_str(conn, obj, want, fmt_in):
     cur = conn.cursor()
     cur.execute(f"select %{fmt_in.value}::text[] = %s::text[]", (obj, want))
     assert cur.fetchone()[0]
+
+
+@pytest.mark.parametrize("fmt_in", PyFormat)
+def test_dump_list_str_none(conn, fmt_in):
+    cur = conn.cursor()
+    cur.adapters.register_dumper(str, StrNoneDumper)
+    cur.adapters.register_dumper(str, StrNoneBinaryDumper)
+
+    cur.execute(f"select %{fmt_in.value}::text[]", (["foo", "", "bar"],))
+    assert cur.fetchone()[0] == ["foo", None, "bar"]
 
 
 @pytest.mark.parametrize("fmt_out", pq.Format)


### PR DESCRIPTION
Allow dumpers to return None, which would be then treated adequately in normal queries, in COPY, as part of composite objects such as Composite or Range.

In the C code, currently only Python dumpers are checked for returning None, because no builtin dumper does it and I don't expect anyone currently subclassing a C dumper. Should the need arise, we can allow None as C dumpers result in a bugfix.

Close #377