### PR TITLE
Review cancel methods implementations

### DIFF
--- a/docs/api/connections.rst
+++ b/docs/api/connections.rst
@@ -303,7 +303,9 @@ The `!Connection` class
 
         .. warning::
 
-            The `!cancel()` method has a few shortcomings:
+            The `!cancel()` method is implemented using the :pq:`PQcancel`
+            function, which is deprecated since PostgreSQL 17, and has a few
+            shortcomings:
 
             - it is blocking even on async connections,
             - it `might use an insecure connection`__ even if the original

--- a/psycopg/psycopg/_connection_base.py
+++ b/psycopg/psycopg/_connection_base.py
@@ -320,13 +320,9 @@ class BaseConnection(Generic[Row]):
         return True
 
     def _cancel_gen(self) -> PQGenConn[None]:
-        try:
-            cancel_conn = self.pgconn.cancel_conn()
-        except e.OperationalError as ex:  # if the connection is closed
-            logger.warning("couldn't create a cancel connection: %s", ex)
-        else:
-            cancel_conn.start()
-            yield from generators.cancel(cancel_conn)
+        cancel_conn = self.pgconn.cancel_conn()
+        cancel_conn.start()
+        yield from generators.cancel(cancel_conn)
 
     def add_notice_handler(self, callback: NoticeHandler) -> None:
         """

--- a/psycopg/psycopg/_connection_base.py
+++ b/psycopg/psycopg/_connection_base.py
@@ -302,7 +302,7 @@ class BaseConnection(Generic[Row]):
             c = self.pgconn.get_cancel()
             c.cancel()
         except Exception as ex:
-            logger.warning("couldn't try to cancel query: %s", str(ex))
+            logger.warning("couldn't try to cancel query: %s", ex)
 
     def _should_cancel(self) -> bool:
         """Check whether the current command should actually be cancelled when

--- a/psycopg/psycopg/_conninfo_attempts.py
+++ b/psycopg/psycopg/_conninfo_attempts.py
@@ -41,7 +41,7 @@ def conninfo_attempts(params: ConnMapping) -> list[ConnDict]:
         try:
             attempts.extend(_resolve_hostnames(attempt))
         except OSError as ex:
-            logger.debug("failed to resolve host %r: %s", attempt.get("host"), str(ex))
+            logger.debug("failed to resolve host %r: %s", attempt.get("host"), ex)
             last_exc = ex
 
     if not attempts:

--- a/psycopg/psycopg/_conninfo_attempts_async.py
+++ b/psycopg/psycopg/_conninfo_attempts_async.py
@@ -40,7 +40,7 @@ async def conninfo_attempts_async(params: ConnMapping) -> list[ConnDict]:
         try:
             attempts.extend(await _resolve_hostnames(attempt))
         except OSError as ex:
-            logger.debug("failed to resolve host %r: %s", attempt.get("host"), str(ex))
+            logger.debug("failed to resolve host %r: %s", attempt.get("host"), ex)
             last_exc = ex
 
     if not attempts:

--- a/psycopg/psycopg/connection.py
+++ b/psycopg/psycopg/connection.py
@@ -279,7 +279,7 @@ class Connection(BaseConnection[Row]):
             try:
                 waiting.wait_conn(self._cancel_gen(), interval=_WAIT_INTERVAL)
             except Exception as ex:
-                logger.warning("couldn't try to cancel query: %s", str(ex))
+                logger.warning("couldn't try to cancel query: %s", ex)
         else:
             self.cancel()
 

--- a/psycopg/psycopg/connection_async.py
+++ b/psycopg/psycopg/connection_async.py
@@ -288,16 +288,23 @@ class AsyncConnection(BaseConnection[Row]):
         If the underlying libpq is older than version 17, the method will fall
         back to using the same implementation of `!cancel()`.
         """
-        if self._should_cancel():
+        if not self._should_cancel():
+            return
+
+        # TODO: replace with capabilities.has_safe_cancel after merging #782
+        if pq.__build_version__ >= 170000:
             try:
                 await waiting.wait_conn_async(
                     self._cancel_gen(), interval=_WAIT_INTERVAL
                 )
-            except e.NotSupportedError:
-                if True:  # ASYNC
-                    await to_thread(self.cancel)
-                else:
-                    self.cancel()
+            except Exception as ex:
+                logger.warning("couldn't try to cancel query: %s", str(ex))
+
+        else:
+            if True:  # ASYNC
+                await to_thread(self.cancel)
+            else:
+                self.cancel()
 
     @asynccontextmanager
     async def transaction(

--- a/psycopg/psycopg/connection_async.py
+++ b/psycopg/psycopg/connection_async.py
@@ -298,7 +298,7 @@ class AsyncConnection(BaseConnection[Row]):
                     self._cancel_gen(), interval=_WAIT_INTERVAL
                 )
             except Exception as ex:
-                logger.warning("couldn't try to cancel query: %s", str(ex))
+                logger.warning("couldn't try to cancel query: %s", ex)
 
         else:
             if True:  # ASYNC


### PR DESCRIPTION
I have cleaned up both `cancel()` and `cancel_safe()`. Both the methods now consistently warn and swallow exceptions on error, but only in the outermost shell; inner methods are more purely mechanism.

Close #778. In preparation for #779. Can make use of #782.