### PR TITLE
Add test for client cursor with list param

### DIFF
--- a/tests/test_cursor_client_async.py
+++ b/tests/test_cursor_client_async.py
@@ -131,6 +131,7 @@ async def test_leak(aconn_cls, dsn, faker, fetch, row_factory):
         ("select %%, %s", (["a"],), "select %, 'a'"),
         ("select %%, %(foo)s", ({"foo": "x"},), "select %, 'x'"),
         ("select %%s, %(foo)s", ({"foo": "x"},), "select %s, 'x'"),
+        ("select %%s, ANY(%(foo)s)", ({"foo": ["x", "y"]},), "select %s, ANY({'x','y'})"),
     ],
 )
 async def test_mogrify(aconn, query, params, want):


### PR DESCRIPTION
Coming from psycopg2, I'm trying to update queries that use lists with `IN`. I've already read the docs and try to use `ANY` now, but without success. I'm using the client cursor and what basically happens is that it seems to just make a string out of any list I give it and slap that into the `ANY`.

As I didn't see it covered yet, I added a test case. It fails and hopefully illustrates the issue, given what I'm doing is on the right track.