### PR TITLE
Replace SELECT 1 with an empty query

### DIFF
--- a/docs/news_pool.rst
+++ b/docs/news_pool.rst
@@ -16,6 +16,8 @@ psycopg_pool 3.2.2 (unreleased)
 - Raise a `RuntimeWarning` instead of a `DeprecationWarning` if an async pool
   is open in the constructor.
 - Fix connections possibly left in the pool after closing (:ticket:`#784`).
+- Use an empty query instead of ``SELECT 1`` to check connections
+  (:ticket:`#790`).
 
 
 Current release

--- a/psycopg_pool/psycopg_pool/pool.py
+++ b/psycopg_pool/psycopg_pool/pool.py
@@ -537,11 +537,11 @@ class ConnectionPool(Generic[CT], BasePool):
         for instance as `!check` callback when a pool is created.
         """
         if conn.autocommit:
-            conn.execute("SELECT 1")
+            conn.execute("--ping")
         else:
             conn.autocommit = True
             try:
-                conn.execute("SELECT 1")
+                conn.execute("--ping")
             finally:
                 conn.autocommit = False
 

--- a/psycopg_pool/psycopg_pool/pool.py
+++ b/psycopg_pool/psycopg_pool/pool.py
@@ -537,11 +537,11 @@ class ConnectionPool(Generic[CT], BasePool):
         for instance as `!check` callback when a pool is created.
         """
         if conn.autocommit:
-            conn.execute("--ping")
+            conn.execute("")
         else:
             conn.autocommit = True
             try:
-                conn.execute("--ping")
+                conn.execute("")
             finally:
                 conn.autocommit = False
 

--- a/psycopg_pool/psycopg_pool/pool_async.py
+++ b/psycopg_pool/psycopg_pool/pool_async.py
@@ -569,7 +569,7 @@ class AsyncConnectionPool(Generic[ACT], BasePool):
         for instance as `!check` callback when a pool is created.
         """
         if conn.autocommit:
-            await conn.execute("--ping")
+            await conn.execute("")
         else:
             if True:  # ASYNC
                 # NOTE: with Psycopg 3.2 we could use conn.set_autocommit() in
@@ -577,13 +577,13 @@ class AsyncConnectionPool(Generic[ACT], BasePool):
                 # previous versions too.
                 await conn.set_autocommit(True)
                 try:
-                    await conn.execute("--ping")
+                    await conn.execute("")
                 finally:
                     await conn.set_autocommit(False)
             else:
                 conn.autocommit = True
                 try:
-                    conn.execute("--ping")
+                    conn.execute("")
                 finally:
                     conn.autocommit = False
 

--- a/psycopg_pool/psycopg_pool/pool_async.py
+++ b/psycopg_pool/psycopg_pool/pool_async.py
@@ -569,7 +569,7 @@ class AsyncConnectionPool(Generic[ACT], BasePool):
         for instance as `!check` callback when a pool is created.
         """
         if conn.autocommit:
-            await conn.execute("SELECT 1")
+            await conn.execute("--ping")
         else:
             if True:  # ASYNC
                 # NOTE: with Psycopg 3.2 we could use conn.set_autocommit() in
@@ -577,13 +577,13 @@ class AsyncConnectionPool(Generic[ACT], BasePool):
                 # previous versions too.
                 await conn.set_autocommit(True)
                 try:
-                    await conn.execute("SELECT 1")
+                    await conn.execute("--ping")
                 finally:
                     await conn.set_autocommit(False)
             else:
                 conn.autocommit = True
                 try:
-                    conn.execute("SELECT 1")
+                    conn.execute("--ping")
                 finally:
                     conn.autocommit = False
 


### PR DESCRIPTION
From #790:
> The current implementation of `psycopg_pool.pool.ConnectionPool.check_connection` uses the `SELECT 1` statement to check if a connection is valid.
> 
> However this goes through the PostgreSQL query planner which means we can make this process a little bit faster by sending an empty query instead.
> 
> This can be done by replacing `conn.execute("SELECT 1")` with `conn.execute("--ping")`
> 
> References:
> - https://github.com/rails/rails/pull/42368
> - [jackc/pgx ping implementation (Go)](https://github.com/jackc/pgx/blob/a3d9120636fc263debce595f3ba05bcd9f4ee809/pgconn/pgconn.go#L1815-L1817)
> - https://github.com/sqlalchemy/sqlalchemy/issues/8491