### PR TITLE
Fix count of chars to escape in textual copy dump

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -16,6 +16,8 @@ Psycopg 3.1.20 (unreleased)
 - Use the simple query protocol to execute COMMIT/ROLLBACK when possible.
   This should make easier to connect the PgBouncer admin database
   (:ticket:`#820`).
+- Avoid unneeded escaping checks and memory over-allocation in text copy
+  (:ticket:`#829`).
 
 
 Current release

--- a/psycopg_c/psycopg_c/_psycopg/copy.pyx
+++ b/psycopg_c/psycopg_c/_psycopg/copy.pyx
@@ -114,7 +114,7 @@ def format_row_text(
     cdef char *buf
     cdef int i, j
     cdef unsigned char *target
-    cdef int nesc = 0
+    cdef int nesc
     cdef int with_tab
     cdef PyObject *fmt = <PyObject *>PG_TEXT
     cdef PyObject *row_dumper
@@ -157,6 +157,7 @@ def format_row_text(
 
         # Now from pos to pos + size there is a textual representation: it may
         # contain chars to escape. Scan to find how many such chars there are.
+        nesc = 0
         for j in range(size):
             if copy_escape_lut[target[j]]:
                 nesc += 1


### PR DESCRIPTION
We missed to reset the number of chars to escape at every field. As a consequence, we end up resizing and scanning all the fields after the first one requiring an escape and allocating a bit more memory than needed.