### PR TITLE
Add async driver to sqlalchemy pipeline

### DIFF
--- a/.github/workflows/3rd-party-tests.yml
+++ b/.github/workflows/3rd-party-tests.yml
@@ -110,7 +110,7 @@ jobs:
         env:
           URL: postgresql+psycopg://postgres:password@127.0.0.1/test
         working-directory: sa_home/sa
-        run: pytest -n 2 -q --dburi $URL --backend-only --dropfirst --color=yes
+        run: pytest -n 2 -q --dburi $URL --backend-only --dropfirst --color=yes --dbdriver psycopg_async
 
   django:
     # linux should be enough to test if everything works.

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -30,6 +30,13 @@ Psycopg 3.2 (unreleased)
 .. __: https://numpy.org/doc/stable/reference/arrays.scalars.html#built-in-scalar-types
 
 
+Psycopg 3.1.16 (unreleased)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Fix empty ports handling in async multiple connection attempts
+  (:ticket:`#703`).
+
+
 Current release
 ---------------
 

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -30,15 +30,15 @@ Psycopg 3.2 (unreleased)
 .. __: https://numpy.org/doc/stable/reference/arrays.scalars.html#built-in-scalar-types
 
 
-Psycopg 3.1.16 (unreleased)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Current release
+---------------
+
+Psycopg 3.1.16
+^^^^^^^^^^^^^^
 
 - Fix empty ports handling in async multiple connection attempts
   (:ticket:`#703`).
 
-
-Current release
----------------
 
 Psycopg 3.1.15
 ^^^^^^^^^^^^^^

--- a/tests/test_conninfo.py
+++ b/tests/test_conninfo.py
@@ -339,6 +339,11 @@ class TestConnectionInfo:
             None,
         ),
         (
+            "host=1.1.1.1,1.1.1.1 port=5432,",
+            ["host=1.1.1.1 port=5432", "host=1.1.1.1 port=''"],
+            None,
+        ),
+        (
             "host=foo.com port=5432",
             ["host=foo.com port=5432"],
             {"PGHOSTADDR": "1.2.3.4"},
@@ -360,6 +365,11 @@ def test_conninfo_attempts(setpgenv, conninfo, want, env):
         ("", [""], None),
         ("host='' user=bar", ["host='' user=bar"], None),
         (
+            "host=127.0.0.1 user=bar port=''",
+            ["host=127.0.0.1 user=bar port='' hostaddr=127.0.0.1"],
+            None,
+        ),
+        (
             "host=127.0.0.1 user=bar",
             ["host=127.0.0.1 user=bar hostaddr=127.0.0.1"],
             None,
@@ -377,6 +387,14 @@ def test_conninfo_attempts(setpgenv, conninfo, want, env):
             [
                 "host=1.1.1.1 port=5432 hostaddr=1.1.1.1",
                 "host=2.2.2.2 port=5432 hostaddr=2.2.2.2",
+            ],
+            None,
+        ),
+        (
+            "host=1.1.1.1,2.2.2.2 port=5432,",
+            [
+                "host=1.1.1.1 port=5432 hostaddr=1.1.1.1",
+                "host=2.2.2.2 port='' hostaddr=2.2.2.2",
             ],
             None,
         ),
@@ -427,6 +445,14 @@ async def test_conninfo_attempts_async_no_resolve(
             [
                 "host=foo.com hostaddr=1.1.1.1 port=5432",
                 "host=qux.com hostaddr=2.2.2.2 port=5433",
+            ],
+            None,
+        ),
+        (
+            "host=foo.com,foo.com port=5432,",
+            [
+                "host=foo.com hostaddr=1.1.1.1 port=5432",
+                "host=foo.com hostaddr=1.1.1.1 port=''",
             ],
             None,
         ),


### PR DESCRIPTION
Also run psycopg async in the sqlalchemy tests. This is partially connected to #703

I'm trying the pipeline at https://github.com/CaselIT/psycopg/actions/runs/7253511346
It should fail due to #703