### PR TITLE
Respect getconn timeout with failed connection checks, delay checks with backoff

### DIFF
--- a/docs/news_pool.rst
+++ b/docs/news_pool.rst
@@ -13,6 +13,8 @@ Future releases
 psycopg_pool 3.2.1 (unreleased)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- Respect timeout on `~ConnectionPool.connection()` when `!check` fails
+  (:ticket:`#709`).
 - Use `typing.Self` as a more correct return value annotation of context
   managers and other self-returning methods (see :ticket:`708`).
 

--- a/docs/news_pool.rst
+++ b/docs/news_pool.rst
@@ -13,8 +13,9 @@ Future releases
 psycopg_pool 3.2.1 (unreleased)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- Respect timeout on `~ConnectionPool.connection()` when `!check` fails
-  (:ticket:`#709`).
+- Respect the `!timeout` parameter on `~ConnectionPool.connection()` when
+  `!check` fails. Also avoid a busy-loop of checking; separate check attempts
+  using an exponential backoff (:ticket:`#709`).
 - Use `typing.Self` as a more correct return value annotation of context
   managers and other self-returning methods (see :ticket:`708`).
 

--- a/psycopg_pool/psycopg_pool/_acompat.py
+++ b/psycopg_pool/psycopg_pool/_acompat.py
@@ -10,6 +10,7 @@ when generating the sync version.
 
 from __future__ import annotations
 
+import time
 import queue
 import asyncio
 import logging
@@ -28,6 +29,7 @@ Event = threading.Event
 Condition = threading.Condition
 Lock = threading.RLock
 ALock = asyncio.Lock
+sleep = time.sleep
 
 Worker: TypeAlias = threading.Thread
 AWorker: TypeAlias = "asyncio.Task[None]"
@@ -162,3 +164,10 @@ def gather(*tasks: threading.Thread, timeout: float | None = None) -> None:
         if not t.is_alive():
             continue
         logger.warning("couldn't stop thread %r within %s seconds", t.name, timeout)
+
+
+def asleep(seconds: float) -> Coroutine[Any, Any, None]:
+    """
+    Equivalent to asyncio.sleep(), converted to time.sleep() by async_to_sync.
+    """
+    return asyncio.sleep(seconds)

--- a/psycopg_pool/psycopg_pool/null_pool.py
+++ b/psycopg_pool/psycopg_pool/null_pool.py
@@ -96,6 +96,9 @@ class NullConnectionPool(_BaseNullConnectionPool, ConnectionPool[CT]):
         logger.info("pool %r is ready to use", self.name)
 
     def _get_ready_connection(self, timeout: Optional[float]) -> Optional[CT]:
+        if timeout is not None and timeout <= 0.0:
+            raise PoolTimeout()
+
         conn: Optional[CT] = None
         if self.max_size == 0 or self._nconns < self.max_size:
             # Create a new connection for the client

--- a/psycopg_pool/psycopg_pool/null_pool_async.py
+++ b/psycopg_pool/psycopg_pool/null_pool_async.py
@@ -93,6 +93,9 @@ class AsyncNullConnectionPool(_BaseNullConnectionPool, AsyncConnectionPool[ACT])
         logger.info("pool %r is ready to use", self.name)
 
     async def _get_ready_connection(self, timeout: Optional[float]) -> Optional[ACT]:
+        if timeout is not None and timeout <= 0.0:
+            raise PoolTimeout()
+
         conn: Optional[ACT] = None
         if self.max_size == 0 or self._nconns < self.max_size:
             # Create a new connection for the client

--- a/psycopg_pool/psycopg_pool/pool.py
+++ b/psycopg_pool/psycopg_pool/pool.py
@@ -187,10 +187,9 @@ class ConnectionPool(Generic[CT], BasePool):
         failing to do so will deplete the pool. A depleted pool is a sad pool:
         you don't want a depleted pool.
         """
-        t0 = monotonic()
         if timeout is None:
             timeout = self.timeout
-        deadline = t0 + timeout
+        deadline = monotonic() + timeout
 
         logger.info("connection requested from %r", self.name)
         self._stats[self._REQUESTS_NUM] += 1
@@ -249,6 +248,9 @@ class ConnectionPool(Generic[CT], BasePool):
 
     def _get_ready_connection(self, timeout: Optional[float]) -> Optional[CT]:
         """Return a connection, if the client deserves one."""
+        if timeout is not None and timeout <= 0.0:
+            raise PoolTimeout()
+
         conn: Optional[CT] = None
         if self._pool:
             # Take a connection ready out of the pool

--- a/psycopg_pool/psycopg_pool/pool_async.py
+++ b/psycopg_pool/psycopg_pool/pool_async.py
@@ -207,10 +207,9 @@ class AsyncConnectionPool(Generic[ACT], BasePool):
         failing to do so will deplete the pool. A depleted pool is a sad pool:
         you don't want a depleted pool.
         """
