### PR TITLE
Fix handling of multiple hosts

### DIFF
--- a/docs/api/dns.rst
+++ b/docs/api/dns.rst
@@ -92,12 +92,6 @@ server before performing a connection.
     .. warning::
         This is an experimental method.
 
-    .. versionchanged:: 3.1
-        Unlike the sync counterpart, perform non-blocking address
-        resolution and populate the ``hostaddr`` connection parameter,
-        unless the user has provided one themselves. See
-        `resolve_hostaddr_async()` for details.
-
 
 .. function:: resolve_hostaddr_async(params)
     :async:

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -38,6 +38,7 @@ Psycopg 3.1.13 (unreleased)
   `~zoneinfo.ZoneInfo` (ambiguous offset, see :ticket:`#652`).
 - Handle gracefully EINTR on signals instead of raising `InterruptedError`,
   consistently with :pep:`475` guideline (:ticket:`#667`).
+- Fix support for connection strings with multiple hosts (:ticket:`#674`).
 
 
 Current release

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -38,7 +38,8 @@ Psycopg 3.1.13 (unreleased)
   `~zoneinfo.ZoneInfo` (ambiguous offset, see :ticket:`#652`).
 - Handle gracefully EINTR on signals instead of raising `InterruptedError`,
   consistently with :pep:`475` guideline (:ticket:`#667`).
-- Fix support for connection strings with multiple hosts (:ticket:`#674`).
+- Fix support for connection strings with multiple hosts/ports and for the
+  ``load_balance_hosts`` connection parameter (:ticket:`#674`).
 
 
 Current release

--- a/psycopg/psycopg/_connection_base.py
+++ b/psycopg/psycopg/_connection_base.py
@@ -423,13 +423,10 @@ class BaseConnection(Generic[Row]):
     def _connect_gen(
         cls: Type[ConnectionType],
         conninfo: str = "",
-        *,
-        autocommit: bool = False,
     ) -> PQGenConn[ConnectionType]:
         """Generator to connect to the database and create a new instance."""
         pgconn = yield from generators.connect(conninfo)
         conn = cls(pgconn)
