### PR TITLE
Add capabilities objects

### DIFF
--- a/docs/advanced/pipeline.rst
+++ b/docs/advanced/pipeline.rst
@@ -302,5 +302,5 @@ The fine prints
 
 The pipeline mode is available on any currently supported PostgreSQL version,
 but, in order to make use of it, the client must use a libpq from PostgreSQL
-14 or higher. You can use `Pipeline.is_supported()` to make sure your client
-has the right library.
+14 or higher. You can use the `~Capabilities.has_pipeline` capability to make
+sure your client has the right library.

--- a/docs/advanced/prepare.rst
+++ b/docs/advanced/prepare.rst
@@ -65,9 +65,11 @@ Using prepared statements with PgBouncer
 Starting from 3.2, Psycopg supports prepared statements when using the
 PgBouncer__ middleware, using the following caveats:
 
-- PgBouncer version must be at least version `1.22`__.
+- PgBouncer version must be version `1.22`__ or newer.
 - PgBouncer `max_prepared_statements`__ must be greater than 0.
-- The libpq version on the client must be from PostgreSQL 17 or higher.
+- The libpq version on the client must be from PostgreSQL 17 or newer
+  (you can check the `~Capabilities.has_pgbouncer_prepared` capability to
+  verify it).
 
 .. __: https://www.pgbouncer.org/
 .. __: https://www.pgbouncer.org/2024/01/pgbouncer-1-22-0

--- a/docs/api/connections.rst
+++ b/docs/api/connections.rst
@@ -287,6 +287,11 @@ The `!Connection` class
 
     .. automethod:: cancel_safe
 
+        .. note::
+
+            You can use the `~Capabilities.has_cancel_safe` capability to check
+            if `!cancel_safe()` will not fall back on the legacy implementation.
+
         .. warning::
 
             This method shouldn't be used as a `~signal.signal` handler.

--- a/docs/api/module.rst
+++ b/docs/api/module.rst
@@ -17,6 +17,25 @@ it also exposes the `module-level objects`__ required by the specifications.
    If you need an asynchronous connection use `AsyncConnection.connect`
    instead.
 
+.. data:: capabilities
+
+    An object that can be used to verify that the client library used by
+    psycopg implements a certain feature. For instance::
+
+        # Fail at import time if encrypted passwords is not available
+        import psycopg
+        psycopg.capabilities.has_encrypt_password(check=True)
+
+        # Verify at runtime if a feature can be used
+        if psycopg.capabilities.has_hostaddr():
+            print(conn.info.hostaddr)
+        else:
+            print("unknown connection hostadd")
+
+    :type: `Capabilities`
+
+    .. versionadded:: 3.2
+
 
 .. rubric:: Exceptions
 

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -19,6 +19,8 @@ Psycopg 3.2 (unreleased)
   (:ticket:`340`).
 - Add :ref:`raw-query-cursors` to execute queries using placeholders in
   PostgreSQL format (`$1`, `$2`...) (:ticket:`#560`).
+- Add `psycopg.capabilities` object to :ref:`inspect the libpq capabilities
+  <capabilities>` (:ticket:`#772`).
 - Add `~rows.scalar_row` to return scalar values from a query (:ticket:`#723`).
 - Prepared statements are now :ref:`compatible with PgBouncer <pgbouncer>`.
   (:ticket:`#589`).

--- a/psycopg/psycopg/__init__.py
+++ b/psycopg/psycopg/__init__.py
@@ -21,7 +21,7 @@ from ._pipeline import Pipeline, AsyncPipeline
 from .connection import Connection
 from .transaction import Rollback, Transaction, AsyncTransaction
 from .cursor_async import AsyncCursor
-from ._capabilities import Capabilities
+from ._capabilities import Capabilities, capabilities
 from .server_cursor import AsyncServerCursor, ServerCursor
 from .client_cursor import AsyncClientCursor, ClientCursor
 from .raw_cursor import AsyncRawCursor, RawCursor
@@ -40,9 +40,6 @@ from .version import __version__ as __version__  # noqa: F401
 logger = logging.getLogger("psycopg")
 if logger.level == logging.NOTSET:
     logger.setLevel(logging.WARNING)
-
-# A global object to check for capabilities.
-capabilities = Capabilities()
 
 # DBAPI compliance
 connect = Connection.connect
