### PR TITLE
fix(c): fix the goto label in the HAVE_POLL branch of wait_c_impl()

### DIFF
--- a/psycopg_c/psycopg_c/_psycopg/waiting.pyx
+++ b/psycopg_c/psycopg_c/_psycopg/waiting.pyx
@@ -84,7 +84,7 @@ retry_eintr:
     }
 
     if (PyErr_CheckSignals()) { goto finally; }
-    if (select_rv < 0) { goto finally; }  /* poll error */
+    if (select_rv < 0) { goto error; }  /* poll error */
 
     rv = 0;  /* success, maybe with timeout */
     if (select_rv >= 0) {


### PR DESCRIPTION
This resolves the following warning when building the extension module:

    $ python psycopg_c/setup.py build_ext -i
    [...]
    building 'psycopg_c._psycopg' extension
    x86_64-linux-gnu-gcc -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -fPIC -I/home/denis/.local/pgsql/include -I/home/denis/src/psycopg3/.venv/include -I/usr/include/python3.11 -c psycopg_c/_psycopg.c -o build/temp.linux-x86_64-cpython-311/psycopg_c/_psycopg.o
    psycopg_c/_psycopg.c: In function ‘wait_c_impl’:
    psycopg_c/_psycopg.c:1649:1: warning: label ‘error’ defined but not used [-Wunused-label]
     1649 |
          | ^