### PR TITLE
chore: Updates action versions and add dependabot to check monthly for updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#package-ecosystem
+
+version: 2
+updates:
+
+  # Enable updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    target-branch: "master"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every month
+      interval: "monthly"
+    groups:
+      actions:
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"

--- a/.github/workflows/3rd-party-tests.yml
+++ b/.github/workflows/3rd-party-tests.yml
@@ -225,7 +225,7 @@ jobs:
           USE_TZ = False
           HERE
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ matrix.python-version }}-pip-${{ hashFiles('django_home/django/tests/requirements/py3.txt', 'django_home/django/setup.cfg') }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger docs build
-        uses: peter-evans/repository-dispatch@v1
+        uses: peter-evans/repository-dispatch@v3
         with:
           repository: psycopg/psycopg-website
           event-type: psycopg3-commit

--- a/.github/workflows/packages-bin.yml
+++ b/.github/workflows/packages-bin.yml
@@ -245,3 +245,17 @@ jobs:
 
 
   # }}}
+
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - linux
+      - macos-14
+      - macos-12
+      - windows
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: psycopg-binary-artifact
+          delete-merged: true

--- a/.github/workflows/packages-bin.yml
+++ b/.github/workflows/packages-bin.yml
@@ -27,14 +27,14 @@ jobs:
 
       - name: Set up QEMU for multi-arch build
         # Check https://github.com/docker/setup-qemu-action for newer versions.
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           # Note: 6.2.0 is buggy: make sure to avoid it.
           # See https://github.com/pypa/cibuildwheel/issues/1250
           image: tonistiigi/binfmt:qemu-v7.0.0
 
       - name: Cache libpq build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /tmp/libpq.build
           key: libpq-${{ matrix.platform }}-${{ matrix.arch }}-${{ env.LIBPQ_VERSION }}-${{ env.OPENSSL_VERSION }}
@@ -43,7 +43,7 @@ jobs:
         run: python3 ./tools/build/copy_to_binary.py
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.5
+        uses: pypa/cibuildwheel@v2.17.0
         with:
           package-dir: psycopg_binary
         env:
@@ -71,8 +71,9 @@ jobs:
             PSYCOPG_TEST_WANT_LIBPQ_BUILD=${{ env.LIBPQ_VERSION }}
             PSYCOPG_TEST_WANT_LIBPQ_IMPORT=${{ env.LIBPQ_VERSION }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: linux-${{matrix.pyver}}-${{matrix.platform}}_${{matrix.arch}}
           path: ./wheelhouse/*.whl
 
     services:
@@ -118,7 +119,7 @@ jobs:
         run: brew services start postgresql@${PG_VERSION}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.5
+        uses: pypa/cibuildwheel@v2.17.0
         with:
           package-dir: psycopg_binary
         env:
@@ -134,8 +135,9 @@ jobs:
             PSYCOPG_TEST_WANT_LIBPQ_BUILD=">= ${PG_VERSION}"
             PSYCOPG_TEST_WANT_LIBPQ_IMPORT=">= ${PG_VERSION}"
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: macos-14-${{matrix.pyver}}-macosx_${{matrix.arch}}
           path: ./wheelhouse/*.whl
 
 
@@ -168,7 +170,7 @@ jobs:
         run: brew services start postgresql@${PG_VERSION}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.5
+        uses: pypa/cibuildwheel@v2.17.0
         with:
           package-dir: psycopg_binary
         env:
@@ -184,8 +186,9 @@ jobs:
             PSYCOPG_TEST_WANT_LIBPQ_BUILD=">= ${PG_VERSION}"
             PSYCOPG_TEST_WANT_LIBPQ_IMPORT=">= ${PG_VERSION}"
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: macos-12-${{matrix.pyver}}-macosx_${{matrix.arch}}
           path: ./wheelhouse/*.whl
 
 
@@ -215,7 +218,7 @@ jobs:
         run: python3 ./tools/build/copy_to_binary.py
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.5
+        uses: pypa/cibuildwheel@v2.17.0
         with:
           package-dir: psycopg_binary
         env:
@@ -235,8 +238,9 @@ jobs:
             PSYCOPG_TEST_WANT_LIBPQ_BUILD=">= 14"
             PSYCOPG_TEST_WANT_LIBPQ_IMPORT=">= 14"
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: windows-${{matrix.pyver}}-${{matrix.arch}}
           path: ./wheelhouse/*.whl
 
 

--- a/.github/workflows/packages-pool.yml
+++ b/.github/workflows/packages-pool.yml
@@ -39,8 +39,9 @@ jobs:
           PSYCOPG_TEST_DSN: "host=127.0.0.1 user=postgres"
           PGPASSWORD: password
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: ${{ matrix.package }}-${{ matrix.format }}
           path: ./dist/*
 
     services:

--- a/.github/workflows/packages-pool.yml
+++ b/.github/workflows/packages-pool.yml
@@ -57,3 +57,14 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - sdist
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: psycopg-pool-artifact
+          delete-merged: true

--- a/.github/workflows/packages-src.yml
+++ b/.github/workflows/packages-src.yml
@@ -65,3 +65,13 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - sdist
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: psycopg-src-artifact
+          delete-merged: true

--- a/.github/workflows/packages-src.yml
+++ b/.github/workflows/packages-src.yml
@@ -47,8 +47,9 @@ jobs:
           PSYCOPG_TEST_DSN: "host=127.0.0.1 user=postgres"
           PGPASSWORD: password
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: ${{ matrix.package }}-${{ matrix.format }}-${{ matrix.impl }}
           path: ./dist/*
 
     services:


### PR DESCRIPTION
Updates the actions which could be done with little to minimal changes.. Includes a monthly dependabot check for actions now.

This is motivated by recent updates to the Node 16 availability for runners: https://github.blog/changelog/2024-05-17-updated-dates-for-actions-runner-using-node20-instead-of-node16-by-default/

Changelogs for review:

- https://github.com/actions/cache/releases/tag/v4.0.0
- https://github.com/actions/upload-artifact/releases/tag/v4.0.0
  - Required the most changes due to how uploads work now.  Each upload needs a distinct name now, so each build produces a new artifact
  - See also https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md
  - If desired, I can attempt to merge them all at the end
- https://github.com/docker/setup-qemu-action/releases/tag/v3.0.0
- https://github.com/peter-evans/repository-dispatch/releases
- https://github.com/pypa/cibuildwheel/releases/tag/v2.17.0

Other possible updates:
- [pypa/cibuildwheel@v2.18.0](https://github.com/pypa/cibuildwheel/releases)
  - musllinux was updated to default to 1.2 (1.1 / Alpine 3.12 is long EoL now).  This would require build script updates, etc and might be considered breaking
  - Seemed to be something with MacOS too, it doesn't finish repairing the wheel

Builds seem to be fine:
- Build binary packages: https://github.com/stumpylog/psycopg/actions/runs/9136339177
- Build pool packages: https://github.com/stumpylog/psycopg/actions/runs/9136644822
- Build source packages: https://github.com/stumpylog/psycopg/actions/runs/9136645187