### PR TITLE
feat(capabilities): add has_send_close_prepared()

### DIFF
--- a/docs/advanced/prepare.rst
+++ b/docs/advanced/prepare.rst
@@ -68,8 +68,8 @@ PgBouncer__ middleware, using the following caveats:
 - PgBouncer version must be version `1.22`__ or newer.
 - PgBouncer `max_prepared_statements`__ must be greater than 0.
 - The libpq version on the client must be from PostgreSQL 17 or newer
-  (you can check the `~Capabilities.has_pgbouncer_prepared` capability to
-  verify it).
+  (you can check the `~Capabilities.has_send_close_prepared()` capability to
+  verify that the libpq implements the features required by PgBouncer).
 
 .. __: https://www.pgbouncer.org/
 .. __: https://www.pgbouncer.org/2024/01/pgbouncer-1-22-0

--- a/docs/api/objects.rst
+++ b/docs/api/objects.rst
@@ -159,7 +159,6 @@ Libpq capabilities information
 
     .. automethod:: has_stream_chunked
     .. automethod:: has_send_close_prepared
-    .. automethod:: has_pgbouncer_prepared
 
         .. seealso:: :ref:`pgbouncer`
 

--- a/docs/api/objects.rst
+++ b/docs/api/objects.rst
@@ -158,6 +158,7 @@ Libpq capabilities information
             the legacy :pq:`PQcancel` implementation.
 
     .. automethod:: has_stream_chunked
+    .. automethod:: has_send_close_prepared
     .. automethod:: has_pgbouncer_prepared
 
         .. seealso:: :ref:`pgbouncer`

--- a/psycopg/psycopg/_capabilities.py
+++ b/psycopg/psycopg/_capabilities.py
@@ -71,15 +71,6 @@ class Capabilities:
         """
         return self._has_feature("PGconn.send_close_prepared()", 170000, check=check)
 
-    def has_pgbouncer_prepared(self, check: bool = False) -> bool:
-        """Check if prepared statements in PgBouncer are supported.
-
-        The feature requires libpq 17.0 and greater.
-        """
-        return self._has_feature(
-            "PgBouncer prepared statements compatibility", 170000, check=check
-        )
-
     def _has_feature(self, feature: str, want_version: int, check: bool) -> bool:
         """
         Check is a version is supported.

--- a/psycopg/psycopg/_capabilities.py
+++ b/psycopg/psycopg/_capabilities.py
@@ -64,6 +64,13 @@ class Capabilities:
             "Cursor.stream() with 'size' parameter greater than 1", 170000, check=check
         )
 
+    def has_send_close_prepared(self, check: bool = False) -> bool:
+        """Check if the `pq.PGconn.send_closed_prepared()` method is implemented.
+
+        The feature requires libpq 17.0 and greater.
+        """
+        return self._has_feature("PGconn.send_close_prepared()", 170000, check=check)
+
     def has_pgbouncer_prepared(self, check: bool = False) -> bool:
         """Check if prepared statements in PgBouncer are supported.
 

--- a/psycopg/psycopg/_connection_base.py
+++ b/psycopg/psycopg/_connection_base.py
@@ -27,6 +27,7 @@ from ._compat import LiteralString, Self, TypeAlias, TypeVar
 from .pq.misc import connection_summary
 from ._pipeline import BasePipeline
 from ._preparing import PrepareManager
+from ._capabilities import capabilities
 from ._connection_info import ConnectionInfo
 
 if TYPE_CHECKING:
@@ -50,7 +51,7 @@ FATAL_ERROR = pq.ExecStatus.FATAL_ERROR
 IDLE = pq.TransactionStatus.IDLE
 INTRANS = pq.TransactionStatus.INTRANS
 
-_HAS_SEND_CLOSE = pq.__build_version__ >= 170000
+_HAS_SEND_CLOSE = capabilities.has_send_close_prepared()
 
 logger = logging.getLogger("psycopg")
 

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -18,7 +18,6 @@ caps = [
     ("has_cancel_safe", "Connection.cancel_safe()", 17),
     ("has_stream_chunked", "Cursor.stream() with 'size' parameter greater than 1", 17),
     ("has_send_close_prepared", "PGconn.send_close_prepared()", 17),
-    ("has_pgbouncer_prepared", "PgBouncer prepared statements compatibility", 17),
 ]
 
 

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -17,6 +17,7 @@ caps = [
     ("has_set_trace_flags", "PGconn.set_trace_flags()", 14),
     ("has_cancel_safe", "Connection.cancel_safe()", 17),
     ("has_stream_chunked", "Cursor.stream() with 'size' parameter greater than 1", 17),
+    ("has_send_close_prepared", "PGconn.send_close_prepared()", 17),
     ("has_pgbouncer_prepared", "PgBouncer prepared statements compatibility", 17),
 ]
 


### PR DESCRIPTION
This is a capability we need internally. `has_pgbouncer_prepared()` is pretty much just an alias of it, more outwards-facing. I wonder if we want to keep them both.