### PR TITLE
Ensure that notifies include those received during concurrent fetch and pipeline processing

### DIFF
--- a/docs/api/connections.rst
+++ b/docs/api/connections.rst
@@ -321,6 +321,12 @@ The `!Connection` class
         any sessions in the database generates a :sql:`NOTIFY` on one of the
         listened channels.
 
+        .. note::
+            While this method can be used concurrently with another
+            thread that's actively using the connection, notifications
+            received during an operation will be emitted only after it
+            completes (this behavior is mandated by the protocol).
+
         .. versionchanged:: 3.2
 
             Added `!timeout` and `!stop_after` parameters.

--- a/psycopg/psycopg/connection.py
+++ b/psycopg/psycopg/connection.py
@@ -325,11 +325,10 @@ class Connection(BaseConnection[Row]):
         self.add_notify_handler(ns.append)
         try:
             while True:
-                # Collect notifications. Also get the connection encoding if any
-                # notification is received to makes sure that they are consistent.
+                # Wait for notifications, collecting and processing them using
+                # thread-safe operations.
                 try:
-                    with self.lock:
-                        self.wait(notifies(self.pgconn), interval=interval)
+                    self.wait(notifies(self.pgconn), interval=interval)
                 except e._NO_TRACEBACK as ex:
                     raise ex.with_traceback(None)
 

--- a/psycopg/psycopg/connection.py
+++ b/psycopg/psycopg/connection.py
@@ -14,6 +14,7 @@ from time import monotonic
 from types import TracebackType
 from typing import Any, Generator, Iterator, List, Optional
 from typing import Type, Union, cast, overload, TYPE_CHECKING
+from collections import deque
 from contextlib import contextmanager
 
 from . import pq
@@ -28,7 +29,6 @@ from ._compat import Self
 from .conninfo import make_conninfo, conninfo_to_dict
 from .conninfo import conninfo_attempts, timeout_from_conninfo
 from ._pipeline import Pipeline
-from ._encodings import pgconn_encoding
 from .generators import notifies
 from .transaction import Transaction
 from .cursor import Cursor
@@ -321,33 +321,35 @@ class Connection(BaseConnection[Row]):
 
         nreceived = 0
 
-        while True:
-            # Collect notifications. Also get the connection encoding if any
-            # notification is received to makes sure that they are consistent.
-            try:
-                with self.lock:
-                    ns = self.wait(notifies(self.pgconn), interval=interval)
-                    if ns:
-                        enc = pgconn_encoding(self.pgconn)
-            except e._NO_TRACEBACK as ex:
-                raise ex.with_traceback(None)
+        ns: deque[Notify] = deque()
+        self.add_notify_handler(ns.append)
+        try:
+            while True:
+                # Collect notifications. Also get the connection encoding if any
+                # notification is received to makes sure that they are consistent.
+                try:
+                    with self.lock:
+                        self.wait(notifies(self.pgconn), interval=interval)
+                except e._NO_TRACEBACK as ex:
+                    raise ex.with_traceback(None)
 
-            # Emit the notifications received.
-            for pgn in ns:
-                n = Notify(pgn.relname.decode(enc), pgn.extra.decode(enc), pgn.be_pid)
-                yield n
-                nreceived += 1
+                # Emit the notifications received.
+                while ns:
+                    yield ns.popleft()
+                    nreceived += 1
 
-            # Stop if we have received enough notifications.
-            if stop_after is not None and nreceived >= stop_after:
-                break
-
-            # Check the deadline after the loop to ensure that timeout=0
-            # polls at least once.
-            if deadline:
-                interval = min(_WAIT_INTERVAL, deadline - monotonic())
-                if interval < 0.0:
+                # Stop if we have received enough notifications.
+                if stop_after is not None and nreceived >= stop_after:
                     break
+
+                # Check the deadline after the loop to ensure that timeout=0
+                # polls at least once.
+                if deadline:
+                    timeout = min(_WAIT_INTERVAL, deadline - monotonic())
+                    if timeout < 0.0:
+                        break
+        finally:
+            self.remove_notify_handler(ns.append)
 
     @contextmanager
     def pipeline(self) -> Iterator[Pipeline]:

--- a/psycopg/psycopg/connection_async.py
+++ b/psycopg/psycopg/connection_async.py
@@ -347,11 +347,10 @@ class AsyncConnection(BaseConnection[Row]):
         self.add_notify_handler(ns.append)
         try:
             while True:
-                # Collect notifications. Also get the connection encoding if any
-                # notification is received to makes sure that they are consistent.
+                # Wait for notifications, collecting and processing them using
+                # thread-safe operations.
                 try:
-                    async with self.lock:
-                        await self.wait(notifies(self.pgconn), interval=interval)
+                    await self.wait(notifies(self.pgconn), interval=interval)
                 except e._NO_TRACEBACK as ex:
                     raise ex.with_traceback(None)
 

