### PR TITLE
chore: use AnyIO 4.0+ in tests dependencies

### DIFF
--- a/psycopg/setup.cfg
+++ b/psycopg/setup.cfg
@@ -64,8 +64,7 @@ binary =
 pool =
     psycopg-pool
 test =
-    # TODO: move to anyio >= 4.0 once support for Python 3.7 is dropped
-    anyio >= 3.6.2, < 4.0
+    anyio >= 4.0
     mypy >= 1.4.1
     pproxy >= 2.7
     pytest >= 6.2.5

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,7 +70,9 @@ def pytest_sessionstart(session):
 
 asyncio_options: Dict[str, Any] = {}
 if sys.platform == "win32":
-    asyncio_options["policy"] = asyncio.WindowsSelectorEventLoopPolicy()
+    asyncio_options[
+        "loop_factory"
+    ] = asyncio.WindowsSelectorEventLoopPolicy().new_event_loop
 
 
 @pytest.fixture(

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -9,7 +9,7 @@ typing-extensions == 4.2.0
 importlib-metadata == 1.4
 
 # From the 'test' extra
-anyio == 3.6.2
+anyio == 4.0
 mypy == 1.4.1
 pproxy == 2.7.0
 pytest == 6.2.5

--- a/tests/pool/test_pool_async_noasyncio.py
+++ b/tests/pool/test_pool_async_noasyncio.py
@@ -2,6 +2,7 @@
 # because they rely on the pool initialization outside the asyncio loop.
 
 import asyncio
+import sys
 
 import pytest
 
@@ -62,18 +63,14 @@ def test_cant_create_open_outside_loop(dsn):
 
 
 @pytest.fixture
-def asyncio_run(anyio_backend_options, recwarn):
+def asyncio_run(recwarn):
     """Fixture reuturning asyncio.run, but managing resources at exit.
 
     In certain runs, fd objects are leaked and the error will only be caught
     downstream, by some innocent test calling gc_collect().
     """
-    try:
-        policy = anyio_backend_options["policy"]
-    except KeyError:
-        pass
-    else:
-        asyncio.set_event_loop_policy(policy)
+    if sys.platform == "win32":
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
     recwarn.clear()
     try:
         yield asyncio.run


### PR DESCRIPTION
Fix #662 