### PR TITLE
Fix memory leak with repeated `register_*()` call

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -7,6 +7,13 @@
 ``psycopg`` release notes
 =========================
 
+Psycopg 3.1.12 (unreleased)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Fix memory leak when `~register_*()` functions are called repeatedly
+  (:ticket:`#647`).
+
+
 Current release
 ---------------
 

--- a/psycopg/psycopg/types/array.py
+++ b/psycopg/psycopg/types/array.py
@@ -311,39 +311,48 @@ def register_array(info: TypeInfo, context: Optional[AdaptContext] = None) -> No
     if not info.array_oid:
         raise ValueError(f"the type info {info} doesn't describe an array")
 
-    base: Type[Any]
     adapters = context.adapters if context else postgres.adapters
 
-    base = getattr(_psycopg, "ArrayLoader", ArrayLoader)
-    name = f"{info.name.title()}{base.__name__}"
-    attribs = {
-        "base_oid": info.oid,
-        "delimiter": info.delimiter.encode(),
-    }
-    loader = type(name, (base,), attribs)
+    loader = _make_loader(info.name, info.oid, info.delimiter)
     adapters.register_loader(info.array_oid, loader)
 
+    # No need to make a new loader because the binary datum has all the info.
     loader = getattr(_psycopg, "ArrayBinaryLoader", ArrayBinaryLoader)
     adapters.register_loader(info.array_oid, loader)
 
-    base = ListDumper
-    name = f"{info.name.title()}{base.__name__}"
-    attribs = {
-        "oid": info.array_oid,
-        "element_oid": info.oid,
-        "delimiter": info.delimiter.encode(),
-    }
-    dumper = type(name, (base,), attribs)
+    dumper = _make_dumper(info.name, info.oid, info.array_oid, info.delimiter)
     adapters.register_dumper(None, dumper)
 
-    base = ListBinaryDumper
-    name = f"{info.name.title()}{base.__name__}"
-    attribs = {
-        "oid": info.array_oid,
-        "element_oid": info.oid,
-    }
-    dumper = type(name, (base,), attribs)
+    dumper = _make_binary_dumper(info.name, info.oid, info.array_oid)
     adapters.register_dumper(None, dumper)
+
+
+# Cache all dynamically-generated types to avoid leaks in case the types
+# cannot be GC'd.
+
+
+@cache
+def _make_loader(name: str, oid: int, delimiter: str) -> Type[Loader]:
+    # Note: caching this function is really needed because, if the C extension
+    # is available, the resulting type cannot be GC'd, so calling
+    # register_array() in a loop results in a leak. See #647.
+    base = getattr(_psycopg, "ArrayLoader", ArrayLoader)
+    attribs = {"base_oid": oid, "delimiter": delimiter.encode()}
+    return type(f"{name.title()}{base.__name__}", (base,), attribs)
+
+
+@cache
+def _make_dumper(
+    name: str, oid: int, array_oid: int, delimiter: str
+) -> Type[BaseListDumper]:
+    attribs = {"oid": array_oid, "element_oid": oid, "delimiter": delimiter.encode()}
+    return type(f"{name.title()}ListDumper", (ListDumper,), attribs)
+
+
+@cache
+def _make_binary_dumper(name: str, oid: int, array_oid: int) -> Type[BaseListDumper]:
+    attribs = {"oid": array_oid, "element_oid": oid}
+    return type(f"{name.title()}ListBinaryDumper", (ListBinaryDumper,), attribs)
 
 
 def register_default_adapters(context: AdaptContext) -> None:

--- a/psycopg/psycopg/types/composite.py
+++ b/psycopg/psycopg/types/composite.py
@@ -8,12 +8,13 @@ import re
 import struct
 from collections import namedtuple
 from typing import Any, Callable, cast, Dict, Iterator, List, Optional
-from typing import Sequence, Tuple, Type
+from typing import NamedTuple, Sequence, Tuple, Type
 
 from .. import pq
 from .. import abc
 from .. import postgres
 from ..adapt import Transformer, PyFormat, RecursiveDumper, Loader, Dumper
