### PR TITLE
document libpq 17 features

### DIFF
--- a/docs/api/pq.rst
+++ b/docs/api/pq.rst
@@ -100,7 +100,7 @@ Objects wrapping libpq structures and functions
            >>> encrypted = conn.pgconn.encrypt_password(password.encode(enc), rolename.encode(enc))
            b'SCRAM-SHA-256$4096:...
 
-    .. .. automethod:: change_password FIXME: needs libpq 17's docs
+    .. automethod:: change_password
 
     .. automethod:: trace
     .. automethod:: set_trace_flags

--- a/docs/api/pq.rst
+++ b/docs/api/pq.rst
@@ -87,6 +87,7 @@ Objects wrapping libpq structures and functions
 .. autoclass:: PGconn()
 
     .. autoattribute:: pgconn_ptr
+    .. automethod:: cancel_conn
     .. automethod:: get_cancel
     .. autoattribute:: needs_password
     .. autoattribute:: used_password
@@ -137,9 +138,11 @@ Objects wrapping libpq structures and functions
 .. autoclass:: Conninfo
 .. autoclass:: Escaping
 
-.. autoclass:: PGcancel()
+.. autoclass:: PGcancelConn()
     :members:
 
+.. autoclass:: PGcancel()
+    :members:
 
 Enumerations
 ------------
@@ -152,7 +155,7 @@ Enumerations
     during the connection phase and are considered internal.
     `ALLOCATED` is only expected to be returned by `PGcancelConn.status`.
 
-    .. seealso:: :pq:`PQstatus()` and `PQcancelStatus()` return this value.
+    .. seealso:: :pq:`PQstatus()` and :pq:`PQcancelStatus()` return this value.
 
 
 .. autoclass:: PollingStatus

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -106,7 +106,7 @@ intersphinx_mapping = {
 autodoc_member_order = "bysource"
 
 # PostgreSQL docs version to link libpq functions to
-libpq_docs_version = "14"
+libpq_docs_version = "17"
 
 # Where to point on :ticket: role
 ticket_url = "https://github.com/psycopg/psycopg/issues/%s"

--- a/docs/lib/libpq_docs.py
+++ b/docs/lib/libpq_docs.py
@@ -183,6 +183,6 @@ def pq_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
 
 
 def setup(app):
-    app.add_config_value("libpq_docs_version", "14", "html")
+    app.add_config_value("libpq_docs_version", "17", "html")
     roles.register_local_role("pq", pq_role)
     get_reader().app = app


### PR DESCRIPTION
We bump `libpq_docs_version = "17"` in docs configuration (first commit), as the `REL_17_STABLE` branch is now available in PostgreSQL git repository. And then document features of libpq 17: `PGCancelConn` and `change_password()`.

#534 