### PR TITLE
docs: let the 'pq' role possibly link to "devel" PostgreSQL docs

### DIFF
--- a/docs/lib/libpq_docs.py
+++ b/docs/lib/libpq_docs.py
@@ -89,7 +89,7 @@ class LibpqReader:
     app = None
 
     _url_pattern = (
-        "https://raw.githubusercontent.com/postgres/postgres/REL_{ver}_STABLE"
+        "https://raw.githubusercontent.com/postgres/postgres/{branch}"
         "/doc/src/sgml/libpq.sgml"
     )
 
@@ -130,7 +130,13 @@ class LibpqReader:
 
     @property
     def sgml_url(self):
-        return self._url_pattern.format(ver=self.version)
+        return self._url_pattern.format(branch=self.branch)
+
+    @property
+    def branch(self):
+        if self.version == "devel":
+            return "master"
+        return f"REL_{self.version}_STABLE"
 
     @property
     def version(self):


### PR DESCRIPTION
If we now set libpq_docs_version to 'devel', the pq Sphinx role will use the master branch when looking libpq.sgml and the 'devel' URL component when linking to libpq online documentation.

* * *

That's something I find useful in order to check if the docs built for #754 are correct by locally tweaking:
```diff
diff --git a/docs/conf.py b/docs/conf.py
index cafcb5e6..db3a017e 100644
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -106,7 +106,7 @@ intersphinx_mapping = {
 autodoc_member_order = "bysource"

 # PostgreSQL docs version to link libpq functions to
-libpq_docs_version = "14"
+libpq_docs_version = "devel"

 # Where to point on :ticket: role
 ticket_url = "https://github.com/psycopg/psycopg/issues/%s"
diff --git a/docs/lib/libpq_docs.py b/docs/lib/libpq_docs.py
index 2868916f..053fd693 100644
--- a/docs/lib/libpq_docs.py
+++ b/docs/lib/libpq_docs.py
@@ -183,6 +183,6 @@ def pq_role(name, rawtext, text, lineno, inliner, options>


 def setup(app):
-    app.add_config_value("libpq_docs_version", "14", "html")
+    app.add_config_value("libpq_docs_version", "devel", "html")
     roles.register_local_role("pq", pq_role)
     get_reader().app = app
```
(Those docs are not pushed for now, but while writing them, I need this.) 