@@ -74,6 +71,8 @@ __all__ = [
     "AsyncServerCursor",
     "AsyncTransaction",
     "BaseConnection",
+    "Capabilities",
+    "capabilities",
     "ClientCursor",
     "Column",
     "Connection",

--- a/psycopg/psycopg/__init__.py
+++ b/psycopg/psycopg/__init__.py
@@ -21,6 +21,7 @@ from ._pipeline import Pipeline, AsyncPipeline
 from .connection import Connection
 from .transaction import Rollback, Transaction, AsyncTransaction
 from .cursor_async import AsyncCursor
+from ._capabilities import Capabilities
 from .server_cursor import AsyncServerCursor, ServerCursor
 from .client_cursor import AsyncClientCursor, ClientCursor
 from .raw_cursor import AsyncRawCursor, RawCursor
@@ -39,6 +40,9 @@ from .version import __version__ as __version__  # noqa: F401
 logger = logging.getLogger("psycopg")
 if logger.level == logging.NOTSET:
     logger.setLevel(logging.WARNING)
+
+# A global object to check for capabilities.
+capabilities = Capabilities()
 
 # DBAPI compliance
 connect = Connection.connect

--- a/psycopg/psycopg/_capabilities.py
+++ b/psycopg/psycopg/_capabilities.py
@@ -11,36 +11,49 @@ from .errors import NotSupportedError
 
 class Capabilities:
     """
-    Check if a feature is supported.
-
-    Every feature check is implemented by a check method `has_SOMETHING`.
-    All the methods return a boolean stating if the capability is supported.
-    If not supported and `check` is True, raise a `NotSupportedError` instead
-    explaining why the feature is not supported.
+    An object to check if a feature is supported by the libpq available on the client.
     """
 
     def has_encrypt_password(self, check: bool = False) -> bool:
-        """Check if the `~PGconn.encrypt_password()` method is implemented."""
-        return self._has_feature("PGconn.encrypt_password()", 100000, check=check)
+        """Check if the `PGconn.encrypt_password()` method is implemented.
+
+        The feature requires libpq 10.0 and greater.
+        """
+        return self._has_feature("pq.PGconn.encrypt_password()", 100000, check=check)
 
     def has_hostaddr(self, check: bool = False) -> bool:
-        """Check if the `~ConnectionInfo.hostaddr` attribute is implemented."""
-        return self._has_feature("Connection.pipeline()", 120000, check=check)
+        """Check if the `ConnectionInfo.hostaddr` attribute is implemented.
+
+        The feature requires libpq 12.0 and greater.
+        """
+        return self._has_feature("Connection.info.hostaddr", 120000, check=check)
 
     def has_pipeline(self, check: bool = False) -> bool:
-        """Check if the `~Connection.pipeline()` method is implemented."""
+        """Check if the :ref:`pipeline mode <pipeline-mode>` is supported.
+
+        The feature requires libpq 14.0 and greater.
+        """
         return self._has_feature("Connection.pipeline()", 140000, check=check)
 
-    def has_set_trace_flag(self, check: bool = False) -> bool:
-        """Check if the `~PGconn.set_trace_flag()` method is implemented."""
-        return self._has_feature("PGconn.set_trace_flag()", 140000, check=check)
+    def has_set_trace_flags(self, check: bool = False) -> bool:
+        """Check if the `pq.PGconn.set_trace_flags()` method is implemented.
+
+        The feature requires libpq 14.0 and greater.
+        """
+        return self._has_feature("PGconn.set_trace_flags()", 140000, check=check)
 
     def has_cancel_safe(self, check: bool = False) -> bool:
-        """Check if the `Connection.cancel_safe()` method is implemented."""
+        """Check if the `Connection.cancel_safe()` method is implemented.
+
+        The feature requires libpq 17.0 and greater.
+        """
         return self._has_feature("Connection.cancel_safe()", 170000, check=check)
 
     def has_pgbouncer_prepared(self, check: bool = False) -> bool:
-        """Check if prepared statements in PgBouncer are supported."""
+        """Check if prepared statements in PgBouncer are supported.
+
+        The feature requires libpq 17.0 and greater.
+        """
         return self._has_feature(
             "PgBouncer prepared statements compatibility", 170000, check=check
         )

--- a/psycopg/psycopg/_capabilities.py
+++ b/psycopg/psycopg/_capabilities.py
@@ -100,3 +100,7 @@ class Capabilities:
             return f"the psycopg[binary] package version {version}"
         else:
             return "system libraries"
+
+
+# The object that will be exposed by the module.
+capabilities = Capabilities()

--- a/psycopg/psycopg/_capabilities.py
+++ b/psycopg/psycopg/_capabilities.py
@@ -1,0 +1,89 @@
+"""
+psycopg capabilities objects
+"""
+
+# Copyright (C) 2024 The Psycopg Team
+
+from . import pq
+from . import _cmodule
+from .errors import NotSupportedError
+
+
+class Capabilities:
+    """
+    Check if a feature is supported.
+
+    Every feature check is implemented by a check method `has_SOMETHING`.
+    All the methods return a boolean stating if the capability is supported.
+    If not supported and `check` is True, raise a `NotSupportedError` instead
+    explaining why the feature is not supported.
+    """
+
+    def has_encrypt_password(self, check: bool = False) -> bool:
+        """Check if the `~PGconn.encrypt_password()` method is implemented."""
+        return self._has_feature("PGconn.encrypt_password()", 100000, check=check)
+
+    def has_hostaddr(self, check: bool = False) -> bool:
+        """Check if the `~ConnectionInfo.hostaddr` attribute is implemented."""
+        return self._has_feature("Connection.pipeline()", 120000, check=check)
+
+    def has_pipeline(self, check: bool = False) -> bool:
+        """Check if the `~Connection.pipeline()` method is implemented."""
+        return self._has_feature("Connection.pipeline()", 140000, check=check)
+
+    def has_set_trace_flag(self, check: bool = False) -> bool:
+        """Check if the `~PGconn.set_trace_flag()` method is implemented."""
+        return self._has_feature("PGconn.set_trace_flag()", 140000, check=check)
+
+    def has_cancel_safe(self, check: bool = False) -> bool:
+        """Check if the `Connection.cancel_safe()` method is implemented."""
+        return self._has_feature("Connection.cancel_safe()", 170000, check=check)
+
+    def has_pgbouncer_prepared(self, check: bool = False) -> bool:
+        """Check if prepared statements in PgBouncer are supported."""
+        return self._has_feature(
+            "PgBouncer prepared statements compatibility", 170000, check=check
+        )
+
+    def _has_feature(self, feature: str, want_version: int, check: bool) -> bool:
+        """
+        Check is a version is supported.
+
+        If `check` is true, raise an exception with an explicative message
+        explaining why the feature is not supported.
+
+        The expletive messages, are left to the user.
+        """
+        msg = ""
+        if pq.version() < want_version:
+            msg = (
+                f"the feature '{feature}' is not available:"
+                f" the client libpq version (imported from {self._libpq_source()})"
+                f" is {pq.version_pretty(pq.version())}; the feature"
+                f" requires libpq version {pq.version_pretty(want_version)}"
+                " or newer"
+            )
+
+        elif pq.__build_version__ < want_version:
+            msg = (
+                f"the feature '{feature}' is not available:"
+                f" you are using a psycopg[{pq.__impl__}] libpq wrapper built"
+                f" with libpq version {pq.version_pretty(pq.__build_version__)};"
+                " the feature requires libpq version"
+                f" {pq.version_pretty(want_version)} or newer"
+            )
+
+        if not msg:
+            return True
+        elif check:
+            raise NotSupportedError(msg)
+        else:
+            return False
+
+    def _libpq_source(self) -> str:
+        """Return a string reporting where the libpq comes from."""
+        if pq.__impl__ == "binary":
+            version: str = _cmodule.__version__ or "unknown"
+            return f"the psycopg[binary] package version {version}"
+        else:
+            return "system libraries"

--- a/psycopg/psycopg/pq/__init__.py
+++ b/psycopg/psycopg/pq/__init__.py
@@ -15,7 +15,7 @@ from typing import Callable, List, Type
 
 from . import abc
 from .misc import ConninfoOption, PGnotify, PGresAttDesc
-from .misc import error_message
+from .misc import error_message, version_pretty
 from ._enums import ConnStatus, DiagnosticField, ExecStatus, Format, Trace
 from ._enums import Ping, PipelineStatus, PollingStatus, TransactionStatus
 
@@ -132,4 +132,5 @@ __all__ = (
     "error_message",
     "ConninfoOption",
     "version",
+    "version_pretty",
 )

--- a/psycopg/psycopg/pq/_pq_ctypes.py
+++ b/psycopg/psycopg/pq/_pq_ctypes.py
@@ -11,7 +11,7 @@ from ctypes import Structure, CFUNCTYPE, POINTER
 from ctypes import c_char, c_char_p, c_int, c_size_t, c_ubyte, c_uint, c_void_p
 from typing import Any, List, NoReturn, Tuple
 
-from .misc import find_libpq_full_path
+from .misc import find_libpq_full_path, version_pretty
 from ..errors import NotSupportedError
 
 libname = find_libpq_full_path()
@@ -194,8 +194,8 @@ PQhost.restype = c_char_p
 def not_supported_before(fname: str, pgversion: int) -> Any:
     def not_supported(*args: Any, **kwargs: Any) -> NoReturn:
         raise NotSupportedError(
-            f"{fname} requires libpq from PostgreSQL {pgversion} on the client;"
-            f" version {libpq_version // 10000} available instead"
+            f"{fname} requires libpq from PostgreSQL {version_pretty(pgversion)} on"
+            f" the client; version {version_pretty(libpq_version)} available instead"
         )
 
     return not_supported
@@ -206,7 +206,7 @@ if libpq_version >= 120000:
     PQhostaddr.argtypes = [PGconn_ptr]
     PQhostaddr.restype = c_char_p
 else:
-    PQhostaddr = not_supported_before("PQhostaddr", 12)
+    PQhostaddr = not_supported_before("PQhostaddr", 120000)
 
 PQport = pq.PQport
 PQport.argtypes = [PGconn_ptr]
@@ -320,8 +320,8 @@ if libpq_version >= 170000:
     PQclosePortal.restype = PGresult_ptr
 
 else:
-    PQclosePrepared = not_supported_before("PQclosePrepared", 17)
-    PQclosePortal = not_supported_before("PQclosePrepared", 17)
+    PQclosePrepared = not_supported_before("PQclosePrepared", 170000)
+    PQclosePortal = not_supported_before("PQclosePrepared", 170000)
 
 PQresultStatus = pq.PQresultStatus
 PQresultStatus.argtypes = [PGresult_ptr]
@@ -526,8 +526,8 @@ if libpq_version >= 170000:
     PQsendClosePortal.restype = c_int
 
 else:
-    PQsendClosePrepared = not_supported_before("PQsendClosePrepared", 17)
-    PQsendClosePortal = not_supported_before("PQsendClosePortal", 17)
+    PQsendClosePrepared = not_supported_before("PQsendClosePrepared", 170000)
+    PQsendClosePortal = not_supported_before("PQsendClosePortal", 170000)
 
 PQgetResult = pq.PQgetResult
 PQgetResult.argtypes = [PGconn_ptr]
@@ -600,15 +600,15 @@ if libpq_version >= 170000:
     PQcancelFinish.restype = None
 
 else:
-    PQcancelCreate = not_supported_before("PQcancelCreate", 17)
-    PQcancelStart = not_supported_before("PQcancelStart", 17)
-    PQcancelBlocking = not_supported_before("PQcancelBlocking", 17)
-    PQcancelPoll = not_supported_before("PQcancelPoll", 17)
-    PQcancelStatus = not_supported_before("PQcancelStatus", 17)
-    PQcancelSocket = not_supported_before("PQcancelSocket", 17)
-    PQcancelErrorMessage = not_supported_before("PQcancelErrorMessage", 17)
-    PQcancelReset = not_supported_before("PQcancelReset", 17)
-    PQcancelFinish = not_supported_before("PQcancelFinish", 17)
+    PQcancelCreate = not_supported_before("PQcancelCreate", 170000)
+    PQcancelStart = not_supported_before("PQcancelStart", 170000)
+    PQcancelBlocking = not_supported_before("PQcancelBlocking", 170000)
+    PQcancelPoll = not_supported_before("PQcancelPoll", 170000)
+    PQcancelStatus = not_supported_before("PQcancelStatus", 170000)
+    PQcancelSocket = not_supported_before("PQcancelSocket", 170000)
+    PQcancelErrorMessage = not_supported_before("PQcancelErrorMessage", 170000)
+    PQcancelReset = not_supported_before("PQcancelReset", 170000)
+    PQcancelFinish = not_supported_before("PQcancelFinish", 170000)
 
 
 PQgetCancel = pq.PQgetCancel
@@ -658,7 +658,7 @@ if libpq_version >= 140000:
     PQsetTraceFlags.argtypes = [PGconn_ptr, c_int]
     PQsetTraceFlags.restype = None
 else:
-    PQsetTraceFlags = not_supported_before("PQsetTraceFlags", 14)
+    PQsetTraceFlags = not_supported_before("PQsetTraceFlags", 140000)
 
 PQuntrace = pq.PQuntrace
 PQuntrace.argtypes = [PGconn_ptr]
@@ -680,7 +680,7 @@ if libpq_version >= 100000:
     ]
     PQencryptPasswordConn.restype = POINTER(c_char)
 else:
