### PR TITLE
Fix deadline on pipeline exit

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -7,6 +7,15 @@
 ``psycopg`` release notes
 =========================
 
+Future releases
+---------------
+
+Psycopg 3.1.18 (unreleased)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Fix possible deadlock on pipeline exit (:ticket:`685`).
+
+
 Current release
 ---------------
 

--- a/psycopg/psycopg/_pipeline.py
+++ b/psycopg/psycopg/_pipeline.py
@@ -132,8 +132,7 @@ class BasePipeline:
             self._enqueue_sync()
             yield from self._communicate_gen()
         finally:
-            # No need to force flush since we emitted a sync just before.
-            yield from self._fetch_gen(flush=False)
+            yield from self._fetch_gen(flush=True)
 
     def _communicate_gen(self) -> PQGen[None]:
         """Communicate with pipeline to send commands and possibly fetch


### PR DESCRIPTION
Without it there may be a deadlock and we would be waiting to fetch a result that will never come.

Close #685.

@dlax if you have any input it would be welcome, thank you :slightly_smiling_face: 