### PR TITLE
fix: add `libc.so` fallback for musl systems to the ctypes impl

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -37,6 +37,10 @@ Psycopg 3.1.18 (unreleased)
 
 - Fix possible deadlock on pipeline exit (:ticket:`685`).
 - Fix overflow loading large intervals in C module (:ticket:`719`).
+- Fix compatibility with musl libc distributions affected by `CPython issue
+  #65821`__ (:ticket:`#725`).
+
+.. __: https://github.com/python/cpython/issues/65821
 
 
 Current release

--- a/psycopg/psycopg/pq/_pq_ctypes.py
+++ b/psycopg/psycopg/pq/_pq_ctypes.py
@@ -29,7 +29,10 @@ FILE_ptr = POINTER(FILE)
 
 if sys.platform == "linux":
     libcname = ctypes.util.find_library("c")
-    assert libcname
+    if not libcname:
+        # Likely this is a system using musl libc, see the following bug:
+        # https://github.com/python/cpython/issues/65821
+        libcname = "libc.so"
     libc = ctypes.cdll.LoadLibrary(libcname)
 
     fdopen = libc.fdopen


### PR DESCRIPTION
Add a fallback to `libc.so` library name to fix loading the ctypes implementation on musl systems.  On musl, `find_library("c")` does not work (the problem has been reported to CPython in 2014, and has not been resolved yet), causing the module to fail on `assert libcname`. Instead, add a fallback to using `libc.so` and let ctypes raise an exception if such a library does not exist.