--- a/psycopg/psycopg/connection_async.py
+++ b/psycopg/psycopg/connection_async.py
@@ -375,8 +375,8 @@ class AsyncConnection(BaseConnection[Row]):
                 # Check the deadline after the loop to ensure that timeout=0
                 # polls at least once.
                 if deadline:
-                    timeout = min(_WAIT_INTERVAL, deadline - monotonic())
-                    if timeout < 0.0:
+                    interval = min(_WAIT_INTERVAL, deadline - monotonic())
+                    if interval < 0.0:
                         break
         finally:
             self.remove_notify_handler(ns.append)

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -75,7 +75,7 @@ def test_notify(conn_cls, conn, dsn):
         for n in gen:
             ns.append((n, time()))
             if len(ns) == 2:
-                cur.execute("notify foo, '3'")
+                conn.execute("notify foo, '3'")
             if len(ns) == 3:
                 break
 

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -66,6 +66,8 @@ def test_notify(conn_cls, conn, dsn):
             nconn.execute("notify foo, '1'")
             sleep(0.25)
             nconn.execute("notify foo, '2'")
+            sleep(0.25)
+            conn.execute("notify foo, '3'")
 
     def receiver():
         conn.set_autocommit(True)
@@ -74,8 +76,6 @@ def test_notify(conn_cls, conn, dsn):
         gen = conn.notifies()
         for n in gen:
             ns.append((n, time()))
-            if len(ns) == 2:
-                conn.execute("notify foo, '3'")
             if len(ns) == 3:
                 break
 
@@ -101,7 +101,7 @@ def test_notify(conn_cls, conn, dsn):
     assert n.pid == conn.pgconn.backend_pid
     assert n.channel == "foo"
     assert n.payload == "3"
-    assert t1 - t0 == pytest.approx(0.5, abs=0.05)
+    assert t1 - t0 == pytest.approx(0.75, abs=0.05)
 
 
 @pytest.mark.slow

--- a/tests/test_notify_async.py
+++ b/tests/test_notify_async.py
@@ -63,6 +63,8 @@ async def test_notify(aconn_cls, aconn, dsn):
             await nconn.execute("notify foo, '1'")
             await asleep(0.25)
             await nconn.execute("notify foo, '2'")
+            await asleep(0.25)
+            await aconn.execute("notify foo, '3'")
 
     async def receiver():
         await aconn.set_autocommit(True)
@@ -71,8 +73,6 @@ async def test_notify(aconn_cls, aconn, dsn):
         gen = aconn.notifies()
         async for n in gen:
             ns.append((n, time()))
-            if len(ns) == 2:
-                await aconn.execute("notify foo, '3'")
             if len(ns) == 3:
                 break
 
@@ -98,7 +98,7 @@ async def test_notify(aconn_cls, aconn, dsn):
     assert n.pid == aconn.pgconn.backend_pid
     assert n.channel == "foo"
     assert n.payload == "3"
-    assert t1 - t0 == pytest.approx(0.5, abs=0.05)
+    assert t1 - t0 == pytest.approx(0.75, abs=0.05)
 
 
 @pytest.mark.slow

--- a/tests/test_notify_async.py
+++ b/tests/test_notify_async.py
@@ -71,14 +71,16 @@ async def test_notify(aconn_cls, aconn, dsn):
         gen = aconn.notifies()
         async for n in gen:
             ns.append((n, time()))
-            if len(ns) >= 2:
-                await gen.aclose()
+            if len(ns) == 2:
+                await aconn.execute("notify foo, '3'")
+            if len(ns) == 3:
+                break
 
     ns: list[tuple[Notify, float]] = []
     t0 = time()
     workers = [spawn(notifier), spawn(receiver)]
     await gather(*workers)
-    assert len(ns) == 2
+    assert len(ns) == 3
 
     n, t1 = ns[0]
     assert n.pid == npid
@@ -90,6 +92,12 @@ async def test_notify(aconn_cls, aconn, dsn):
     assert n.pid == npid
     assert n.channel == "foo"
     assert n.payload == "2"
+    assert t1 - t0 == pytest.approx(0.5, abs=0.05)
+
+    n, t1 = ns[2]
+    assert n.pid == aconn.pgconn.backend_pid
+    assert n.channel == "foo"
+    assert n.payload == "3"
     assert t1 - t0 == pytest.approx(0.5, abs=0.05)
 
 


### PR DESCRIPTION
This fixes issue #756.

This change addresses a race condition with the concurrent use of the `notifies` generator with fetch and/or pipeline communications in other threads.

The proposed behavior should be less surprising since it streamlines how notifies are distributed – now always through the notify handlers.

When would you rely on this behavior? The issue came up writing test code where a single connection was used to both generate and receive notifications, motivated by the thread-safe nature of the connection object. I think the new behavior aligns better with this promise.