+from .._compat import cache
 from .._struct import pack_len, unpack_len
 from ..postgres import TEXT_OID
 from .._typeinfo import CompositeInfo as CompositeInfo  # exported here
@@ -69,8 +70,8 @@ class TupleDumper(SequenceDumper):
 class TupleBinaryDumper(Dumper):
     format = pq.Format.BINARY
 
-    # Subclasses must set an info
-    info: CompositeInfo
+    # Subclasses must set this info
+    _field_types: Tuple[int, ...]
 
     def __init__(self, cls: type, context: Optional[abc.AdaptContext] = None):
         super().__init__(cls, context)
@@ -80,9 +81,9 @@ class TupleBinaryDumper(Dumper):
         # in case the composite contains another composite. Make sure to use
         # a separate Transformer instance instead.
         self._tx = Transformer(context)
-        self._tx.set_dumper_types(self.info.field_types, self.format)
+        self._tx.set_dumper_types(self._field_types, self.format)
 
-        nfields = len(self.info.field_types)
+        nfields = len(self._field_types)
         self._formats = (PyFormat.from_pq(self.format),) * nfields
 
     def dump(self, obj: Tuple[Any, ...]) -> bytearray:
@@ -90,7 +91,7 @@ class TupleBinaryDumper(Dumper):
         adapted = self._tx.dump_sequence(obj, self._formats)
         for i in range(len(obj)):
             b = adapted[i]
-            oid = self.info.field_types[i]
+            oid = self._field_types[i]
             if b is not None:
                 out += _pack_oidlen(oid, len(b))
                 out += b