-    PQencryptPasswordConn = not_supported_before("PQencryptPasswordConn", 10)
+    PQencryptPasswordConn = not_supported_before("PQencryptPasswordConn", 100000)
 
 PQmakeEmptyPGresult = pq.PQmakeEmptyPGresult
 PQmakeEmptyPGresult.argtypes = [PGconn_ptr, c_int]
@@ -723,11 +723,11 @@ if libpq_version >= 140000:
     PQsendFlushRequest.restype = c_int
 
 else:
-    PQpipelineStatus = not_supported_before("PQpipelineStatus", 14)
-    PQenterPipelineMode = not_supported_before("PQenterPipelineMode", 14)
-    PQexitPipelineMode = not_supported_before("PQexitPipelineMode", 14)
-    PQpipelineSync = not_supported_before("PQpipelineSync", 14)
-    PQsendFlushRequest = not_supported_before("PQsendFlushRequest", 14)
+    PQpipelineStatus = not_supported_before("PQpipelineStatus", 140000)
+    PQenterPipelineMode = not_supported_before("PQenterPipelineMode", 140000)
+    PQexitPipelineMode = not_supported_before("PQexitPipelineMode", 140000)
+    PQpipelineSync = not_supported_before("PQpipelineSync", 140000)
+    PQsendFlushRequest = not_supported_before("PQsendFlushRequest", 140000)
 
 
 # 33.18. SSL Support

