### PR TITLE
fix: fix handling of floating point values for connect_timeout

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -50,6 +50,8 @@ Psycopg 3.1.19
 ^^^^^^^^^^^^^^
 
 - Fix excessive stripping of error message prefixes (:ticket:`#752`).
+- Allow to specify the ``connect_timeout`` connection parameter as float
+  (:ticket:`#796`).
 
 
 Current release

--- a/psycopg/psycopg/conninfo.py
+++ b/psycopg/psycopg/conninfo.py
@@ -138,9 +138,9 @@ def timeout_from_conninfo(params: ConnDict) -> int:
     if value is None:
         value = _DEFAULT_CONNECT_TIMEOUT
     try:
-        timeout = int(value)
+        timeout = int(float(value))
     except ValueError:
-        raise e.ProgrammingError(f"bad value for connect_timeout: {value!r}")
+        raise e.ProgrammingError(f"bad value for connect_timeout: {value!r}") from None
 
     if timeout <= 0:
         # The sync connect function will stop on the default socket timeout

--- a/tests/test_conninfo.py
+++ b/tests/test_conninfo.py
@@ -96,6 +96,7 @@ def test_no_munging():
         ("connect_timeout=0", _DEFAULT_CONNECT_TIMEOUT, None),
         ("connect_timeout=1", 2, None),
         ("connect_timeout=10", 10, None),
+        ("connect_timeout=5.0", 5, None),
         ("", 15, {"PGCONNECT_TIMEOUT": "15"}),
     ],
 )


### PR DESCRIPTION
The [`connect_timeout`](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-CONNECT-TIMEOUT) parameter is specified as integer.

It seems that certain libpq versions handle correctly a floating point connect timeout:

```
$ psql connect_timeout=5.0
psql (11.22 (Debian 11.22-0+deb10u2), server 16.2)
WARNING: psql major version 11, server major version 16.
         Some psql features might not work.
Type "help" for help.
```

others don't

```
$ psql --version
psql (PostgreSQL) 16.2 (Ubuntu 16.2-1.pgdg22.04+1)
$ psql "connect_timeout=5.0"
psql: error: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: invalid integer value "5.0" for connection option "connect_timeout"
```

Psycopg doesn't, but mostly by accident, and in the recent version where the connection timeout and the multiple attempts are taken more care of:

```
$ python -c "import psycopg; psycopg.connect('connect_timeout=5.0')"
Traceback (most recent call last):
  File "/home/piro/dev/LiveSurface/BackSurface/.venv/lib/python3.10/site-packages/psycopg/conninfo.py", line 141, in timeout_from_conninfo
    timeout = int(value)
ValueError: invalid literal for int() with base 10: '5.0'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/piro/dev/LiveSurface/BackSurface/.venv/lib/python3.10/site-packages/psycopg/connection.py", line 727, in connect
    timeout = timeout_from_conninfo(params)
  File "/home/piro/dev/LiveSurface/BackSurface/.venv/lib/python3.10/site-packages/psycopg/conninfo.py", line 143, in timeout_from_conninfo
    raise e.ProgrammingError(f"bad value for connect_timeout: {value!r}")
psycopg.ProgrammingError: bad value for connect_timeout: '5.0'
```

it seems safe to parse a floating point error too.