-        t0 = monotonic()
         if timeout is None:
             timeout = self.timeout
-        deadline = t0 + timeout
+        deadline = monotonic() + timeout
 
         logger.info("connection requested from %r", self.name)
         self._stats[self._REQUESTS_NUM] += 1
@@ -270,6 +269,9 @@ class AsyncConnectionPool(Generic[ACT], BasePool):
 
     async def _get_ready_connection(self, timeout: Optional[float]) -> Optional[ACT]:
         """Return a connection, if the client deserves one."""
+        if timeout is not None and timeout <= 0.0:
+            raise PoolTimeout()
+
         conn: Optional[ACT] = None
         if self._pool:
             # Take a connection ready out of the pool

--- a/tests/pool/test_pool.py
+++ b/tests/pool/test_pool.py
@@ -475,10 +475,10 @@ def test_shrink(dsn, monkeypatch):
 def test_reconnect(proxy, caplog, monkeypatch):
     caplog.set_level(logging.WARNING, logger="psycopg.pool")
 
-    assert pool.base.ConnectionAttempt.INITIAL_DELAY == 1.0
-    assert pool.base.ConnectionAttempt.DELAY_JITTER == 0.1
-    monkeypatch.setattr(pool.base.ConnectionAttempt, "INITIAL_DELAY", 0.1)
-    monkeypatch.setattr(pool.base.ConnectionAttempt, "DELAY_JITTER", 0.0)
+    assert pool.base.AttemptWithBackoff.INITIAL_DELAY == 1.0
+    assert pool.base.AttemptWithBackoff.DELAY_JITTER == 0.1
+    monkeypatch.setattr(pool.base.AttemptWithBackoff, "INITIAL_DELAY", 0.1)
+    monkeypatch.setattr(pool.base.AttemptWithBackoff, "DELAY_JITTER", 0.0)
 
     caplog.clear()
     proxy.start()
@@ -986,10 +986,10 @@ def test_cancellation_in_queue(dsn):
 def test_check_backoff(dsn, caplog, monkeypatch):
     caplog.set_level(logging.INFO, logger="psycopg.pool")
 
-    assert pool.base.ConnectionAttempt.INITIAL_DELAY == 1.0
-    assert pool.base.ConnectionAttempt.DELAY_JITTER == 0.1
-    monkeypatch.setattr(pool.base.ConnectionAttempt, "INITIAL_DELAY", 0.1)
-    monkeypatch.setattr(pool.base.ConnectionAttempt, "DELAY_JITTER", 0.0)
+    assert pool.base.AttemptWithBackoff.INITIAL_DELAY == 1.0
+    assert pool.base.AttemptWithBackoff.DELAY_JITTER == 0.1
+    monkeypatch.setattr(pool.base.AttemptWithBackoff, "INITIAL_DELAY", 0.1)
+    monkeypatch.setattr(pool.base.AttemptWithBackoff, "DELAY_JITTER", 0.0)
 
     def check(conn):
         raise Exception()

--- a/tests/pool/test_pool_async.py
+++ b/tests/pool/test_pool_async.py
@@ -481,10 +481,10 @@ async def test_shrink(dsn, monkeypatch):
 async def test_reconnect(proxy, caplog, monkeypatch):
     caplog.set_level(logging.WARNING, logger="psycopg.pool")
 
-    assert pool.base.ConnectionAttempt.INITIAL_DELAY == 1.0
-    assert pool.base.ConnectionAttempt.DELAY_JITTER == 0.1
-    monkeypatch.setattr(pool.base.ConnectionAttempt, "INITIAL_DELAY", 0.1)
-    monkeypatch.setattr(pool.base.ConnectionAttempt, "DELAY_JITTER", 0.0)
+    assert pool.base.AttemptWithBackoff.INITIAL_DELAY == 1.0
+    assert pool.base.AttemptWithBackoff.DELAY_JITTER == 0.1
+    monkeypatch.setattr(pool.base.AttemptWithBackoff, "INITIAL_DELAY", 0.1)
+    monkeypatch.setattr(pool.base.AttemptWithBackoff, "DELAY_JITTER", 0.0)
 
     caplog.clear()
     proxy.start()