--- a/psycopg/psycopg/pq/misc.py
+++ b/psycopg/psycopg/pq/misc.py
@@ -175,3 +175,17 @@ def connection_summary(pgconn: PGconn) -> str:
     if sparts:
         sparts = f" ({sparts})"
     return f"[{status}]{sparts}"
+
+
+def version_pretty(version: int) -> str:
+    """
+    Return a pretty representation of a PostgreSQL version
+
+    For instance: 140002 -> 14.2, 90610 -> 9.6.10
+    """
+    version, patch = divmod(version, 100)
+    major, minor = divmod(version, 100)
+    if major >= 10 and minor == 0:
+        return f"{major}.{patch}"
+    else:
+        return f"{major}.{minor}.{patch}"

--- a/psycopg_c/psycopg_c/pq/pgconn.pyx
+++ b/psycopg_c/psycopg_c/pq/pgconn.pyx
@@ -24,15 +24,16 @@ from cpython.memoryview cimport PyMemoryView_FromObject
 
 import sys
 
-from psycopg.pq import Format as PqFormat, Trace
+from psycopg.pq import Format as PqFormat, Trace, version_pretty
 from psycopg.pq.misc import PGnotify, connection_summary
 from psycopg_c.pq cimport PQBuffer
 
 cdef object _check_supported(fname, int pgversion):
     if libpq.PG_VERSION_NUM < pgversion:
         raise e.NotSupportedError(
-            f"{fname} requires libpq from PostgreSQL {pgversion // 10000} on the"
-            f" client; version {libpq.PG_VERSION_NUM // 10000} available instead"
+            f"{fname} requires libpq from PostgreSQL {version_pretty(pgversion)}"
+            f" on the client; version {version_pretty(libpq.PG_VERSION_NUM)}"
+            " available instead"
         )
 
 cdef class PGconn:

