### PR TITLE
Fix conninfo handling

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -17,6 +17,8 @@ Psycopg 3.1.15 (unreleased)
   :ticket:`#694`).
 - Fix async connection to hosts resolving to multiple IP addresses (regression
   in 3.1.13, :ticket:`#695`).
+- Respect the :envvar:`PGCONNECT_TIMEOUT` environment variable to determine
+  the connection timeout.
 
 
 Current release

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -13,8 +13,10 @@ Future releases
 Psycopg 3.1.15 (unreleased)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- Fix async connection to hosts resolving to  multiple IP addresses
-  (:ticket:`#695`).
+- Fix use of ``service`` in connection string (regression in 3.1.13,
+  :ticket:`#694`).
+- Fix async connection to hosts resolving to multiple IP addresses (regression
+  in 3.1.13, :ticket:`#695`).
 
 
 Current release

--- a/psycopg/psycopg/_dns.py
+++ b/psycopg/psycopg/_dns.py
@@ -52,13 +52,15 @@ async def resolve_hostaddr_async(params: Dict[str, Any]) -> Dict[str, Any]:
     hostaddrs: list[str] = []
     ports: list[str] = []
 
-    for attempt in conninfo._split_attempts(conninfo._inject_defaults(params)):
+    for attempt in conninfo._split_attempts(params):
         try:
             async for a2 in conninfo._split_attempts_and_resolve(attempt):
-                hosts.append(a2["host"])
-                hostaddrs.append(a2["hostaddr"])
-                if "port" in params:
-                    ports.append(a2["port"])
+                if a2.get("host") is not None:
+                    hosts.append(a2["host"])
+                if a2.get("hostaddr") is not None:
+                    hostaddrs.append(a2["hostaddr"])
+                if a2.get("port") is not None:
+                    ports.append(str(a2["port"]))
         except OSError as ex:
             last_exc = ex
 

--- a/psycopg/psycopg/_dns.py
+++ b/psycopg/psycopg/_dns.py
@@ -52,21 +52,13 @@ async def resolve_hostaddr_async(params: Dict[str, Any]) -> Dict[str, Any]:
     hostaddrs: list[str] = []
     ports: list[str] = []
 
-    for attempt in conninfo._split_attempts(params):
-        try:
-            async for a2 in conninfo._split_attempts_and_resolve(attempt):
-                if a2.get("host") is not None:
-                    hosts.append(a2["host"])
-                if a2.get("hostaddr") is not None:
-                    hostaddrs.append(a2["hostaddr"])
-                if a2.get("port") is not None:
-                    ports.append(str(a2["port"]))
-        except OSError as ex:
-            last_exc = ex
-
-    if params.get("host") and not hosts:
-        # We couldn't resolve anything
-        raise e.OperationalError(str(last_exc))
+    async for attempt in conninfo.conninfo_attempts_async(params):
+        if attempt.get("host") is not None:
+            hosts.append(attempt["host"])
+        if attempt.get("hostaddr") is not None:
+            hostaddrs.append(attempt["hostaddr"])
+        if attempt.get("port") is not None:
+            ports.append(str(attempt["port"]))
 
     out = params.copy()
     shosts = ",".join(hosts)

--- a/psycopg/psycopg/_dns.py
+++ b/psycopg/psycopg/_dns.py
@@ -52,7 +52,7 @@ async def resolve_hostaddr_async(params: Dict[str, Any]) -> Dict[str, Any]:
     hostaddrs: list[str] = []
     ports: list[str] = []
 
-    async for attempt in conninfo.conninfo_attempts_async(params):
+    for attempt in await conninfo.conninfo_attempts_async(params):
         if attempt.get("host") is not None:
             hosts.append(attempt["host"])
         if attempt.get("hostaddr") is not None:

--- a/psycopg/psycopg/connection.py
+++ b/psycopg/psycopg/connection.py
@@ -31,7 +31,7 @@ from .cursor import Cursor
 from ._compat import LiteralString
 from .pq.misc import connection_summary
 from .conninfo import make_conninfo, conninfo_to_dict, ConnectionInfo
