### PR TITLE
Handle gracefully EINTR on signals instead of raising InterruptedError

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -30,16 +30,18 @@ Psycopg 3.2 (unreleased)
 .. __: https://numpy.org/doc/stable/reference/arrays.scalars.html#built-in-scalar-types
 
 
-Current release
----------------
-
 Psycopg 3.1.13 (unreleased)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Raise `DataError` instead of whatever internal failure trying to dump a
   `~datetime.time` object with with a `!tzinfo` specified as
   `~zoneinfo.ZoneInfo` (ambiguous offset, see :ticket:`#652`).
+- Handle gracefully EINTR on signals instead of raising `InterruptedError`,
+  consistently with :pep:`475` guideline (:ticket:`#667`).
 
+
+Current release
+---------------
 
 Psycopg 3.1.12
 ^^^^^^^^^^^^^^

--- a/tests/test_concurrency_async.py
+++ b/tests/test_concurrency_async.py
@@ -317,6 +317,52 @@ asyncio.run(main())
 
 
 @pytest.mark.slow
+@pytest.mark.subprocess
+@pytest.mark.parametrize("itimername, signame", [("ITIMER_REAL", "SIGALRM")])
+def test_eintr(dsn, itimername, signame):
+    try:
+        itimer = int(getattr(signal, itimername))
+        sig = int(getattr(signal, signame))
+    except AttributeError:
+        pytest.skip(f"unknown interrupt timer: {itimername}")
+
+    script = f"""\
+import signal
+import asyncio
+import psycopg
+
+def signal_handler(signum, frame):
+    assert signum == {sig!r}
+
+# Install a handler for the signal
+signal.signal({sig!r}, signal_handler)
+
+# Restart system calls interrupted by the signal
+signal.siginterrupt({sig!r}, False)
+
+
+async def main():
+    async with await psycopg.AsyncConnection.connect({dsn!r}) as conn:
+        # Fire an interrupt signal every 0.25 seconds
+        signal.setitimer({itimer!r}, 0.25, 0.25)
+
+        cur = conn.cursor()
+        await cur.execute("select 'ok' from pg_sleep(0.5)")
+        print((await cur.fetchone())[0])
+
+asyncio.run(main())
+"""
+    cp = sp.run(
+        [sys.executable, "-s"], input=script, text=True, stdout=sp.PIPE, stderr=sp.PIPE
+    )
+    assert "InterruptedError" not in cp.stderr
+    assert (
+        cp.returncode == 0
+    ), f"script terminated with {signal.Signals(abs(cp.returncode)).name}"
+    assert cp.stdout.rstrip() == "ok"
+
+
+@pytest.mark.slow
 @pytest.mark.crdb("skip")
 @pytest.mark.skipif(
     sys.platform == "win32",


### PR DESCRIPTION
Fix #667

The sync test reproduces the issue. The async code is not affected; test added to check for regressions should we refactor the async waiting function.

@Jawshua