--- a/tests/fix_db.py
+++ b/tests/fix_db.py
@@ -69,9 +69,11 @@ def pytest_collection_modifyitems(items):
 
 
 def pytest_runtest_setup(item):
-    for m in item.iter_markers(name="pipeline"):
-        if not psycopg.Pipeline.is_supported():
-            pytest.skip(psycopg.Pipeline._not_supported_reason())
+    try:
+        psycopg.capabilities.has_pipeline(check=True)
+    except psycopg.NotSupportedError as ex:
+        for m in item.iter_markers(name="pipeline"):
+            pytest.skip(str(ex))
 
 
 def pytest_configure(config):
@@ -213,8 +215,10 @@ def conn(conn_cls, dsn, request, tracefile):
 @pytest.fixture(params=[True, False], ids=["pipeline=on", "pipeline=off"])
 def pipeline(request, conn):
     if request.param:
-        if not psycopg.Pipeline.is_supported():
-            pytest.skip(psycopg.Pipeline._not_supported_reason())
+        try:
+            psycopg.capabilities.has_pipeline(check=True)
+        except psycopg.NotSupportedError as ex:
+            pytest.skip(str(ex))
         with conn.pipeline() as p:
             yield p
         return
@@ -236,8 +240,10 @@ async def aconn(dsn, aconn_cls, request, tracefile):
 @pytest.fixture(params=[True, False], ids=["pipeline=on", "pipeline=off"])
 async def apipeline(request, aconn):
     if request.param:
