### PR TITLE
feat: also handle the timeout in async cancel_safe() with libpq < 17

### DIFF
--- a/psycopg/psycopg/connection_async.py
+++ b/psycopg/psycopg/connection_async.py
@@ -304,7 +304,10 @@ class AsyncConnection(BaseConnection[Row]):
             )
         else:
             if True:  # ASYNC
-                await to_thread(self.cancel)
+                try:
+                    await asyncio.wait_for(to_thread(self.cancel), timeout)
+                except asyncio.TimeoutError as exc:
+                    raise e.CancellationTimeout("cancellation timeout expired") from exc
             else:
                 self.cancel()
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -846,8 +846,9 @@ def test_cancel_safe_error(conn_cls, proxy, caplog):
 
 @pytest.mark.slow
 @pytest.mark.timing
-@pytest.mark.libpq(">= 17")
 def test_cancel_safe_timeout(conn_cls, proxy):
+    if pq.version() < 170000:
+        pytest.skip("only for libpq >= 17")
     proxy.start()
     with conn_cls.connect(proxy.client_dsn) as conn:
         proxy.stop()

--- a/tests/test_connection_async.py
+++ b/tests/test_connection_async.py
@@ -850,8 +850,10 @@ async def test_cancel_safe_error(aconn_cls, proxy, caplog):
 
 @pytest.mark.slow
 @pytest.mark.timing
-@pytest.mark.libpq(">= 17")
 async def test_cancel_safe_timeout(aconn_cls, proxy):
+    if False:  # ASYNC
+        if pq.version() < 170000:
+            pytest.skip("only for libpq >= 17")
     proxy.start()
     async with await aconn_cls.connect(proxy.client_dsn) as aconn:
         proxy.stop()


### PR DESCRIPTION
See comments from https://github.com/psycopg/psycopg/pull/780#issuecomment-2062492554 