### PR TITLE
fix(pool): make sure there are no connection in the pool after close()

### DIFF
--- a/docs/news_pool.rst
+++ b/docs/news_pool.rst
@@ -15,6 +15,7 @@ psycopg_pool 3.2.2 (unreleased)
 
 - Raise a `RuntimeWarning` instead of a `DeprecationWarning` if an async pool
   is open in the constructor.
+- Fix connections possibly left in the pool after closing (:ticket:`#784`).
 
 
 Current release


### PR DESCRIPTION
The case has been reported in #784. While not easy to reproduce, it seems that it might be caused by the pool being closed while a worker is still trying to create a connection, which will be put in the _pool state after supposedly no other operation should have been performed.

Stop the workers and then empty the pool only after they have stopped to run.

Also refactor the cleanup of the pool and waiting queue, moving them to close(). There is no reason why a method called "stop workers" should empty them, and there is no other code path that use such feature.

Close #784.

@adriangb could you please try if this changeset fixes your problem?