-from .conninfo import conninfo_attempts, ConnDict
+from .conninfo import conninfo_attempts, ConnDict, timeout_from_conninfo
 from ._pipeline import BasePipeline, Pipeline
 from .generators import notifies, connect, execute
 from ._encodings import pgconn_encoding
@@ -106,11 +106,6 @@ class BaseConnection(Generic[Row]):
     # Enums useful for the connection
     ConnStatus = pq.ConnStatus
     TransactionStatus = pq.TransactionStatus
-
-    # Default timeout for connection a attempt.
-    # Arbitrary timeout, what applied by the libpq on my computer.
-    # Your mileage won't vary.
-    _DEFAULT_CONNECT_TIMEOUT = 130
 
     def __init__(self, pgconn: "PGconn"):
         self.pgconn = pgconn
@@ -730,7 +725,7 @@ class Connection(BaseConnection[Row]):
         Connect to a database server and return a new `Connection` instance.
         """
         params = cls._get_connection_params(conninfo, **kwargs)
-        timeout = int(params["connect_timeout"])
+        timeout = timeout_from_conninfo(params)
         rv = None
         attempts = conninfo_attempts(params)
         for attempt in attempts:
@@ -803,18 +798,7 @@ class Connection(BaseConnection[Row]):
         :return: Connection arguments merged and eventually modified, in a
             format similar to `~conninfo.conninfo_to_dict()`.
         """
-        params = conninfo_to_dict(conninfo, **kwargs)
-
-        # Make sure there is an usable connect_timeout
-        if "connect_timeout" in params:
-            params["connect_timeout"] = int(params["connect_timeout"])
-        else:
-            # The sync connect function will stop on the default socket timeout
-            # Because in async connection mode we need to enforce the timeout
-            # ourselves, we need a finite value.
-            params["connect_timeout"] = cls._DEFAULT_CONNECT_TIMEOUT
-
-        return params
+        return conninfo_to_dict(conninfo, **kwargs)
 
     def close(self) -> None:
         """Close the database connection."""

--- a/psycopg/psycopg/connection_async.py
+++ b/psycopg/psycopg/connection_async.py
@@ -120,12 +120,22 @@ class AsyncConnection(BaseConnection[Row]):
         params = await cls._get_connection_params(conninfo, **kwargs)
         timeout = int(params["connect_timeout"])
         rv = None
-        for attempt in await conninfo_attempts_async(params):
+        attempts = await conninfo_attempts_async(params)
+        for attempt in attempts:
             try:
                 conninfo = make_conninfo(**attempt)
                 rv = await cls._wait_conn(cls._connect_gen(conninfo), timeout=timeout)
                 break
             except e._NO_TRACEBACK as ex:
+                if len(attempts) > 1:
+                    logger.debug(
+                        "connection attempt failed on host: %r, port: %r,"
+                        " hostaddr: %r: %s",
+                        attempt.get("host"),
+                        attempt.get("port"),
+                        attempt.get("hostaddr"),
+                        str(ex),
+                    )
                 last_ex = ex
 
         if not rv:

--- a/psycopg/psycopg/connection_async.py
+++ b/psycopg/psycopg/connection_async.py
@@ -120,7 +120,7 @@ class AsyncConnection(BaseConnection[Row]):
         params = await cls._get_connection_params(conninfo, **kwargs)
         timeout = int(params["connect_timeout"])
         rv = None
-        async for attempt in conninfo_attempts_async(params):
+        for attempt in await conninfo_attempts_async(params):
             try:
                 conninfo = make_conninfo(**attempt)
                 rv = await cls._wait_conn(cls._connect_gen(conninfo), timeout=timeout)

--- a/psycopg/psycopg/conninfo.py
+++ b/psycopg/psycopg/conninfo.py
@@ -304,7 +304,7 @@ def conninfo_attempts(params: ConnDict) -> list[ConnDict]:
     # one attempt and wouldn't get to try the following ones, as before
     # fixing #674.
     attempts = _split_attempts(params)
-    if params.get("load_balance_hosts", "disable") == "random":
+    if _get_param(params, "load_balance_hosts") == "random":
         shuffle(attempts)
     return attempts
 
