### PR TITLE
Improve performance of copy

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -53,6 +53,7 @@ Psycopg 3.1.19 (unreleased)
 - Fix excessive stripping of error message prefixes (:ticket:`#752`).
 - Allow to specify the ``connect_timeout`` connection parameter as float
   (:ticket:`#796`).
+- Improve COPY performance on macOS (:ticket:`#745`).
 
 
 Current release

--- a/psycopg/psycopg/_copy_base.py
+++ b/psycopg/psycopg/_copy_base.py
@@ -7,6 +7,7 @@ psycopg copy support
 from __future__ import annotations
 
 import re
+import sys
 import struct
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Generic, List, Match
@@ -52,6 +53,10 @@ MAX_BUFFER_SIZE = 4 * BUFFER_SIZE
 # Max size of the write queue of buffers. More than that copy will block
 # Each buffer should be around BUFFER_SIZE size.
 QUEUE_SIZE = 1024
+
+# On certain systems, memmove seems particularly slow and flushing often is
+# more performing than accumulating a larger buffer. See #746 for details.
+PREFER_FLUSH = sys.platform == "darwin"
 
 
 class BaseCopy(Generic[ConnectionType]):

--- a/psycopg/psycopg/generators.py
+++ b/psycopg/psycopg/generators.py
@@ -346,6 +346,16 @@ def copy_to(pgconn: PGconn, buffer: Buffer) -> PQGen[None]:
             if ready:
                 break
 
+    # Repeat until it the message is flushed to the server
+    while True:
+        while True:
+            ready = yield WAIT_W
+            if ready:
+                break
+        f = pgconn.flush()
+        if f == 0:
+            break
+
 
 def copy_end(pgconn: PGconn, error: Optional[bytes]) -> PQGen[PGresult]:
     # Retry enqueuing end copy message until successful

--- a/tests/scripts/copytest.py
+++ b/tests/scripts/copytest.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python
+"""Copy operation micro-benchmarks.
+"""
+from __future__ import annotations
+
+import sys
+import asyncio
+import logging
+from time import time
+from typing import Any
+from argparse import ArgumentParser, Namespace
+
+import psycopg
+from psycopg.abc import Query
+from psycopg import sql
+
+logger = logging.getLogger()
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+)
+
+
+def main():
+    args = parse_cmdline()
+    logger.setLevel(args.loglevel)
+
+    if getattr(args, "async"):
+        asyncio.run(main_async(args))
+    else:
+        main_sync(args)
+
+
+def main_sync(args: Namespace) -> None:
+    test = CopyPutTest(args)
+    with psycopg.Connection.connect(args.dsn) as conn:
+        with conn.cursor() as cur:
+            writer = getattr(psycopg.copy, args.writer)(cur) if args.writer else None
+            cur.execute(test.get_table_stmt())
+            t0 = time()
+            with cur.copy(test.get_copy_stmt(), writer=writer) as copy:
+                for i in range(args.nrecs):
+                    copy.write_row(test.get_record())
+            tf = time()
+
+    logger.info("time to copy: %.6f sec", tf - t0)
+
+
+async def main_async(args: Namespace) -> None:
+    test = CopyPutTest(args)
+    async with await psycopg.AsyncConnection.connect(args.dsn) as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(test.get_table_stmt())
+            writer = getattr(psycopg.copy, args.writer)(cur) if args.writer else None
+            t0 = time()
+            async with cur.copy(test.get_copy_stmt(), writer=writer) as copy:
+                for i in range(args.nrecs):
+                    await copy.write_row(test.get_record())
+            tf = time()
+
+    logger.info("time to copy: %.6f sec", tf - t0)
+
+
+class CopyPutTest:
+    def __init__(self, args: Namespace):
+        self.args = args
+
+    def get_table_stmt(self) -> Query:
+        fields = sql.SQL(", ").join(
+            [sql.SQL(f"f{i} text") for i in range(self.args.nfields)]
+        )
+        stmt = sql.SQL(
+            """\
+create temp table testcopy (id serial primary key, {})
+"""
+        ).format(fields)
+        return stmt
+
+    def get_copy_stmt(self) -> Query:
+        fields = sql.SQL(", ").join(
+            [sql.Identifier(f"f{i}") for i in range(self.args.nfields)]
+        )
+        stmt = sql.SQL(
+            """\
+copy testcopy ({}) from stdin
+"""
+        ).format(fields)
+        return stmt
+
+    def get_record(self) -> tuple[Any, ...]:
+        return tuple("x" * self.args.colsize for _ in range(self.args.nfields))
+
+
+def parse_cmdline() -> Namespace:
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument("--dsn", default="", help="database connection string")
+    parser.add_argument(
+        "--async", action="store_true", default=False, help="test async objects"
+    )
+    parser.add_argument(
+        "--nrecs",
+        type=int,
+        default=1000,
+        help="number of records to write [default: %(default)s]",
+    )
+    parser.add_argument(
+        "--nfields",
+        type=int,
+        default=10,
+        help="number of columns to write [default: %(default)s]",
+    )
+    parser.add_argument(
+        "--colsize",
+        type=int,
+        default=10,
+        help="width of each column to write [default: %(default)s]",
+    )
+    parser.add_argument("--writer", help="test alternative writer")
+
+    g = parser.add_mutually_exclusive_group()
+    g.add_argument(
+        "-q",
+        "--quiet",
+        help="Talk less",
+        dest="loglevel",
+        action="store_const",
+        const=logging.WARN,
+        default=logging.INFO,
+    )
+    g.add_argument(
+        "-v",
+        "--verbose",
+        help="Talk more",
+        dest="loglevel",
+        action="store_const",
+        const=logging.DEBUG,
+        default=logging.INFO,
+    )
+
+    args = parser.parse_args()
+
+    if args.writer:
+        try:
+            getattr(psycopg.copy, args.writer)
+        except AttributeError:
+            parser.error(f"unknown writer: {args.writer!r}")
+
+    return args
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -643,7 +643,7 @@ def test_worker_life(conn, format, buffer):
 
 def test_worker_error_propagated(conn, monkeypatch):
 
-    def copy_to_broken(pgconn, buffer):
+    def copy_to_broken(pgconn, buffer, flush=True):
         raise ZeroDivisionError
         yield
 

--- a/tests/test_copy_async.py
+++ b/tests/test_copy_async.py
@@ -656,7 +656,7 @@ async def test_worker_life(aconn, format, buffer):
 
 
 async def test_worker_error_propagated(aconn, monkeypatch):
-    def copy_to_broken(pgconn, buffer):
+    def copy_to_broken(pgconn, buffer, flush=True):
         raise ZeroDivisionError
         yield
 


### PR DESCRIPTION
Fixes #745 

I kept the flush code the same as `copy_end`, but think it may be better to break if `f != 1` instead of `f == 0` in both places to account for errors, which return -1 ([Postgres docs](https://www.postgresql.org/docs/current/libpq-async.html#LIBPQ-PQFLUSH)).