### PR TITLE
Use simple query protocol to execute BEGIN/COMMIT out of pipeline mode

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -7,6 +7,17 @@
 ``psycopg`` release notes
 =========================
 
+Future releases
+---------------
+
+Psycopg 3.1.20 (unreleased)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Use the simple query protocol to execute COMMIT/ROLLBACK when possible.
+  This should make easier to connect the PgBouncer admin database
+  (:ticket:`#820`).
+
+
 Current release
 ---------------
 

--- a/psycopg/psycopg/connection.py
+++ b/psycopg/psycopg/connection.py
@@ -464,7 +464,13 @@ class BaseConnection(Generic[Row]):
             self._pipeline.result_queue.append(None)
             return None
 
-        self.pgconn.send_query_params(command, None, result_format=result_format)
+        # Unless needed, use the simple query protocol, e.g. to interact with
+        # pgbouncer. In pipeline mode we always use the advanced query protocol
+        # instead, see #350
+        if result_format == TEXT:
+            self.pgconn.send_query(command)
+        else:
+            self.pgconn.send_query_params(command, None, result_format=result_format)
 
         result = (yield from execute(self.pgconn))[-1]
         if result.status != COMMAND_OK and result.status != TUPLES_OK:


### PR DESCRIPTION
We started using the extended protocol in e5079184 to fix #350, but, probably to keep symmetry, we also changed the behaviour out of the pipeline.

This turns out to be a problem for people connecting to the PgBouncer admin console. They can use the `ClientCursor`, which tries to use the simple protocol as much as it can, but they currently have to use autocommit. With this changeset autocommit shouldn't be needed anymore. See #808.