@@ -337,7 +337,7 @@ async def conninfo_attempts_async(params: ConnDict) -> list[ConnDict]:
         # We couldn't resolve anything
         raise e.OperationalError(str(last_exc))
 
-    if params.get("load_balance_hosts", "disable") == "random":
+    if _get_param(params, "load_balance_hosts") == "random":
         shuffle(attempts)
 
     return attempts

--- a/psycopg/psycopg/conninfo.py
+++ b/psycopg/psycopg/conninfo.py
@@ -446,7 +446,9 @@ def timeout_from_conninfo(params: ConnDict) -> int:
     # - at least 2 seconds.
     #
     # See connectDBComplete in fe-connect.c
-    value = params.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
+    value: str | int | None = _get_param(params, "connect_timeout")
+    if value is None:
+        value = _DEFAULT_CONNECT_TIMEOUT
     try:
         timeout = int(value)
     except ValueError:

--- a/psycopg/psycopg/conninfo.py
+++ b/psycopg/psycopg/conninfo.py
@@ -422,12 +422,7 @@ async def _resolve_hostnames(params: ConnDict) -> list[ConnDict]:
 
     loop = asyncio.get_running_loop()
 
-    port = _get_param(params, "port")
-    if not port:
-        portdef = _get_param_def("port")
-        if portdef:
-            port = portdef.compiled
-
+    port = _get_param(params, "port", compiled_default=True)
     assert port and "," not in port  # assume a libpq default and no multi
     ans = await loop.getaddrinfo(
         host, int(port), proto=socket.IPPROTO_TCP, type=socket.SOCK_STREAM
@@ -466,7 +461,9 @@ def timeout_from_conninfo(params: ConnDict) -> int:
     return timeout
 
 
-def _get_param(params: ConnDict, name: str) -> str | None:
+def _get_param(
+    params: ConnDict, name: str, compiled_default: bool = False
+) -> str | None:
     """
     Return a value from a connection string.
 
@@ -485,7 +482,7 @@ def _get_param(params: ConnDict, name: str) -> str | None:
     if env is not None:
         return env
 
-    return None
+    return paramdef.compiled if compiled_default else None
 
 
 @dataclass

--- a/psycopg/psycopg/conninfo.py
+++ b/psycopg/psycopg/conninfo.py
@@ -10,7 +10,7 @@ import os
 import re
 import socket
 import asyncio
-from typing import Any, Iterator, AsyncIterator
+from typing import Any
 from random import shuffle
 from pathlib import Path
 from datetime import tzinfo
@@ -282,7 +282,7 @@ class ConnectionInfo:
         return value.decode(self.encoding)
 
 
-def conninfo_attempts(params: ConnDict) -> Iterator[ConnDict]:
+def conninfo_attempts(params: ConnDict) -> list[ConnDict]:
     """Split a set of connection params on the single attempts to perform.
 
     A connection param can perform more than one attempt more than one ``host``
@@ -298,10 +298,10 @@ def conninfo_attempts(params: ConnDict) -> Iterator[ConnDict]:
     attempts = _split_attempts(params)
     if params.get("load_balance_hosts", "disable") == "random":
         shuffle(attempts)
-    yield from attempts
+    return attempts
 
 
-async def conninfo_attempts_async(params: ConnDict) -> AsyncIterator[ConnDict]:
+async def conninfo_attempts_async(params: ConnDict) -> list[ConnDict]:
     """Split a set of connection params on the single attempts to perform.
 
     A connection param can perform more than one attempt more than one ``host``
@@ -331,8 +331,7 @@ async def conninfo_attempts_async(params: ConnDict) -> AsyncIterator[ConnDict]:
     if params.get("load_balance_hosts", "disable") == "random":
         shuffle(attempts)
 
-    for attempt in attempts:
-        yield attempt
+    return attempts
 
 
 def _split_attempts(params: ConnDict) -> list[ConnDict]:

--- a/psycopg/psycopg/conninfo.py
+++ b/psycopg/psycopg/conninfo.py
@@ -10,6 +10,7 @@ import os
 import re
 import socket
 import asyncio
+import logging
 from typing import Any
 from random import shuffle
 from pathlib import Path
@@ -25,6 +26,8 @@ from ._tz import get_tzinfo
 from ._encodings import pgconn_encoding
 
 ConnDict: TypeAlias = "dict[str, Any]"
+
+logger = logging.getLogger("psycopg")
 
 
 def make_conninfo(conninfo: str = "", **kwargs: Any) -> str:
@@ -321,6 +324,7 @@ async def conninfo_attempts_async(params: ConnDict) -> list[ConnDict]:
         try:
             attempts.extend(await _resolve_hostnames(attempt))
         except OSError as ex:
+            logger.debug("failed to resolve host %r: %s", attempt.get("host"), str(ex))
             last_exc = ex
 
     if not attempts:

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -876,13 +876,6 @@ def drop_default_args_from_conninfo(conninfo):
         if params.get(key) == value:
             params.pop(key)
 
-    removeif("host", "")
-    removeif("hostaddr", "")
-    removeif("port", "5432")
-    if "," in params.get("host", ""):
-        nhosts = len(params["host"].split(","))
-        removeif("port", ",".join(["5432"] * nhosts))
-        removeif("hostaddr", "," * (nhosts - 1))
     removeif("connect_timeout", str(DEFAULT_TIMEOUT))
 
     return params

--- a/tests/test_conninfo.py
+++ b/tests/test_conninfo.py
@@ -10,7 +10,6 @@ from psycopg.conninfo import make_conninfo, conninfo_to_dict, ConnectionInfo
 from psycopg.conninfo import conninfo_attempts, conninfo_attempts_async
 from psycopg._encodings import pg2pyenc
 
-from .utils import alist
 from .fix_crdb import crdb_encoding
 
 snowman = "\u2603"
@@ -349,7 +348,7 @@ class TestConnectionInfo:
 def test_conninfo_attempts(setpgenv, conninfo, want, env):
     setpgenv(env)
     params = conninfo_to_dict(conninfo)
-    attempts = list(conninfo_attempts(params))
+    attempts = conninfo_attempts(params)
     want = list(map(conninfo_to_dict, want))
     assert want == attempts
 
@@ -401,7 +400,7 @@ async def test_conninfo_attempts_async_no_resolve(
 ):
     setpgenv(env)
     params = conninfo_to_dict(conninfo)
-    attempts = await alist(conninfo_attempts_async(params))
+    attempts = await conninfo_attempts_async(params)
     want = list(map(conninfo_to_dict, want))
     assert want == attempts
 
@@ -460,7 +459,7 @@ async def test_conninfo_attempts_async_no_resolve(
 @pytest.mark.anyio
 async def test_conninfo_attempts_async(conninfo, want, env, fake_resolve):
     params = conninfo_to_dict(conninfo)
-    attempts = await alist(conninfo_attempts_async(params))
+    attempts = await conninfo_attempts_async(params)
     want = list(map(conninfo_to_dict, want))
     assert want == attempts
 
@@ -479,7 +478,7 @@ async def test_conninfo_attempts_async_bad(setpgenv, conninfo, env, fake_resolve
     setpgenv(env)
     params = conninfo_to_dict(conninfo)
     with pytest.raises(psycopg.Error):
-        await alist(conninfo_attempts_async(params))
+        await conninfo_attempts_async(params)
 
 
 @pytest.mark.parametrize(
@@ -495,7 +494,7 @@ def test_conninfo_attempts_bad(setpgenv, conninfo, env):
     setpgenv(env)
     params = conninfo_to_dict(conninfo)
     with pytest.raises(psycopg.Error):
-        list(conninfo_attempts(params))
+        conninfo_attempts(params)
 
 
 def test_conninfo_random():
@@ -518,16 +517,16 @@ def test_conninfo_random():
 @pytest.mark.anyio
 async def test_conninfo_random_async(fake_resolve):
     args = {"host": "alot.com"}
-    hostaddrs = [att["hostaddr"] async for att in conninfo_attempts_async(args)]
+    hostaddrs = [att["hostaddr"] for att in await conninfo_attempts_async(args)]
     assert len(hostaddrs) == 20
     assert hostaddrs == sorted(hostaddrs)
 
     args["load_balance_hosts"] = "disable"
-    hostaddrs = [att["hostaddr"] async for att in conninfo_attempts_async(args)]
+    hostaddrs = [att["hostaddr"] for att in await conninfo_attempts_async(args)]
     assert hostaddrs == sorted(hostaddrs)
 
     args["load_balance_hosts"] = "random"
-    hostaddrs = [att["hostaddr"] async for att in conninfo_attempts_async(args)]
+    hostaddrs = [att["hostaddr"] for att in await conninfo_attempts_async(args)]
     assert hostaddrs != sorted(hostaddrs)
 
 

--- a/tests/test_conninfo.py
+++ b/tests/test_conninfo.py
@@ -1,7 +1,6 @@
 import socket
 import asyncio
 import datetime as dt
-from functools import reduce
 
 import pytest
 
@@ -13,7 +12,6 @@ from psycopg._encodings import pg2pyenc
 
 from .utils import alist
 from .fix_crdb import crdb_encoding
-from .test_connection import drop_default_args_from_conninfo
 
 snowman = "\u2603"
 
@@ -322,26 +320,27 @@ class TestConnectionInfo:
 @pytest.mark.parametrize(
     "conninfo, want, env",
     [
-        ("", "", None),
-        ("host='' user=bar", "host='' user=bar", None),
+        ("", [""], None),
+        ("service=foo", ["service=foo"], None),
+        ("host='' user=bar", ["host='' user=bar"], None),
         (
             "host=127.0.0.1 user=bar",
-            "host=127.0.0.1 user=bar",
+            ["host=127.0.0.1 user=bar"],
             None,
         ),
         (
             "host=1.1.1.1,2.2.2.2 user=bar",
-            "host=1.1.1.1,2.2.2.2 user=bar",
+            ["host=1.1.1.1 user=bar", "host=2.2.2.2 user=bar"],
             None,
         ),
         (
             "host=1.1.1.1,2.2.2.2 port=5432",
-            "host=1.1.1.1,2.2.2.2 port=5432,5432",
+            ["host=1.1.1.1 port=5432", "host=2.2.2.2 port=5432"],
             None,
         ),
         (
             "host=foo.com port=5432",
-            "host=foo.com port=5432 hostaddr=1.2.3.4",
+            ["host=foo.com port=5432"],
             {"PGHOSTADDR": "1.2.3.4"},
         ),
     ],
@@ -351,38 +350,47 @@ def test_conninfo_attempts(setpgenv, conninfo, want, env):
     setpgenv(env)
     params = conninfo_to_dict(conninfo)
     attempts = list(conninfo_attempts(params))
-    params = drop_default_args_from_conninfo(reduce(merge_conninfos, attempts))
-    assert drop_default_args_from_conninfo(conninfo_to_dict(want)) == params
+    want = list(map(conninfo_to_dict, want))
+    assert want == attempts
 
 
 @pytest.mark.parametrize(
     "conninfo, want, env",
     [
-        ("", "", None),
-        ("host='' user=bar", "host='' user=bar", None),
+        ("", [""], None),
+        ("host='' user=bar", ["host='' user=bar"], None),
         (
             "host=127.0.0.1 user=bar",
-            "host=127.0.0.1 user=bar hostaddr=127.0.0.1",
+            ["host=127.0.0.1 user=bar hostaddr=127.0.0.1"],
             None,
         ),
         (
             "host=1.1.1.1,2.2.2.2 user=bar",
-            "host=1.1.1.1,2.2.2.2 user=bar hostaddr=1.1.1.1,2.2.2.2",
+            [
+                "host=1.1.1.1 user=bar hostaddr=1.1.1.1",
+                "host=2.2.2.2 user=bar hostaddr=2.2.2.2",
+            ],
             None,
         ),
         (
             "host=1.1.1.1,2.2.2.2 port=5432",
-            "host=1.1.1.1,2.2.2.2 port=5432,5432 hostaddr=1.1.1.1,2.2.2.2",
+            [
+                "host=1.1.1.1 port=5432 hostaddr=1.1.1.1",
+                "host=2.2.2.2 port=5432 hostaddr=2.2.2.2",
+            ],
             None,
         ),
         (
             "port=5432",
-            "host=1.1.1.1,2.2.2.2 port=5432,5432 hostaddr=1.1.1.1,2.2.2.2",
+            [
+                "host=1.1.1.1 port=5432 hostaddr=1.1.1.1",
+                "host=2.2.2.2 port=5432 hostaddr=2.2.2.2",
+            ],
             {"PGHOST": "1.1.1.1,2.2.2.2"},
         ),
         (
             "host=foo.com port=5432",
-            "host=foo.com port=5432 hostaddr=1.2.3.4",
+            ["host=foo.com port=5432"],
             {"PGHOSTADDR": "1.2.3.4"},
         ),
     ],
@@ -394,8 +402,8 @@ async def test_conninfo_attempts_async_no_resolve(
     setpgenv(env)
     params = conninfo_to_dict(conninfo)
     attempts = await alist(conninfo_attempts_async(params))
-    params = drop_default_args_from_conninfo(reduce(merge_conninfos, attempts))
-    assert drop_default_args_from_conninfo(conninfo_to_dict(want)) == params
+    want = list(map(conninfo_to_dict, want))
+    assert want == attempts
 
 
 @pytest.mark.parametrize(
@@ -403,42 +411,48 @@ async def test_conninfo_attempts_async_no_resolve(
     [
         (
             "host=foo.com,qux.com",
-            "host=foo.com,qux.com hostaddr=1.1.1.1,2.2.2.2",
+            ["host=foo.com hostaddr=1.1.1.1", "host=qux.com hostaddr=2.2.2.2"],
             None,
         ),
         (
             "host=foo.com,qux.com port=5433",
-            "host=foo.com,qux.com hostaddr=1.1.1.1,2.2.2.2 port=5433,5433",
+            [
+                "host=foo.com hostaddr=1.1.1.1 port=5433",
+                "host=qux.com hostaddr=2.2.2.2 port=5433",
+            ],
             None,
         ),
         (
             "host=foo.com,qux.com port=5432,5433",
-            "host=foo.com,qux.com hostaddr=1.1.1.1,2.2.2.2 port=5432,5433",
+            [
+                "host=foo.com hostaddr=1.1.1.1 port=5432",
+                "host=qux.com hostaddr=2.2.2.2 port=5433",
+            ],
             None,
         ),
         (
             "host=foo.com,nosuchhost.com",
-            "host=foo.com hostaddr=1.1.1.1",
+            ["host=foo.com hostaddr=1.1.1.1"],
             None,
         ),
         (
             "host=foo.com, port=5432,5433",
-            "host=foo.com, hostaddr=1.1.1.1, port=5432,5433",
+            ["host=foo.com hostaddr=1.1.1.1 port=5432", "host='' port=5433"],
             None,
         ),
         (
             "host=nosuchhost.com,foo.com",
-            "host=foo.com hostaddr=1.1.1.1",
+            ["host=foo.com hostaddr=1.1.1.1"],
             None,
         ),
         (
             "host=foo.com,qux.com",
-            "host=foo.com,qux.com hostaddr=1.1.1.1,2.2.2.2",
+            ["host=foo.com hostaddr=1.1.1.1", "host=qux.com hostaddr=2.2.2.2"],
             {},
         ),
         (
             "host=dup.com",
-            "host=dup.com,dup.com hostaddr=3.3.3.3,3.3.3.4",
+            ["host=dup.com hostaddr=3.3.3.3", "host=dup.com hostaddr=3.3.3.4"],
             None,
         ),
     ],
@@ -447,8 +461,8 @@ async def test_conninfo_attempts_async_no_resolve(
 async def test_conninfo_attempts_async(conninfo, want, env, fake_resolve):
     params = conninfo_to_dict(conninfo)
     attempts = await alist(conninfo_attempts_async(params))
-    params = drop_default_args_from_conninfo(reduce(merge_conninfos, attempts))
-    assert drop_default_args_from_conninfo(conninfo_to_dict(want)) == params
+    want = list(map(conninfo_to_dict, want))
+    assert want == attempts
 
 
 @pytest.mark.parametrize(
@@ -534,18 +548,3 @@ async def fail_resolve(monkeypatch):
         pytest.fail(f"shouldn't try to resolve {host}")
 
     monkeypatch.setattr(asyncio.get_running_loop(), "getaddrinfo", fail_getaddrinfo)
-
-
-def merge_conninfos(a1, a2):
-    """
-    merge conninfo attempts into a multi-host conninfo.
-    """
-    assert set(a1) == set(a2)
-    rv = {}
-    for k in a1:
-        if k in ("host", "hostaddr", "port"):
-            rv[k] = f"{a1[k]},{a2[k]}"
-        else:
-            assert a1[k] == a2[k]
-            rv[k] = a1[k]
-    return rv

--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -4,7 +4,6 @@ import psycopg
 from psycopg.conninfo import conninfo_to_dict
 
 from .test_conninfo import fake_resolve  # noqa: F401  # fixture
-from .test_connection import drop_default_args_from_conninfo
 
 
 @pytest.mark.usefixtures("fake_resolve")
@@ -22,7 +21,7 @@ async def test_resolve_hostaddr_conn(aconn_cls, monkeypatch):
 
     assert len(got) == 1
     want = {"host": "foo.com", "hostaddr": "1.1.1.1"}
-    assert drop_default_args_from_conninfo(got[0]) == want
+    assert conninfo_to_dict(got[0]) == want
 
 
 @pytest.mark.dns

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -3,8 +3,6 @@ import pytest
 from psycopg._cmodule import _psycopg
 from psycopg.conninfo import conninfo_to_dict
 
-from .test_connection import drop_default_args_from_conninfo
-
 
 @pytest.mark.parametrize(
     "args, kwargs, want",
@@ -22,7 +20,7 @@ def test_connect(monkeypatch, dsn_env, args, kwargs, want, setpgenv):
 
     orig_connect = psycopg.connection.connect  # type: ignore
 
-    got_conninfo = None
+    got_conninfo: str
 
     def mock_connect(conninfo):
         nonlocal got_conninfo
@@ -33,7 +31,7 @@ def test_connect(monkeypatch, dsn_env, args, kwargs, want, setpgenv):
     monkeypatch.setattr(psycopg.connection, "connect", mock_connect)
 
     conn = psycopg.connect(*args, **kwargs)
-    assert drop_default_args_from_conninfo(got_conninfo) == conninfo_to_dict(want)
+    assert conninfo_to_dict(got_conninfo) == conninfo_to_dict(want)
     conn.close()
 
 

--- a/tests/test_psycopg_dbapi20.py
+++ b/tests/test_psycopg_dbapi20.py
@@ -7,7 +7,6 @@ from psycopg.conninfo import conninfo_to_dict
 
 from . import dbapi20
 from . import dbapi20_tpc
-from .test_connection import drop_default_args_from_conninfo
 
 
 @pytest.fixture(scope="class")
@@ -145,7 +144,7 @@ def test_connect_args(monkeypatch, pgconn, args, kwargs, want, setpgenv):
     setpgenv({})
     monkeypatch.setattr(psycopg.connection, "connect", fake_connect)
     conn = psycopg.connect(*args, **kwargs)
-    assert drop_default_args_from_conninfo(got_conninfo) == conninfo_to_dict(want)
+    assert conninfo_to_dict(got_conninfo) == conninfo_to_dict(want)
     conn.close()
 
 


### PR DESCRIPTION
The refactor introduced in 3.1.13 was taking the freedom to replace certain values with what seemed to be equivalent changes, such as replacing a missing host with an empty string

However this turned out to break the use of service file, because values taken from service files have a precedence stronger than the env vars but weaker than the connection string values (see [docs](https://www.postgresql.org/docs/current/libpq-pgservice.html)).

- #694

As a bonus, we also broke async name resolution, but that might have already been fixed

- #695

This branch cleans up some of the changes made in order to implement the handling of multiple hosts in the connection string:

- the connection string is not tampered with anymore (all the test support to consider two connection strings "equivalent" have been dropped)
- added debug logging to figure out why a connection attempt is dropped
- the PG env var to set the connection timeout is not respected

Working on the issue highlighted a few shortcomings, that can be resolved in a follow-up release:

- #698
- #699