@@ -993,10 +993,10 @@ async def test_cancellation_in_queue(dsn):
 async def test_check_backoff(dsn, caplog, monkeypatch):
     caplog.set_level(logging.INFO, logger="psycopg.pool")
 
-    assert pool.base.ConnectionAttempt.INITIAL_DELAY == 1.0
-    assert pool.base.ConnectionAttempt.DELAY_JITTER == 0.1
-    monkeypatch.setattr(pool.base.ConnectionAttempt, "INITIAL_DELAY", 0.1)
-    monkeypatch.setattr(pool.base.ConnectionAttempt, "DELAY_JITTER", 0.0)
+    assert pool.base.AttemptWithBackoff.INITIAL_DELAY == 1.0
+    assert pool.base.AttemptWithBackoff.DELAY_JITTER == 0.1
+    monkeypatch.setattr(pool.base.AttemptWithBackoff, "INITIAL_DELAY", 0.1)
+    monkeypatch.setattr(pool.base.AttemptWithBackoff, "DELAY_JITTER", 0.0)
 
     async def check(conn):
         raise Exception()

--- a/tests/pool/test_pool_async.py
+++ b/tests/pool/test_pool_async.py
@@ -986,3 +986,34 @@ async def test_cancellation_in_queue(dsn):
         async with p.connection() as conn:
             cur = await conn.execute("select 1")
             assert await cur.fetchone() == (1,)
+
+
+@pytest.mark.slow
+@pytest.mark.timing
+async def test_check_backoff(dsn, caplog, monkeypatch):
+    caplog.set_level(logging.INFO, logger="psycopg.pool")
+
+    assert pool.base.ConnectionAttempt.INITIAL_DELAY == 1.0
+    assert pool.base.ConnectionAttempt.DELAY_JITTER == 0.1
+    monkeypatch.setattr(pool.base.ConnectionAttempt, "INITIAL_DELAY", 0.1)
+    monkeypatch.setattr(pool.base.ConnectionAttempt, "DELAY_JITTER", 0.0)
+
+    async def check(conn):
+        raise Exception()
+
+    caplog.clear()
+    async with pool.AsyncConnectionPool(dsn, min_size=1, check=check) as p:
+        await p.wait(2.0)
+
+        with pytest.raises(pool.PoolTimeout):
+            async with p.connection(timeout=1.0):
+                assert False
+
+    times = [rec.created for rec in caplog.records if "failed check" in rec.message]
+    assert times[1] - times[0] < 0.05
+    deltas = [times[i + 1] - times[i] for i in range(1, len(times) - 1)]
+    assert len(deltas) == 3
+    want = 0.1
+    for delta in deltas:
+        assert delta == pytest.approx(want, 0.05), deltas
+        want *= 2

--- a/tests/pool/test_pool_common.py
+++ b/tests/pool/test_pool_common.py
@@ -610,6 +610,20 @@ def test_check_init(pool_cls, dsn):
     assert checked
 
 
+@pytest.mark.slow
+def test_check_timeout(pool_cls, dsn):
+    def check(conn):
+        raise Exception()
+
+    t0 = time()
+    with pytest.raises(pool.PoolTimeout):
+        with pool_cls(dsn, check=check, timeout=1.0) as p:
+            with p.connection():
+                assert False
+
+    assert time() - t0 <= 1.5
+
+
 @skip_sync
 def test_cancellation_in_queue(pool_cls, dsn):
     # https://github.com/psycopg/psycopg/issues/509

--- a/tests/pool/test_pool_common_async.py
+++ b/tests/pool/test_pool_common_async.py
@@ -629,6 +629,20 @@ async def test_check_init(pool_cls, dsn):
     assert checked
 
 
+@pytest.mark.slow
+async def test_check_timeout(pool_cls, dsn):
+    async def check(conn):
+        raise Exception()
+
+    t0 = time()
+    with pytest.raises(pool.PoolTimeout):
+        async with pool_cls(dsn, check=check, timeout=1.0) as p:
+            async with p.connection():
+                assert False
+
+    assert time() - t0 <= 1.5
+
+
 @skip_sync
 async def test_cancellation_in_queue(pool_cls, dsn):
     # https://github.com/psycopg/psycopg/issues/509


### PR DESCRIPTION
Previously we failed to check when the timeout expired. Working on it, the issue of a needlessly tight loop of checks has been spotted, so we have reused the same backoff + jitter policy used in reconnection attempts (which was conveniently encapsulated into a class) to back off repeated checks too.

Close #709