-        if not psycopg.Pipeline.is_supported():
-            pytest.skip(psycopg.Pipeline._not_supported_reason())
+        try:
+            psycopg.capabilities.has_pipeline(check=True)
+        except psycopg.NotSupportedError as ex:
+            pytest.skip(str(ex))
         async with aconn.pipeline() as p:
             yield p
         return

--- a/tests/pq/test_misc.py
+++ b/tests/pq/test_misc.py
@@ -81,3 +81,11 @@ def test_result_set_attrs(pgconn):
 
     with pytest.raises(psycopg.OperationalError):
         res.set_attributes(attrs)
+
+
+@pytest.mark.parametrize(
+    "intv, strv",
+    [(91020, "9.10.20"), (100004, "10.4"), (101112, "10.11.12")],
+)
+def test_version_pretty(intv, strv):
+    assert pq.version_pretty(intv) == strv

--- a/tests/pq/test_pq.py
+++ b/tests/pq/test_pq.py
@@ -54,4 +54,4 @@ def test_pipeline_not_supported(conn):
         with conn.pipeline():
             pass
 
-    assert "too old" in str(exc.value)
+    assert "requires libpq version 14.0 or newer" in str(exc.value)

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -1,0 +1,68 @@
+import re
+
+import pytest
+
+from psycopg import pq, _cmodule
+from psycopg import capabilities, NotSupportedError
+
+caps = [
+    ("has_encrypt_password", "encrypt_password", 10),
+    ("has_hostaddr", "PGconn.hostaddr", 12),
+    ("has_pipeline", "Connection.pipeline()", 14),
+    ("has_set_trace_flag", "PGconn.set_trace_flag()", 14),
+    ("has_cancel_safe", "Connection.cancel_safe()", 17),
+    ("has_pgbouncer_prepared", "PgBouncer prepared statements compatibility", 17),
+]
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    [
+        pytest.param(method_name, marks=pytest.mark.libpq(f">= {min_ver}"))
+        for method_name, _, min_ver in caps
+    ],
+)
+def test_has_capability(method_name):
+    method = getattr(capabilities, method_name)
+    assert method()
+    assert method(check=True)
+
+
+@pytest.mark.parametrize(
+    "method_name, label",
+    [
+        pytest.param(method_name, label, marks=pytest.mark.libpq(f"< {min_ver}"))
+        for method_name, label, min_ver in caps
+    ],
+)
+def test_no_capability(method_name, label):
+    method = getattr(capabilities, method_name)
+    assert not method()
+    with pytest.raises(NotSupportedError, match=f"'{re.escape(label)}'"):
+        method(check=True)
+
+
+def test_build_or_import_msg(monkeypatch):
+    monkeypatch.setattr(pq, "version", lambda: 140000)
+    monkeypatch.setattr(pq, "__build_version__", 139999)
+    with pytest.raises(NotSupportedError, match=r"built with libpq version 13\.99\.99"):
+        capabilities.has_pipeline(check=True)
+
+    monkeypatch.setattr(pq, "version", lambda: 139999)
+    with pytest.raises(
+        NotSupportedError, match=r"client libpq version \(.*\) is 13\.99\.99"
+    ):
+        capabilities.has_pipeline(check=True)
+
+
+def test_impl_build_error(monkeypatch):
+    monkeypatch.setattr(pq, "__build_version__", 139999)
+    monkeypatch.setattr(pq, "version", lambda: 139999)
+    if pq.__impl__ == "binary":
+        ver = _cmodule.__version__
+        assert ver
+        msg = "(imported from the psycopg[binary] package version {ver})"
+    else:
+        msg = "(imported from system libraries)"
+        with pytest.raises(NotSupportedError, match=re.escape(msg)):
+            capabilities.has_pipeline(check=True)

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -6,10 +6,10 @@ from psycopg import pq, _cmodule
 from psycopg import capabilities, NotSupportedError
 
 caps = [
-    ("has_encrypt_password", "encrypt_password", 10),
-    ("has_hostaddr", "PGconn.hostaddr", 12),
+    ("has_encrypt_password", "pq.PGconn.encrypt_password()", 10),
+    ("has_hostaddr", "Connection.info.hostaddr", 12),
     ("has_pipeline", "Connection.pipeline()", 14),
-    ("has_set_trace_flag", "PGconn.set_trace_flag()", 14),
+    ("has_set_trace_flags", "PGconn.set_trace_flags()", 14),
     ("has_cancel_safe", "Connection.cancel_safe()", 17),
     ("has_pgbouncer_prepared", "PgBouncer prepared statements compatibility", 17),
 ]

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -174,8 +174,10 @@ def test_pipeline_communicate_abort(pgconn, pipeline_demo, pipeline, generators)
 
 @pytest.fixture
 def pipeline_uniqviol(pgconn):
