### PR TITLE
Make opening an async connection pool in the constructor a runtime warning

### DIFF
--- a/docs/advanced/pool.rst
+++ b/docs/advanced/pool.rst
@@ -304,15 +304,15 @@ call the `~ConnectionPool.open()` method (and optionally the
 `~ClonnectionPool.close()` method) at application startup/shutdown. For
 example, in FastAPI, you can use `startup/shutdown events`__::
 
-    pool = ConnectionPool(..., open=False, ...)
+    pool = AsyncConnectionPool(..., open=False, ...)
 
     @app.on_event("startup")
-    def open_pool():
-        pool.open()
+    async def open_pool():
+        await pool.open()
 
     @app.on_event("shutdown")
-    def close_pool():
-        pool.close()
+    async def close_pool():
+        await pool.close()
 
 .. __: https://fastapi.tiangolo.com/advanced/events/#events-startup-shutdown
 
@@ -321,6 +321,11 @@ example, in FastAPI, you can use `startup/shutdown events`__::
     proved to be not the best idea and, in future releases, the default might
     be changed to `!False`. As a consequence, if you rely on the pool to be
     opened on creation, you should specify `!open=True` explicitly.
+
+.. warning::
+    Opening an async pool in the constructor is deprecated and will be removed
+    in the future. When using `AsyncConnectionPool` you should call `await
+    pool.open()` or `async with ... as pool` explicitly.
 
 
 .. _null-pool:

--- a/docs/news_pool.rst
+++ b/docs/news_pool.rst
@@ -7,6 +7,16 @@
 ``psycopg_pool`` release notes
 ==============================
 
+Future releases
+---------------
+
+psycopg_pool 3.2.2 (unreleased)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Raise a `RuntimeWarning` instead of a `DeprecationWarning` if an async pool
+  is open in the constructor.
+
+
 Current release
 ---------------
 

--- a/psycopg_pool/psycopg_pool/pool_async.py
+++ b/psycopg_pool/psycopg_pool/pool_async.py
@@ -139,7 +139,7 @@ class AsyncConnectionPool(Generic[ACT], BasePool):
                 " is deprecated and will not be supported anymore in a future"
                 " release. Please use `await pool.open()`, or use the pool as context"
                 f" manager using: `async with {type(self).__name__}(...) as pool: `...",
-                DeprecationWarning,
+                RuntimeWarning,
             )
 
     async def wait(self, timeout: float = 30.0) -> None:

--- a/tests/pool/test_pool_async_noasyncio.py
+++ b/tests/pool/test_pool_async_noasyncio.py
@@ -55,7 +55,7 @@ def test_working_created_before_loop(dsn, asyncio_run):
 
 
 def test_cant_create_open_outside_loop(dsn):
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(RuntimeWarning):
         with pytest.raises(RuntimeError):
             pool.AsyncConnectionPool(dsn, open=True)
 

--- a/tests/pool/test_pool_common.py
+++ b/tests/pool/test_pool_common.py
@@ -57,6 +57,7 @@ def test_context(pool_cls, dsn):
 
 
 def test_create_warning(pool_cls, dsn):
+    warning_cls = DeprecationWarning
     # No warning on explicit open for sync pool
     p = pool_cls(dsn, open=True)
     try:
@@ -80,7 +81,7 @@ def test_create_warning(pool_cls, dsn):
             pass
 
     # Warning on open not specified
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(warning_cls):
         p = pool_cls(dsn)
         try:
             with p.connection():
@@ -89,7 +90,7 @@ def test_create_warning(pool_cls, dsn):
             p.close()
 
     # Warning also if open is called explicitly on already implicitly open
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(warning_cls):
         p = pool_cls(dsn)
         p.open()
         try:

--- a/tests/pool/test_pool_common_async.py
+++ b/tests/pool/test_pool_common_async.py
@@ -59,12 +59,14 @@ async def test_context(pool_cls, dsn):
 
 async def test_create_warning(pool_cls, dsn):
     if True:  # ASYNC
+        warning_cls = RuntimeWarning
         # warning on explicit open too on async
-        with pytest.warns(DeprecationWarning):
+        with pytest.warns(warning_cls):
             p = pool_cls(dsn, open=True)
             await p.close()
 
     else:
+        warning_cls = DeprecationWarning
         # No warning on explicit open for sync pool
         p = pool_cls(dsn, open=True)
         try:
@@ -88,7 +90,7 @@ async def test_create_warning(pool_cls, dsn):
             pass
 
     # Warning on open not specified
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(warning_cls):
         p = pool_cls(dsn)
         try:
             async with p.connection():
@@ -97,7 +99,7 @@ async def test_create_warning(pool_cls, dsn):
             await p.close()
 
     # Warning also if open is called explicitly on already implicitly open
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(warning_cls):
         p = pool_cls(dsn)
         await p.open()
         try:


### PR DESCRIPTION
Deprecation warnings are ignored by default and easy to miss.

Close #737.