-        conn._autocommit = bool(autocommit)
         return conn
 
     def _exec_command(

--- a/psycopg/psycopg/_connection_base.py
+++ b/psycopg/psycopg/_connection_base.py
@@ -97,6 +97,11 @@ class BaseConnection(Generic[Row]):
     ConnStatus = pq.ConnStatus
     TransactionStatus = pq.TransactionStatus
 
+    # Default timeout for connection a attempt.
+    # Arbitrary timeout, what applied by the libpq on my computer.
+    # Your mileage won't vary.
+    _DEFAULT_CONNECT_TIMEOUT = 130
+
     def __init__(self, pgconn: "PGconn"):
         self.pgconn = pgconn
         self._autocommit = False

--- a/psycopg/psycopg/connection.py
+++ b/psycopg/psycopg/connection.py
@@ -123,12 +123,12 @@ class Connection(BaseConnection[Row]):
 
         try:
             rv = cls._wait_conn(
-                cls._connect_gen(conninfo, autocommit=autocommit),
-                timeout=params["connect_timeout"],
+                cls._connect_gen(conninfo), timeout=params["connect_timeout"]
             )
         except e._NO_TRACEBACK as ex:
             raise ex.with_traceback(None)
 
+        rv._autocommit = bool(autocommit)
         if row_factory:
             rv.row_factory = row_factory
         if cursor_factory:

--- a/psycopg/psycopg/connection_async.py
+++ b/psycopg/psycopg/connection_async.py
@@ -139,12 +139,12 @@ class AsyncConnection(BaseConnection[Row]):
 
         try:
             rv = await cls._wait_conn(
-                cls._connect_gen(conninfo, autocommit=autocommit),
-                timeout=params["connect_timeout"],
+                cls._connect_gen(conninfo), timeout=params["connect_timeout"]
             )
         except e._NO_TRACEBACK as ex:
             raise ex.with_traceback(None)
 
+        rv._autocommit = bool(autocommit)
         if row_factory:
             rv.row_factory = row_factory
         if cursor_factory:

--- a/psycopg/psycopg/conninfo.py
+++ b/psycopg/psycopg/conninfo.py
@@ -11,6 +11,7 @@ import re
 import socket
 import asyncio
 from typing import Any, Iterator, AsyncIterator
+from random import shuffle
 from pathlib import Path
 from datetime import tzinfo
 from functools import lru_cache
@@ -339,8 +340,14 @@ def conninfo_attempts(params: ConnDict) -> Iterator[ConnDict]:
     Because the libpq async function doesn't honour the timeout, we need to
     reimplement the repeated attempts.
     """
-    for attempt in _split_attempts(_inject_defaults(params)):
-        yield attempt
+    if params.get("load_balance_hosts", "disable") == "random":
+        attempts = list(_split_attempts(_inject_defaults(params)))
+        shuffle(attempts)
+        for attempt in attempts:
+            yield attempt
+    else:
+        for attempt in _split_attempts(_inject_defaults(params)):
+            yield attempt
 
 
 async def conninfo_attempts_async(params: ConnDict) -> AsyncIterator[ConnDict]:

--- a/psycopg/psycopg/conninfo.py
+++ b/psycopg/psycopg/conninfo.py
@@ -4,20 +4,26 @@ Functions to manipulate conninfo strings
 
 # Copyright (C) 2020 The Psycopg Team
 
+from __future__ import annotations
+
 import os
 import re
 import socket
 import asyncio
-from typing import Any, Dict, List, Optional
+from typing import Any, Iterator, AsyncIterator
 from pathlib import Path
 from datetime import tzinfo
 from functools import lru_cache
 from ipaddress import ip_address
+from typing_extensions import TypeAlias
 
 from . import pq
 from . import errors as e
 from ._tz import get_tzinfo
+from ._compat import cache
 from ._encodings import pgconn_encoding
+
+ConnDict: TypeAlias = "dict[str, Any]"
 
 
 def make_conninfo(conninfo: str = "", **kwargs: Any) -> str:
@@ -61,7 +67,7 @@ def make_conninfo(conninfo: str = "", **kwargs: Any) -> str:
     return conninfo
 
 
-def conninfo_to_dict(conninfo: str = "", **kwargs: Any) -> Dict[str, Any]:
+def conninfo_to_dict(conninfo: str = "", **kwargs: Any) -> ConnDict:
     """
     Convert the `!conninfo` string into a dictionary of parameters.
 
@@ -84,7 +90,7 @@ def conninfo_to_dict(conninfo: str = "", **kwargs: Any) -> Dict[str, Any]:
     return rv
 
 
-def _parse_conninfo(conninfo: str) -> List[pq.ConninfoOption]:
+def _parse_conninfo(conninfo: str) -> list[pq.ConninfoOption]:
     """
     Verify that `!conninfo` is a valid connection string.
 
@@ -167,7 +173,7 @@ class ConnectionInfo:
         """
         return self._get_pgconn_attr("options")
 
-    def get_parameters(self) -> Dict[str, str]:
+    def get_parameters(self) -> dict[str, str]:
         """Return the connection parameters values.
 
         Return all the parameters set to a non-default value, which might come
@@ -228,7 +234,7 @@ class ConnectionInfo:
         """
         return pq.PipelineStatus(self.pgconn.pipeline_status)
 
-    def parameter_status(self, param_name: str) -> Optional[str]:
+    def parameter_status(self, param_name: str) -> str | None:
         """
         Return a parameter setting of the connection.
 
@@ -275,7 +281,7 @@ class ConnectionInfo:
         return value.decode(self.encoding)
 
 
-async def resolve_hostaddr_async(params: Dict[str, Any]) -> Dict[str, Any]:
+async def resolve_hostaddr_async(params: ConnDict) -> ConnDict:
     """
     Perform async DNS lookup of the hosts and return a new params dict.
 
@@ -292,80 +298,173 @@ async def resolve_hostaddr_async(params: Dict[str, Any]) -> Dict[str, Any]:
     Raise `~psycopg.OperationalError` if connection is not possible (e.g. no
     host resolve, inconsistent lists length).
     """
-    hostaddr_arg = params.get("hostaddr", os.environ.get("PGHOSTADDR", ""))
-    if hostaddr_arg:
-        # Already resolved
-        return params
+    hosts: list[str] = []
+    hostaddrs: list[str] = []
+    ports: list[str] = []
 
-    host_arg: str = params.get("host", os.environ.get("PGHOST", ""))
-    if not host_arg:
-        # Nothing to resolve
-        return params
-
-    hosts_in = host_arg.split(",")
-    port_arg: str = str(params.get("port", os.environ.get("PGPORT", "")))
-    ports_in = port_arg.split(",") if port_arg else []
-    default_port = "5432"
-
-    if len(ports_in) == 1:
-        # If only one port is specified, the libpq will apply it to all
-        # the hosts, so don't mangle it.
-        default_port = ports_in.pop()
-
-    elif len(ports_in) > 1:
-        if len(ports_in) != len(hosts_in):
-            # ProgrammingError would have been more appropriate, but this is
-            # what the raise if the libpq fails connect in the same case.
-            raise e.OperationalError(
-                f"cannot match {len(hosts_in)} hosts with {len(ports_in)} port numbers"
-            )
-        ports_out = []
-
-    hosts_out = []
-    hostaddr_out = []
-    loop = asyncio.get_running_loop()
-    for i, host in enumerate(hosts_in):
-        if not host or host.startswith("/") or host[1:2] == ":":
-            # Local path
-            hosts_out.append(host)
-            hostaddr_out.append("")
-            if ports_in:
-                ports_out.append(ports_in[i])
-            continue
-
-        # If the host is already an ip address don't try to resolve it
-        if is_ip_address(host):
-            hosts_out.append(host)
-            hostaddr_out.append(host)
-            if ports_in:
-                ports_out.append(ports_in[i])
-            continue
-
+    for attempt in _split_attempts(_inject_defaults(params)):
         try:
-            port = ports_in[i] if ports_in else default_port
-            ans = await loop.getaddrinfo(
-                host, port, proto=socket.IPPROTO_TCP, type=socket.SOCK_STREAM
-            )
+            async for a2 in _split_attempts_and_resolve(attempt):
+                hosts.append(a2["host"])
+                hostaddrs.append(a2["hostaddr"])
+                if "port" in params:
+                    ports.append(a2["port"])
         except OSError as ex:
             last_exc = ex
-        else:
-            for item in ans:
-                hosts_out.append(host)
-                hostaddr_out.append(item[4][0])
-                if ports_in:
-                    ports_out.append(ports_in[i])
 
-    # Throw an exception if no host could be resolved
-    if not hosts_out:
+    if params.get("host") and not hosts:
+        # We couldn't resolve anything
         raise e.OperationalError(str(last_exc))
 
     out = params.copy()
-    out["host"] = ",".join(hosts_out)
-    out["hostaddr"] = ",".join(hostaddr_out)
-    if ports_in:
-        out["port"] = ",".join(ports_out)
+    shosts = ",".join(hosts)
+    if shosts:
+        out["host"] = shosts
+    shostaddrs = ",".join(hostaddrs)
+    if shostaddrs:
+        out["hostaddr"] = shostaddrs
+    sports = ",".join(ports)
+    if ports:
+        out["port"] = sports
 
     return out
+
+
+def _inject_defaults(params: ConnDict) -> ConnDict:
+    """
+    Add defaults to a dictionary of parameters.
+
+    This avoids the need to look up for env vars at various stages during
+    processing.
+
+    Note that a port is always specified. 5432 likely comes from here.
+
+    The `host`, `hostaddr`, `port` will be always set to a string.
+    """
+    defaults = _conn_defaults()
+    out = params.copy()
+
+    def inject(name: str, envvar: str) -> None:
+        value = out.get(name)
+        if not value:
+            out[name] = os.environ.get(envvar, defaults[name])
+        else:
+            out[name] = str(value)
+
+    inject("host", "PGHOST")
+    inject("hostaddr", "PGHOSTADDR")
+    inject("port", "PGPORT")
+
+    return out
+
+
+def _split_attempts(params: ConnDict) -> Iterator[ConnDict]:
+    """
+    Split connection parameters with a sequence of hosts into separate attempts.
+
+    Assume that `host`, `hostaddr`, `port` are always present and a string (as
+    emitted from `_inject_defaults()`).
+    """
+
+    def split_val(key: str) -> list[str]:
+        # Assume all keys are present and strings.
+        val: str = params[key]
+        return val.split(",") if val else []
+
+    hosts = split_val("host")
+    hostaddrs = split_val("hostaddr")
+    ports = split_val("port")
+
+    if hosts and hostaddrs and len(hosts) != len(hostaddrs):
+        raise e.OperationalError(
+            f"could not match {len(hosts)} host names"
+            f" with {len(hostaddrs)} hostaddr values"
+        )
+
+    nhosts = max(len(hosts), len(hostaddrs))
+
+    if 1 < len(ports) != nhosts:
+        raise e.OperationalError(
+            f"could not match {len(ports)} port numbers to {len(hosts)} hosts"
+        )
+    elif len(ports) == 1:
+        ports *= nhosts
+
+    # A single attempt to make
+    if nhosts <= 1:
+        yield params
+        return
+
+    # Now all lists are either empty or have the same length
+    for i in range(nhosts):
+        attempt = params.copy()
+        if hosts:
+            attempt["host"] = hosts[i]
+        if hostaddrs:
+            attempt["hostaddr"] = hostaddrs[i]
+        if ports:
+            attempt["port"] = ports[i]
+        yield attempt
+
+
+async def _split_attempts_and_resolve(params: ConnDict) -> AsyncIterator[ConnDict]:
+    """
+    Perform async DNS lookup of the hosts and return a new params dict.
+
+    :param params: The input parameters, for instance as returned by
+        `~psycopg.conninfo.conninfo_to_dict()`. The function expects at most
+        a single entry for host, hostaddr, port and doesn't check for env vars
+        because it is designed to further process the input of _split_attempts()
+
+    If a ``host`` param is present but not ``hostname``, resolve the host
+    addresses dynamically.
+
+    The function may change the input ``host``, ``hostname``, ``port`` to allow
+    connecting without further DNS lookups.
+
+    Raise `~psycopg.OperationalError` if resolution fails.
+    """
+    host = params["host"]
+    if not host or host.startswith("/") or host[1:2] == ":":
+        # Local path, or no host to resolve
+        yield params
+        return
+
+    hostaddr = params["hostaddr"]
+    if hostaddr:
+        # Already resolved
+        yield params
+        return
+
+    if is_ip_address(host):
+        # If the host is already an ip address don't try to resolve it
+        params["hostaddr"] = host
+        yield params
+        return
+
+    loop = asyncio.get_running_loop()
+
+    port = params["port"]
+    ans = await loop.getaddrinfo(
+        host, port, proto=socket.IPPROTO_TCP, type=socket.SOCK_STREAM
+    )
+
+    attempt = params.copy()
+    for item in ans:
+        attempt["hostaddr"] = item[4][0]
+    yield attempt
+
+
+@cache
+def _conn_defaults() -> dict[str, str]:
+    """
+    Return a dictionary of defaults for connection strings parameters.
+    """
+    defs = pq.Conninfo.get_defaults()
+    return {
+        d.keyword.decode(): d.compiled.decode() if d.compiled is not None else ""
+        for d in defs
+    }
 
 
 @lru_cache()

--- a/tests/_test_connection.py
+++ b/tests/_test_connection.py
@@ -105,7 +105,10 @@ conninfo_params_timeout = [
 
 
 def drop_default_args_from_conninfo(conninfo):
-    params = conninfo_to_dict(conninfo)
+    if isinstance(conninfo, str):
+        params = conninfo_to_dict(conninfo)
+    else:
+        params = conninfo.copy()
 
     def removeif(key, value):
         if params.get(key) == value:
@@ -114,6 +117,10 @@ def drop_default_args_from_conninfo(conninfo):
     removeif("host", "")
     removeif("hostaddr", "")
     removeif("port", "5432")
+    if "," in params.get("host", ""):
+        nhosts = len(params["host"].split(","))
+        removeif("port", ",".join(["5432"] * nhosts))
+        removeif("hostaddr", "," * (nhosts - 1))
     removeif("connect_timeout", str(DEFAULT_TIMEOUT))
 
     return params

--- a/tests/fix_proxy.py
+++ b/tests/fix_proxy.py
@@ -60,7 +60,7 @@ class Proxy:
         # Get server params
         host = cdict.get("host") or os.environ.get("PGHOST")
         self.server_host = host if host and not host.startswith("/") else "localhost"
-        self.server_port = cdict.get("port", "5432")
+        self.server_port = cdict.get("port") or os.environ.get("PGPORT", "5432")
 
         # Get client params
         self.client_host = "localhost"

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -17,7 +17,7 @@ from .utils import gc_collect
 from .acompat import is_async, skip_sync, skip_async
 from ._test_cursor import my_row_factory
 from ._test_connection import tx_params, tx_params_isolation, tx_values_map
-from ._test_connection import conninfo_params_timeout
+from ._test_connection import conninfo_params_timeout, drop_default_args_from_conninfo
 from ._test_connection import testctx  # noqa: F401  # fixture
 from .test_adapt import make_bin_dumper, make_dumper
 
@@ -399,26 +399,27 @@ def test_autocommit_unknown(conn):
         (("dbname=foo user=bar",), {}, "dbname=foo user=bar"),
         (("dbname=foo",), {"user": "baz"}, "dbname=foo user=baz"),
         (
-            ("dbname=foo port=5432",),
+            ("dbname=foo port=5433",),
             {"dbname": "qux", "user": "joe"},
-            "dbname=qux user=joe port=5432",
+            "dbname=qux user=joe port=5433",
         ),
         (("dbname=foo",), {"user": None}, "dbname=foo"),
     ],
 )
 def test_connect_args(conn_cls, monkeypatch, setpgenv, pgconn, args, kwargs, want):
-    the_conninfo: str
+    got_conninfo: str
 
     def fake_connect(conninfo):
-        nonlocal the_conninfo
-        the_conninfo = conninfo
+        nonlocal got_conninfo
+        got_conninfo = conninfo
         return pgconn
         yield
 
     setpgenv({})
     monkeypatch.setattr(psycopg.generators, "connect", fake_connect)
     conn = conn_cls.connect(*args, **kwargs)
-    assert conninfo_to_dict(the_conninfo) == conninfo_to_dict(want)
+    got_params = drop_default_args_from_conninfo(got_conninfo)
+    assert got_params == conninfo_to_dict(want)
     conn.close()
 
 
@@ -790,7 +791,7 @@ def test_get_connection_params(conn_cls, dsn, kwargs, exp, setpgenv):
     setpgenv({})
     params = conn_cls._get_connection_params(dsn, **kwargs)
     conninfo = make_conninfo(**params)
-    assert conninfo_to_dict(conninfo) == exp[0]
+    assert drop_default_args_from_conninfo(conninfo) == exp[0]
     assert params["connect_timeout"] == exp[1]
 
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -54,6 +54,38 @@ def test_connect_timeout(conn_cls, deaf_port):
     assert elapsed == pytest.approx(1.0, abs=0.05)
 
 
+@pytest.mark.slow
+@pytest.mark.timing
+def test_multi_hosts(conn_cls, proxy, dsn, deaf_port, monkeypatch):
+    args = conninfo_to_dict(dsn)
+    args["host"] = f"{proxy.client_host},{proxy.server_host}"
+    args["port"] = f"{deaf_port},{proxy.server_port}"
+    args.pop("hostaddr", None)
+    monkeypatch.setattr(conn_cls, "_DEFAULT_CONNECT_TIMEOUT", 2)
+    t0 = time.time()
+    with conn_cls.connect(**args) as conn:
+        elapsed = time.time() - t0
+        assert 2.0 < elapsed < 2.5
+        assert conn.info.port == int(proxy.server_port)
+        assert conn.info.host == proxy.server_host
+
+
+@pytest.mark.slow
+@pytest.mark.timing
+def test_multi_hosts_timeout(conn_cls, proxy, dsn, deaf_port):
+    args = conninfo_to_dict(dsn)
+    args["host"] = f"{proxy.client_host},{proxy.server_host}"
+    args["port"] = f"{deaf_port},{proxy.server_port}"
+    args.pop("hostaddr", None)
+    args["connect_timeout"] = "1"
+    t0 = time.time()
+    with conn_cls.connect(**args) as conn:
+        elapsed = time.time() - t0
+        assert 1.0 < elapsed < 1.5
+        assert conn.info.port == int(proxy.server_port)
+        assert conn.info.host == proxy.server_host
+
+
 def test_close(conn):
     assert not conn.closed
     assert not conn.broken

--- a/tests/test_conninfo.py
+++ b/tests/test_conninfo.py
@@ -479,6 +479,23 @@ def test_conninfo_attempts_bad(setpgenv, conninfo, env):
         list(conninfo_attempts(params))
 
 
+def test_conninfo_random(dsn, conn_cls):
+    hosts = [f"host{n:02d}" for n in range(50)]
+    args = {"host": ",".join(hosts)}
+    ahosts = [att["host"] for att in conninfo_attempts(args)]
+    assert ahosts == hosts
+
+    args["load_balance_hosts"] = "disable"
+    ahosts = [att["host"] for att in conninfo_attempts(args)]
+    assert ahosts == hosts
+
+    args["load_balance_hosts"] = "random"
+    ahosts = [att["host"] for att in conninfo_attempts(args)]
+    assert ahosts != hosts
+    ahosts.sort()
+    assert ahosts == hosts
+
+
 @pytest.fixture
 async def fake_resolve(monkeypatch):
     fake_hosts = {

--- a/tests/test_conninfo.py
+++ b/tests/test_conninfo.py
@@ -1,16 +1,19 @@
 import socket
 import asyncio
 import datetime as dt
+from functools import reduce
 
 import pytest
 
 import psycopg
 from psycopg import ProgrammingError
 from psycopg.conninfo import make_conninfo, conninfo_to_dict, ConnectionInfo
-from psycopg.conninfo import resolve_hostaddr_async
+from psycopg.conninfo import conninfo_attempts, conninfo_attempts_async
 from psycopg._encodings import pg2pyenc
 
+from .acompat import alist
 from .fix_crdb import crdb_encoding
+from ._test_connection import drop_default_args_from_conninfo
 
 snowman = "\u2603"
 
@@ -323,6 +326,42 @@ class TestConnectionInfo:
         ("host='' user=bar", "host='' user=bar", None),
         (
             "host=127.0.0.1 user=bar",
+            "host=127.0.0.1 user=bar",
+            None,
+        ),
+        (
+            "host=1.1.1.1,2.2.2.2 user=bar",
+            "host=1.1.1.1,2.2.2.2 user=bar",
+            None,
+        ),
+        (
+            "host=1.1.1.1,2.2.2.2 port=5432",
+            "host=1.1.1.1,2.2.2.2 port=5432,5432",
+            None,
+        ),
+        (
+            "host=foo.com port=5432",
+            "host=foo.com port=5432 hostaddr=1.2.3.4",
+            {"PGHOSTADDR": "1.2.3.4"},
+        ),
+    ],
+)
+@pytest.mark.anyio
+def test_conninfo_attempts(setpgenv, conninfo, want, env):
+    setpgenv(env)
+    params = conninfo_to_dict(conninfo)
+    attempts = list(conninfo_attempts(params))
+    params = drop_default_args_from_conninfo(reduce(merge_conninfos, attempts))
+    assert drop_default_args_from_conninfo(conninfo_to_dict(want)) == params
+
+
+@pytest.mark.parametrize(
+    "conninfo, want, env",
+    [
+        ("", "", None),
+        ("host='' user=bar", "host='' user=bar", None),
+        (
+            "host=127.0.0.1 user=bar",
             "host=127.0.0.1 user=bar hostaddr=127.0.0.1",
             None,
         ),
@@ -349,13 +388,14 @@ class TestConnectionInfo:
     ],
 )
 @pytest.mark.anyio
-async def test_resolve_hostaddr_async_no_resolve(
+async def test_conninfo_attempts_async_no_resolve(
     setpgenv, conninfo, want, env, fail_resolve
 ):
     setpgenv(env)
     params = conninfo_to_dict(conninfo)
-    params = await resolve_hostaddr_async(params)
-    assert conninfo_to_dict(want) == params
+    attempts = await alist(conninfo_attempts_async(params))
+    params = drop_default_args_from_conninfo(reduce(merge_conninfos, attempts))
+    assert drop_default_args_from_conninfo(conninfo_to_dict(want)) == params
 
 
 @pytest.mark.parametrize(
@@ -399,10 +439,11 @@ async def test_resolve_hostaddr_async_no_resolve(
     ],
 )
 @pytest.mark.anyio
-async def test_resolve_hostaddr_async(conninfo, want, env, fake_resolve):
+async def test_conninfo_attempts_async(conninfo, want, env, fake_resolve):
     params = conninfo_to_dict(conninfo)
-    params = await resolve_hostaddr_async(params)
-    assert conninfo_to_dict(want) == params
+    attempts = await alist(conninfo_attempts_async(params))
+    params = drop_default_args_from_conninfo(reduce(merge_conninfos, attempts))
+    assert drop_default_args_from_conninfo(conninfo_to_dict(want)) == params
 
 
 @pytest.mark.parametrize(
@@ -415,11 +456,27 @@ async def test_resolve_hostaddr_async(conninfo, want, env, fake_resolve):
     ],
 )
 @pytest.mark.anyio
-async def test_resolve_hostaddr_async_bad(setpgenv, conninfo, env, fake_resolve):
+async def test_conninfo_attempts_async_bad(setpgenv, conninfo, env, fake_resolve):
     setpgenv(env)
     params = conninfo_to_dict(conninfo)
     with pytest.raises(psycopg.Error):
-        await resolve_hostaddr_async(params)
+        await alist(conninfo_attempts_async(params))
+
+
+@pytest.mark.parametrize(
+    "conninfo, env",
+    [
+        ("host=foo.com port=1,2", None),
+        ("host=1.1.1.1,2.2.2.2 port=5432,5433,5434", None),
+        ("host=1.1.1.1,2.2.2.2", {"PGPORT": "1,2,3"}),
+    ],
+)
+@pytest.mark.anyio
+def test_conninfo_attempts_bad(setpgenv, conninfo, env):
+    setpgenv(env)
+    params = conninfo_to_dict(conninfo)
+    with pytest.raises(psycopg.Error):
+        list(conninfo_attempts(params))
 
 
 @pytest.fixture
@@ -448,3 +505,18 @@ async def fail_resolve(monkeypatch):
         pytest.fail(f"shouldn't try to resolve {host}")
 
     monkeypatch.setattr(asyncio.get_running_loop(), "getaddrinfo", fail_getaddrinfo)
+
+
+def merge_conninfos(a1, a2):
+    """
+    merge conninfo attempts into a multi-host conninfo.
+    """
+    assert set(a1) == set(a2)
+    rv = {}
+    for k in a1:
+        if k in ("host", "hostaddr", "port"):
+            rv[k] = f"{a1[k]},{a2[k]}"
+        else:
+            assert a1[k] == a2[k]
+            rv[k] = a1[k]
+    return rv

--- a/tests/test_conninfo.py
+++ b/tests/test_conninfo.py
@@ -333,17 +333,17 @@ class TestConnectionInfo:
         ),
         (
             "host=1.1.1.1,2.2.2.2 port=5432",
-            "host=1.1.1.1,2.2.2.2 port=5432 hostaddr=1.1.1.1,2.2.2.2",
+            "host=1.1.1.1,2.2.2.2 port=5432,5432 hostaddr=1.1.1.1,2.2.2.2",
             None,
         ),
         (
             "port=5432",
-            "host=1.1.1.1,2.2.2.2 port=5432 hostaddr=1.1.1.1,2.2.2.2",
+            "host=1.1.1.1,2.2.2.2 port=5432,5432 hostaddr=1.1.1.1,2.2.2.2",
             {"PGHOST": "1.1.1.1,2.2.2.2"},
         ),
         (
             "host=foo.com port=5432",
-            "host=foo.com port=5432",
+            "host=foo.com port=5432 hostaddr=1.2.3.4",
             {"PGHOSTADDR": "1.2.3.4"},
         ),
     ],
@@ -368,7 +368,7 @@ async def test_resolve_hostaddr_async_no_resolve(
         ),
         (
             "host=foo.com,qux.com port=5433",
-            "host=foo.com,qux.com hostaddr=1.1.1.1,2.2.2.2 port=5433",
+            "host=foo.com,qux.com hostaddr=1.1.1.1,2.2.2.2 port=5433,5433",
             None,
         ),
         (

--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -4,6 +4,7 @@ import psycopg
 from psycopg.conninfo import conninfo_to_dict
 
 from .test_conninfo import fake_resolve  # noqa: F401  # fixture
+from ._test_connection import drop_default_args_from_conninfo
 
 
 @pytest.mark.usefixtures("fake_resolve")
@@ -21,7 +22,7 @@ async def test_resolve_hostaddr_conn(aconn_cls, monkeypatch):
 
     assert len(got) == 1
     want = {"host": "foo.com", "hostaddr": "1.1.1.1"}
-    assert conninfo_to_dict(got[0]) == want
+    assert drop_default_args_from_conninfo(got[0]) == want
 
 
 @pytest.mark.dns
@@ -33,7 +34,6 @@ async def test_resolve_hostaddr_async_warning(recwarn):
     params = await psycopg._dns.resolve_hostaddr_async(  # type: ignore[attr-defined]
         params
     )
-    assert conninfo_to_dict(conninfo) == params
     assert "resolve_hostaddr_async" in str(recwarn.pop(DeprecationWarning).message)
 
 

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,10 +1,13 @@
 import pytest
 
 from psycopg._cmodule import _psycopg
+from psycopg.conninfo import conninfo_to_dict
+
+from ._test_connection import drop_default_args_from_conninfo
 
 
 @pytest.mark.parametrize(
-    "args, kwargs, want_conninfo",
+    "args, kwargs, want",
     [
         ((), {}, ""),
         (("dbname=foo",), {"user": "bar"}, "dbname=foo user=bar"),
@@ -12,7 +15,7 @@ from psycopg._cmodule import _psycopg
         ((), {"user": "foo", "dbname": None}, "user=foo"),
     ],
 )
-def test_connect(monkeypatch, dsn, args, kwargs, want_conninfo):
+def test_connect(monkeypatch, dsn, args, kwargs, want):
     # Check the main args passing from psycopg.connect to the conn generator
     # Details of the params manipulation are in test_conninfo.
     import psycopg.connection
@@ -29,7 +32,7 @@ def test_connect(monkeypatch, dsn, args, kwargs, want_conninfo):
     monkeypatch.setattr(psycopg.generators, "connect", mock_connect)
 
     conn = psycopg.connect(*args, **kwargs)
-    assert got_conninfo == want_conninfo
+    assert drop_default_args_from_conninfo(got_conninfo) == conninfo_to_dict(want)
     conn.close()
 
 

--- a/tests/test_psycopg_dbapi20.py
+++ b/tests/test_psycopg_dbapi20.py
@@ -7,6 +7,7 @@ from psycopg.conninfo import conninfo_to_dict
 
 from . import dbapi20
 from . import dbapi20_tpc
+from ._test_connection import drop_default_args_from_conninfo
 
 
 @pytest.fixture(scope="class")
@@ -125,25 +126,25 @@ def test_time_from_ticks(ticks, want):
         (("host=foo user=bar",), {}, "host=foo user=bar"),
         (("host=foo",), {"user": "baz"}, "host=foo user=baz"),
         (
-            ("host=foo port=5432",),
+            ("host=foo port=5433",),
             {"host": "qux", "user": "joe"},
-            "host=qux user=joe port=5432",
+            "host=qux user=joe port=5433",
         ),
         (("host=foo",), {"user": None}, "host=foo"),
     ],
 )
 def test_connect_args(monkeypatch, pgconn, args, kwargs, want):
-    the_conninfo: str
+    got_conninfo: str
 
     def fake_connect(conninfo):
-        nonlocal the_conninfo
-        the_conninfo = conninfo
+        nonlocal got_conninfo
+        got_conninfo = conninfo
         return pgconn
         yield
 
     monkeypatch.setattr(psycopg.generators, "connect", fake_connect)
     conn = psycopg.connect(*args, **kwargs)
-    assert conninfo_to_dict(the_conninfo) == conninfo_to_dict(want)
+    assert drop_default_args_from_conninfo(got_conninfo) == conninfo_to_dict(want)
     conn.close()
 
 

--- a/tools/async_to_sync.py
+++ b/tools/async_to_sync.py
@@ -308,6 +308,7 @@ class RenameAsyncToSync(ast.NodeTransformer):
         "aspawn": "spawn",
         "asynccontextmanager": "contextmanager",
         "connection_async": "connection",
+        "conninfo_attempts_async": "conninfo_attempts",
         "current_task_name": "current_thread_name",
         "cursor_async": "cursor",
         "ensure_table_async": "ensure_table",


### PR DESCRIPTION
When using the async connection path, the libpq doesn't try connection attempts to multiple hosts. Which is kinda natural, as it doesn't enforce the timeout, so it wouldn't know when to proceed.

This MR splits a conninfo containing more than one host into a sequence of attempt, each one to be tried with the connection timeout requested, or with a finite default (set to an arbitrary 2m 10s because that's what my Ubuntu times out with).

The mechanism of splitting a conninfo into leads itself to a simpler implementation of the async DNS lookup. In particular, previously we would have looked up all the host before attempting a connection; now we look up only the host as we try to connect to.

This MR might close:

- #602
- #674 

To do:

- [x] Add tests for the connection attempts
- [x] Implement [attempts randomization](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-LOAD-BALANCE-HOSTS)
- [x] Move `conninfo.resolve_hostaddr_async` to `conninfo._dsn`: the first version is no more used internally; the latter is exposed as deprecated function but we won't drop it right now.