### PR TITLE
[maint-3.1] fix: flush PG environment variables in test_connect{,_args}

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -409,6 +409,7 @@ def test_connect_args(conn_cls, monkeypatch, setpgenv, pgconn, args, kwargs, wan
         return pgconn
         yield
 
+    setpgenv({})
     monkeypatch.setattr(psycopg.connection, "connect", fake_connect)
     conn = conn_cls.connect(*args, **kwargs)
     got_params = drop_default_args_from_conninfo(got_conninfo)

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -15,7 +15,7 @@ from .test_connection import drop_default_args_from_conninfo
         ((), {"user": "foo", "dbname": None}, "user=foo"),
     ],
 )
-def test_connect(monkeypatch, dsn, args, kwargs, want, setpgenv):
+def test_connect(monkeypatch, dsn_env, args, kwargs, want, setpgenv):
     # Check the main args passing from psycopg.connect to the conn generator
     # Details of the params manipulation are in test_conninfo.
     import psycopg.connection
@@ -27,7 +27,7 @@ def test_connect(monkeypatch, dsn, args, kwargs, want, setpgenv):
     def mock_connect(conninfo):
         nonlocal got_conninfo
         got_conninfo = conninfo
-        return orig_connect(dsn)
+        return orig_connect(dsn_env)
 
     setpgenv({})
     monkeypatch.setattr(psycopg.connection, "connect", mock_connect)

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -15,7 +15,7 @@ from .test_connection import drop_default_args_from_conninfo
         ((), {"user": "foo", "dbname": None}, "user=foo"),
     ],
 )
-def test_connect(monkeypatch, dsn, args, kwargs, want):
+def test_connect(monkeypatch, dsn, args, kwargs, want, setpgenv):
     # Check the main args passing from psycopg.connect to the conn generator
     # Details of the params manipulation are in test_conninfo.
     import psycopg.connection
@@ -29,6 +29,7 @@ def test_connect(monkeypatch, dsn, args, kwargs, want):
         got_conninfo = conninfo
         return orig_connect(dsn)
 
+    setpgenv({})
     monkeypatch.setattr(psycopg.connection, "connect", mock_connect)
 
     conn = psycopg.connect(*args, **kwargs)

--- a/tests/test_psycopg_dbapi20.py
+++ b/tests/test_psycopg_dbapi20.py
@@ -133,7 +133,7 @@ def test_time_from_ticks(ticks, want):
         (("host=foo",), {"user": None}, "host=foo"),
     ],
 )
-def test_connect_args(monkeypatch, pgconn, args, kwargs, want):
+def test_connect_args(monkeypatch, pgconn, args, kwargs, want, setpgenv):
     got_conninfo: str
 
     def fake_connect(conninfo):
@@ -142,6 +142,7 @@ def test_connect_args(monkeypatch, pgconn, args, kwargs, want):
         return pgconn
         yield
 
+    setpgenv({})
     monkeypatch.setattr(psycopg.connection, "connect", fake_connect)
     conn = psycopg.connect(*args, **kwargs)
     assert drop_default_args_from_conninfo(got_conninfo) == conninfo_to_dict(want)


### PR DESCRIPTION
These tests were previously affected by environment variables, that can be used to configure a postgresql instance.

Closes: #681