### PR TITLE
test: let pytest show more info in summary

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ requires = ["setuptools>=49.2.0", "wheel>=0.37"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
+addopts = "-ra"
 filterwarnings = [
     "error",
 ]


### PR DESCRIPTION
We add '-ra' to pytest options so as to get report about "(a)ll except passed" tests. This is in particular useful to get the detailed message about why some tests got skipped (especially useful in CI).