### PR TITLE
fix(cursor) Use ProgrammingError can't execute over cursor

### DIFF
--- a/psycopg/psycopg/_cursor_base.py
+++ b/psycopg/psycopg/_cursor_base.py
@@ -462,7 +462,7 @@ class BaseCursor(Generic[ConnectionType, Row]):
 
         for res in results:
             status = res.status
-            if status != TUPLES_OK and status != COMMAND_OK and status != EMPTY_QUERY:
+            if status != TUPLES_OK and status != COMMAND_OK:
                 self._raise_for_result(res)
 
     def _raise_for_result(self, result: "PGresult") -> NoReturn:
@@ -478,6 +478,8 @@ class BaseCursor(Generic[ConnectionType, Row]):
             raise e.ProgrammingError(
                 "COPY cannot be used with this method; use copy() instead"
             )
+        elif status == EMPTY_QUERY:
+            raise e.ProgrammingError("can't execute an empty query")
         else:
             raise e.InternalError(
                 "unexpected result status from query:" f" {pq.ExecStatus(status).name}"

--- a/tests/test_cursor_common.py
+++ b/tests/test_cursor_common.py
@@ -220,10 +220,9 @@ def test_execute_sequence(conn):
 @pytest.mark.parametrize("query", ["", " ", ";"])
 def test_execute_empty_query(conn, query):
     cur = conn.cursor()
-    cur.execute(query)
-    assert cur.pgresult.status == cur.ExecStatus.EMPTY_QUERY
     with pytest.raises(psycopg.ProgrammingError):
-        cur.fetchone()
+        cur.execute(query)
+        assert cur.pgresult.status == cur.ExecStatus.EMPTY_QUERY
 
 
 def test_execute_type_change(conn):
@@ -487,7 +486,7 @@ def test_rownumber(conn):
     assert cur.rownumber == 42
 
 
-@pytest.mark.parametrize("query", ["", "set timezone to utc"])
+@pytest.mark.parametrize("query", ["set timezone to utc"])
 def test_rownumber_none(conn, query):
     cur = conn.cursor()
     cur.execute(query)

--- a/tests/test_cursor_common_async.py
+++ b/tests/test_cursor_common_async.py
@@ -221,10 +221,9 @@ async def test_execute_sequence(aconn):
 @pytest.mark.parametrize("query", ["", " ", ";"])
 async def test_execute_empty_query(aconn, query):
     cur = aconn.cursor()
-    await cur.execute(query)
-    assert cur.pgresult.status == cur.ExecStatus.EMPTY_QUERY
     with pytest.raises(psycopg.ProgrammingError):
-        await cur.fetchone()
+        await cur.execute(query)
+        assert cur.pgresult.status == cur.ExecStatus.EMPTY_QUERY
 
 
 async def test_execute_type_change(aconn):
@@ -492,7 +491,7 @@ async def test_rownumber(aconn):
     assert cur.rownumber == 42
 
 
-@pytest.mark.parametrize("query", ["", "set timezone to utc"])
+@pytest.mark.parametrize("query", ["set timezone to utc"])
 async def test_rownumber_none(aconn, query):
     cur = aconn.cursor()
     await cur.execute(query)


### PR DESCRIPTION
When sending an empty query to the database, raise an exception from the cursor instead of `fetchone`/`many`.
This change restores the behavior used in the previous version:

 https://github.com/psycopg/psycopg2/blob/89005ac5b849c6428c05660b23c5a266c96e677d/psycopg/cursor_int.c#L119