### PR TITLE
Fix support for gevent

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,6 +38,8 @@ jobs:
           - {impl: c, python: "3.11", postgres: "postgres:12", libpq: oldest}
           - {impl: c, python: "3.12", postgres: "postgres:11", libpq: newest}
 
+          - {impl: python, python: "3.8", ext: gevent, postgres: "postgres:16"}
+          - {impl: c, python: "3.12", ext: gevent, postgres: "postgres:14"}
           - {impl: python, python: "3.9", ext: dns, postgres: "postgres:14"}
           - {impl: python, python: "3.9", ext: postgis, postgres: "postgis/postgis"}
           - {impl: python, python: "3.10", ext: numpy, postgres: "postgres:14"}
@@ -76,6 +78,12 @@ jobs:
         run: |
           echo "DEPS=$DEPS ./psycopg_c" >> $GITHUB_ENV
 
+      - name: Include gevent to the packages to install
+        if: ${{ matrix.ext == 'gevent' }}
+        run: |
+          echo "DEPS=$DEPS gevent" >> $GITHUB_ENV
+          echo "MARKERS=$MARKERS gevent" >> $GITHUB_ENV
+
       - name: Include dnspython to the packages to install
         if: ${{ matrix.ext == 'dns' }}
         run: |
@@ -96,7 +104,7 @@ jobs:
       - name: Configure to use the oldest dependencies
         if: ${{ matrix.ext == 'min' }}
         run: |
-          echo "DEPS=$DEPS dnspython shapely numpy" >> $GITHUB_ENV
+          echo "DEPS=$DEPS dnspython shapely numpy gevent" >> $GITHUB_ENV
           echo "PIP_CONSTRAINT=${{ github.workspace }}/tests/constraints.txt" \
             >> $GITHUB_ENV
 

--- a/docs/advanced/async.rst
+++ b/docs/advanced/async.rst
@@ -141,6 +141,31 @@ manually cancel connections.  This should no longer be necessary.
 .. __: https://docs.python.org/3/library/asyncio-task.html#task-cancellation
 
 
+.. index:: gevent
+
+.. _gevent:
+
+Gevent support
+--------------
+
+Psycopg 3 supports `gevent <https://www.gevent.org/>`__ out of the box. If the
+`socket` module is found patched by functions such as
+`gevent.monkey.patch_select()`__ or `patch_all()`__, psycopg will behave in a
+collaborative way.
+
+Unlike with `!psycopg2`, using the `!psycogreen` module is not required.
+
+.. __: http://www.gevent.org/api/gevent.monkey.html#gevent.monkey.patch_select
+.. __: http://www.gevent.org/api/gevent.monkey.html#gevent.monkey.patch_all
+
+.. warning::
+
+    gevent support was initially accidental, and was accidentally broken in
+    psycopg 3.1.4.
+
+    gevent is officially supported only starting from psycopg 3.1.14.
+
+
 .. index::
     pair: Asynchronous; Notifications
     pair: LISTEN; SQL command

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -30,6 +30,14 @@ Psycopg 3.2 (unreleased)
 .. __: https://numpy.org/doc/stable/reference/arrays.scalars.html#built-in-scalar-types
 
 
+Psycopg 3.1.14 (unreleased)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Fix :ref:`interaction with gevent <gevent>` (:ticket:`#527`).
+
+.. _gevent: https://www.gevent.org/
+
+
 Current release
 ---------------
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ def pytest_configure(config):
         # catch the exception for my life.
         "subprocess: the test import psycopg after subprocess",
         "timing: the test is timing based and can fail on cheese hardware",
+        "gevent: the test requires the gevent module to be installed",
         "dns: the test requires dnspython to run",
         "postgis: the test requires the PostGIS extension to run",
         "numpy: the test requires numpy module to be installed",

--- a/tests/test_gevent.py
+++ b/tests/test_gevent.py
@@ -7,6 +7,8 @@ import psycopg
 
 pytest.importorskip("gevent")
 
+pytestmark = [pytest.mark.gevent]
+
 
 @pytest.mark.slow
 @pytest.mark.timing

--- a/tests/test_gevent.py
+++ b/tests/test_gevent.py
@@ -1,0 +1,82 @@
+import sys
+import json
+import subprocess as sp
+
+import pytest
+import psycopg
+
+pytest.importorskip("gevent")
+
+
+@pytest.mark.slow
+@pytest.mark.timing
+def test_gevent(dsn):
+    TICK = 0.1
+    script = f"""\
+import gevent.monkey
+gevent.monkey.patch_all()
+
+import json
+import time
+import gevent
+import psycopg
+
+TICK = {TICK!r}
+dts = []
+queried = False
+
+def ticker():
+    t0 = time.time()
+    for i in range(5):
+        time.sleep(TICK)
+        t = time.time()
+        dts.append(t - t0)
+        t0 = t
+
+def querier():
+    time.sleep(TICK * 2)
+    with psycopg.connect({dsn!r}) as conn:
+        conn.execute("select pg_sleep(0.3)")
+
+    global queried
+    queried = True
+
+jobs = [gevent.spawn(ticker), gevent.spawn(querier)]
+gevent.joinall(jobs, timeout=3)
+print(json.dumps(dts))
+"""
+    cmdline = [sys.executable, "-c", script]
+    rv = sp.run(cmdline, check=True, text=True, stdout=sp.PIPE)
+    dts = json.loads(rv.stdout)
+
+    for dt in dts:
+        assert TICK <= dt < TICK * 1.1
+
+
+@pytest.mark.skipif("not psycopg._cmodule._psycopg")
+def test_patched_dont_use_wait_c():
+    if psycopg.waiting.wait is not psycopg.waiting.wait_c:
+        pytest.skip("wait_c not normally in use")
+
+    script = """
+import gevent.monkey
+gevent.monkey.patch_all()
+
+import psycopg
+assert psycopg.waiting.wait is not psycopg.waiting.wait_c
+"""
+    sp.check_call([sys.executable, "-c", script])
+
+
+@pytest.mark.skipif("not psycopg._cmodule._psycopg")
+def test_unpatched_still_use_wait_c():
+    if psycopg.waiting.wait is not psycopg.waiting.wait_c:
+        pytest.skip("wait_c not normally in use")
+
+    script = """
+import gevent.monkey
+
+import psycopg
+assert psycopg.waiting.wait is psycopg.waiting.wait_c
+"""
+    sp.check_call([sys.executable, "-c", script])


### PR DESCRIPTION
In order to support gevent is just sufficient to avoid using the `wait_c` function; the monkeypatching mechanism can take care of it. This way `psycogreen` is not needed.

Detect that gevent has patched the `socket` module, and, if so, collaborate. Added test to prove that collaboration works as expected.

- Close #527
- Close #536 