### PR TITLE
Fix closing of pools

### DIFF
--- a/psycopg_pool/psycopg_pool/pool.py
+++ b/psycopg_pool/psycopg_pool/pool.py
@@ -425,11 +425,12 @@ class ConnectionPool(Generic[CT], BasePool):
             waiting = list(self._waiting)
             self._waiting.clear()
             connections = list(self._pool)
-            self._pool.clear()
 
-        # Now that the flag _closed is set, getconn will fail immediately,
-        # putconn will just close the returned connection.
-        self._stop_workers(waiting, connections, timeout)
+            # Now that the flag _closed is set, getconn will fail immediately,
+            # putconn will just close the returned connection.
+            self._stop_workers(waiting, connections, timeout)
+
+            self._pool.clear()
 
     def _stop_workers(
         self,

--- a/psycopg_pool/psycopg_pool/pool_async.py
+++ b/psycopg_pool/psycopg_pool/pool_async.py
@@ -457,11 +457,12 @@ class AsyncConnectionPool(Generic[ACT], BasePool):
             waiting = list(self._waiting)
             self._waiting.clear()
             connections = list(self._pool)
-            self._pool.clear()
 
-        # Now that the flag _closed is set, getconn will fail immediately,
-        # putconn will just close the returned connection.
-        await self._stop_workers(waiting, connections, timeout)
+            # Now that the flag _closed is set, getconn will fail immediately,
+            # putconn will just close the returned connection.
+            await self._stop_workers(waiting, connections, timeout)
+
+            self._pool.clear()
 
     async def _stop_workers(
         self,


### PR DESCRIPTION
I have a reproducible test where there are still connections left in `pool._pool` after `close()` is run. This seems to fix it for my case but I have no idea why and can't really share a reproducible example. My guess is it has something to do with a race condition and/or weirdness with pytest and event loops.

I'm opening this first to see what happens in CI.