### PR TITLE
Mark test_identify_closure as timing-sensitive

### DIFF
--- a/tests/crdb/test_connection.py
+++ b/tests/crdb/test_connection.py
@@ -64,6 +64,7 @@ def test_broken(conn):
 
 
 @pytest.mark.slow
+@pytest.mark.timing
 def test_identify_closure(conn_cls, dsn):
     with conn_cls.connect(dsn, autocommit=True) as conn:
         with conn_cls.connect(dsn, autocommit=True) as conn2:

--- a/tests/crdb/test_connection_async.py
+++ b/tests/crdb/test_connection_async.py
@@ -63,6 +63,7 @@ async def test_broken(aconn):
 
 
 @pytest.mark.slow
+@pytest.mark.timing
 async def test_identify_closure(aconn_cls, dsn):
     async with await aconn_cls.connect(dsn) as conn:
         async with await aconn_cls.connect(dsn) as conn2:

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -213,6 +213,7 @@ def test_cancel_stream(conn):
 
 @pytest.mark.crdb_skip("pg_terminate_backend")
 @pytest.mark.slow
+@pytest.mark.timing
 def test_identify_closure(conn_cls, dsn):
     def closer():
         time.sleep(0.2)

--- a/tests/test_concurrency_async.py
+++ b/tests/test_concurrency_async.py
@@ -162,6 +162,7 @@ async def test_cancel_stream(aconn):
 
 
 @pytest.mark.slow
+@pytest.mark.timing
 @pytest.mark.crdb_skip("pg_terminate_backend")
 async def test_identify_closure(aconn_cls, dsn):
     async def closer():


### PR DESCRIPTION
Went and marked all of them as timing sensitive, since they follow the same pattern.

```
____________________________ test_identify_closure _____________________________

conn_cls = <class 'psycopg.Connection'>, dsn = 'host=127.0.0.1 user=psycopg'

    @pytest.mark.crdb_skip("pg_terminate_backend")
    @pytest.mark.slow
    def test_identify_closure(conn_cls, dsn):
        def closer():
            time.sleep(0.2)
            conn2.execute("select pg_terminate_backend(%s)", [conn.pgconn.backend_pid])

        conn = conn_cls.connect(dsn)
        conn2 = conn_cls.connect(dsn)
        try:
            t = threading.Thread(target=closer)
            t.start()
            t0 = time.time()
            try:
                with pytest.raises(psycopg.OperationalError):
                    conn.execute("select pg_sleep(1.0)")
                t1 = time.time()
>               assert 0.2 < t1 - t0 < 0.4
E               assert 0.2 < (1697715164.8614173 - 1697715164.6617775)

tests/test_concurrency.py:231: AssertionError
```