-    if not psycopg.Pipeline.is_supported():
-        pytest.skip(psycopg.Pipeline._not_supported_reason())
+    try:
+        psycopg.capabilities.has_pipeline(check=True)
+    except psycopg.NotSupportedError as ex:
+        pytest.skip(str(ex))
     assert pgconn.pipeline_status == 0
     res = pgconn.exec_(b"DROP TABLE IF EXISTS pg_pipeline_uniqviol")
     assert res.status == pq.ExecStatus.COMMAND_OK, res.error_message

--- a/tools/update_oids.py
+++ b/tools/update_oids.py
@@ -21,6 +21,7 @@ from typing import List
 from pathlib import Path
 
 import psycopg
+from psycopg.pq import version_pretty
 from psycopg.rows import TupleRow
 from psycopg.crdb import CrdbConnection
 from psycopg._compat import TypeAlias
@@ -90,13 +91,10 @@ def update_crdb_python_oids(conn: Connection) -> None:
 
 def get_version_comment(conn: Connection) -> List[str]:
     if conn.info.vendor == "PostgreSQL":
-        # Assume PG > 10
-        num = conn.info.server_version
-        version = f"{num // 10000}.{num % 100}"
+        version = version_pretty(conn.info.server_version)
     elif conn.info.vendor == "CockroachDB":
         assert isinstance(conn, CrdbConnection)
-        num = conn.info.server_version
-        version = f"{num // 10000}.{num % 10000 // 100}.{num % 100}"
+        version = version_pretty(conn.info.server_version)
     else:
         raise NotImplementedError(f"unexpected vendor: {conn.info.vendor}")
     return ["", f"    # Generated from {conn.info.vendor} {version}", ""]


### PR DESCRIPTION
The object, exposed as `psycopg.capabilities`, exposes `has_STUFF()` methods to verify if a certain feature is supported.

If `check=True` is specified, raise an exception instead of returning False, with a finely crafted message such as:

> the feature 'Connection.pipeline()' is not available: you are using a psycopg[c] libpq wrapper built with libpq version 9.5.3; the feature requires libpq version at least 14.0
>
> the feature 'Connection.pipeline()' is not available: the client libpq version (imported from system libraries) is 13.4; the feature requires libpq version at least 14.0
>
> the feature 'Connection.pipeline()' is not available: the client libpq version (imported from psycopg[binary] version 3.2.0) is 13.4; the feature requires libpq version at least 14.0

helping to diagnose the problem.

As a side effect, added a `pq.version_pretty()` function to convert the numieric version to the postgres version. Code refactored to use it instead of homegrown `// 10000`, divmod, and similar.

The `Pipeline.is_supported()` method has been reimplemented using `Capabilities.has_pipeline()`.

Close #772