@@ -243,43 +244,27 @@ def register_composite(
     info.register(context)
 
     if not factory:
-        factory = namedtuple(  # type: ignore
-            _as_python_identifier(info.name),
-            [_as_python_identifier(n) for n in info.field_names],
-        )
+        factory = _nt_from_info(info)
 
     adapters = context.adapters if context else postgres.adapters
 
     # generate and register a customized text loader
-    loader: Type[BaseCompositeLoader] = type(
-        f"{info.name.title()}Loader",
-        (CompositeLoader,),
-        {
-            "factory": factory,
-            "fields_types": info.field_types,
-        },
-    )
+    loader: Type[BaseCompositeLoader]
+    loader = _make_loader(info.name, tuple(info.field_types), factory)
     adapters.register_loader(info.oid, loader)
 
     # generate and register a customized binary loader
-    loader = type(
-        f"{info.name.title()}BinaryLoader",
-        (CompositeBinaryLoader,),
-        {"factory": factory},
-    )
+    loader = _make_binary_loader(info.name, factory)
     adapters.register_loader(info.oid, loader)
 
     # If the factory is a type, create and register dumpers for it
     if isinstance(factory, type):
-        dumper = type(
-            f"{info.name.title()}BinaryDumper",
-            (TupleBinaryDumper,),
-            {"oid": info.oid, "info": info},
-        )
+        dumper: Type[Dumper]
+        dumper = _make_binary_dumper(info.name, info.oid, tuple(info.field_types))
         adapters.register_dumper(factory, dumper)
 
         # Default to the text dumper because it is more flexible
-        dumper = type(f"{info.name.title()}Dumper", (TupleDumper,), {"oid": info.oid})
+        dumper = _make_dumper(info.name, info.oid)
         adapters.register_dumper(factory, dumper)
 
         info.python_type = factory
@@ -290,3 +275,54 @@ def register_default_adapters(context: abc.AdaptContext) -> None:
     adapters.register_dumper(tuple, TupleDumper)
     adapters.register_loader("record", RecordLoader)
     adapters.register_loader("record", RecordBinaryLoader)
+
+
+def _nt_from_info(info: CompositeInfo) -> Type[NamedTuple]:
+    name = _as_python_identifier(info.name)
+    fields = tuple(_as_python_identifier(n) for n in info.field_names)
+    return _make_nt(name, fields)
+
+
+# Cache all dynamically-generated types to avoid leaks in case the types
+# cannot be GC'd.
+
+
+@cache
+def _make_nt(name: str, fields: Tuple[str, ...]) -> Type[NamedTuple]:
+    return namedtuple(name, fields)  # type: ignore[return-value]
+
+
+@cache
+def _make_loader(
+    name: str, types: Tuple[int, ...], factory: Callable[..., Any]
+) -> Type[BaseCompositeLoader]:
+    return type(
+        f"{name.title()}Loader",
+        (CompositeLoader,),
+        {"factory": factory, "fields_types": list(types)},
+    )
+
+
+@cache
+def _make_binary_loader(
+    name: str, factory: Callable[..., Any]
+) -> Type[BaseCompositeLoader]:
+    return type(
+        f"{name.title()}BinaryLoader", (CompositeBinaryLoader,), {"factory": factory}
+    )
+
+
+@cache
+def _make_dumper(name: str, oid: int) -> Type[TupleDumper]:
+    return type(f"{name.title()}Dumper", (TupleDumper,), {"oid": oid})
+
+
+@cache
+def _make_binary_dumper(
+    name: str, oid: int, field_types: Tuple[int, ...]
+) -> Type[TupleBinaryDumper]:
+    return type(
+        f"{name.title()}BinaryDumper",
+        (TupleBinaryDumper,),
+        {"oid": oid, "_field_types": field_types},
+    )

--- a/psycopg/psycopg/types/hstore.py
+++ b/psycopg/psycopg/types/hstore.py
@@ -5,13 +5,14 @@ Dict to hstore adaptation
 # Copyright (C) 2021 The Psycopg Team
 
 import re
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Type
 from typing_extensions import TypeAlias
 
 from .. import errors as e
 from .. import postgres
 from ..abc import Buffer, AdaptContext
 from ..adapt import PyFormat, RecursiveDumper, RecursiveLoader
+from .._compat import cache
 from ..postgres import TEXT_OID
 from .._typeinfo import TypeInfo
 
@@ -121,10 +122,25 @@ def register_hstore(info: TypeInfo, context: Optional[AdaptContext] = None) -> N
     adapters = context.adapters if context else postgres.adapters
 
     # Generate and register a customized text dumper
-    class HstoreDumper(BaseHstoreDumper):
-        oid = info.oid
-
-    adapters.register_dumper(dict, HstoreDumper)
+    adapters.register_dumper(dict, _make_hstore_dumper(info.oid))
 
     # register the text loader on the oid
     adapters.register_loader(info.oid, HstoreLoader)
+
+
+# Cache all dynamically-generated types to avoid leaks in case the types
+# cannot be GC'd.
+
+
+@cache
+def _make_hstore_dumper(oid_in: int) -> Type[BaseHstoreDumper]:
+    """
+    Return an hstore dumper class configured using `oid_in`.
+
+    Avoid to create new classes if the oid configured is the same.
+    """
+
+    class HstoreDumper(BaseHstoreDumper):
+        oid = oid_in
+
+    return HstoreDumper

--- a/psycopg/psycopg/types/json.py
+++ b/psycopg/psycopg/types/json.py
@@ -13,6 +13,7 @@ from .. import postgres
 from ..pq import Format
 from ..adapt import Buffer, Dumper, Loader, PyFormat, AdaptersMap
 from ..errors import DataError
+from .._compat import cache
 
 JsonDumpsFunction = Callable[[Any], Union[str, bytes]]
 JsonLoadsFunction = Callable[[Union[str, bytes]], Any]
@@ -51,13 +52,9 @@ def set_json_dumps(
             (Jsonb, PyFormat.BINARY),
             (Jsonb, PyFormat.TEXT),
         ]
-        dumper: Type[_JsonDumper]
         for wrapper, format in grid:
             base = _get_current_dumper(adapters, wrapper, format)
-            name = base.__name__
-            if not base.__name__.startswith("Custom"):
-                name = f"Custom{name}"
-            dumper = type(name, (base,), {"_dumps": dumps})
+            dumper = _make_dumper(base, dumps)
             adapters.register_dumper(wrapper, dumper)
 
 
@@ -89,10 +86,29 @@ def set_json_loads(
             ("jsonb", JsonbLoader),
             ("jsonb", JsonbBinaryLoader),
         ]
-        loader: Type[_JsonLoader]
         for tname, base in grid:
-            loader = type(f"Custom{base.__name__}", (base,), {"_loads": loads})
+            loader = _make_loader(base, loads)
             context.adapters.register_loader(tname, loader)
+
+
+# Cache all dynamically-generated types to avoid leaks in case the types
+# cannot be GC'd.
+
+
+@cache
+def _make_dumper(base: Type[abc.Dumper], dumps: JsonDumpsFunction) -> Type[abc.Dumper]:
+    name = base.__name__
+    if not name.startswith("Custom"):
+        name = f"Custom{name}"
+    return type(name, (base,), {"_dumps": dumps})
+
+
+@cache
+def _make_loader(base: Type[Loader], loads: JsonLoadsFunction) -> Type[Loader]:
+    name = base.__name__
+    if not name.startswith("Custom"):
+        name = f"Custom{name}"
+    return type(name, (base,), {"_loads": loads})
 
 
 class _JsonWrapper:

--- a/psycopg/psycopg/types/multirange.py
+++ b/psycopg/psycopg/types/multirange.py
@@ -14,6 +14,7 @@ from .. import postgres
 from ..pq import Format
 from ..abc import AdaptContext, Buffer, Dumper, DumperKey
 from ..adapt import RecursiveDumper, RecursiveLoader, PyFormat
+from .._compat import cache
 from .._struct import pack_len, unpack_len
 from ..postgres import INVALID_OID, TEXT_OID
 from .._typeinfo import MultirangeInfo as MultirangeInfo  # exported here
@@ -353,20 +354,29 @@ def register_multirange(
     adapters = context.adapters if context else postgres.adapters
 
     # generate and register a customized text loader
-    loader: Type[MultirangeLoader[Any]] = type(
-        f"{info.name.title()}Loader",
-        (MultirangeLoader,),
-        {"subtype_oid": info.subtype_oid},
-    )
+    loader: Type[BaseMultirangeLoader[Any]]
+    loader = _make_loader(info.name, info.subtype_oid)
     adapters.register_loader(info.oid, loader)
 
     # generate and register a customized binary loader
-    bloader: Type[MultirangeBinaryLoader[Any]] = type(
-        f"{info.name.title()}BinaryLoader",
-        (MultirangeBinaryLoader,),
-        {"subtype_oid": info.subtype_oid},
+    loader = _make_binary_loader(info.name, info.subtype_oid)
+    adapters.register_loader(info.oid, loader)
+
+
+# Cache all dynamically-generated types to avoid leaks in case the types
+# cannot be GC'd.
+
+
+@cache
+def _make_loader(name: str, oid: int) -> Type[MultirangeLoader[Any]]:
+    return type(f"{name.title()}Loader", (MultirangeLoader,), {"subtype_oid": oid})
+
+
+@cache
+def _make_binary_loader(name: str, oid: int) -> Type[MultirangeBinaryLoader[Any]]:
+    return type(
+        f"{name.title()}BinaryLoader", (MultirangeBinaryLoader,), {"subtype_oid": oid}
     )
-    adapters.register_loader(info.oid, bloader)
 
 
 # Text dumpers for builtin multirange types wrappers


### PR DESCRIPTION
The leak is caused by subclasses of C extension types not being GC'd. However this MR introduces caching of all the dynamically generated types.

The cache keys are usually oid, type names, etc, so they are not expected to change repeatedly and, unless connecting to an unbound number of servers, each one with different type oids, the caches themselves are not expected to cause a leak.

Close #647 