### PR TITLE
chore: drop pq enums aliases on connection and cursor

### DIFF
--- a/psycopg/psycopg/_connection_base.py
+++ b/psycopg/psycopg/_connection_base.py
@@ -94,10 +94,6 @@ class BaseConnection(Generic[Row]):
     ProgrammingError = e.ProgrammingError
     NotSupportedError = e.NotSupportedError
 
-    # Enums useful for the connection
-    ConnStatus = pq.ConnStatus
-    TransactionStatus = pq.TransactionStatus
-
     def __init__(self, pgconn: PGconn):
         self.pgconn = pgconn
         self._autocommit = False

--- a/psycopg/psycopg/_cursor_base.py
+++ b/psycopg/psycopg/_cursor_base.py
@@ -51,8 +51,6 @@ class BaseCursor(Generic[ConnectionType, Row]):
         __weakref__
         """.split()
 
-    ExecStatus = pq.ExecStatus
-
     _tx: Transformer
     _make_row: RowMaker[Row]
     _pgconn: PGconn

--- a/tests/_test_copy.py
+++ b/tests/_test_copy.py
@@ -1,6 +1,6 @@
 import struct
 
-from psycopg.pq import Format
+from psycopg import pq
 from psycopg.copy import AsyncWriter
 from psycopg.copy import FileWriter as FileWriter  # noqa: F401
 
@@ -43,7 +43,7 @@ async def ensure_table_async(cur, tabledef, name="copy_in"):
 
 def py_to_raw(item, fmt):
     """Convert from Python type to the expected result from the db"""
-    if fmt == Format.TEXT:
+    if fmt == pq.Format.TEXT:
         if isinstance(item, int):
             return str(item)
     else:

--- a/tests/_test_transaction.py
+++ b/tests/_test_transaction.py
@@ -1,6 +1,7 @@
 import sys
 import pytest
 import psycopg
+from psycopg import pq
 
 
 # TODOCRDB: is this the expected behaviour?
@@ -50,9 +51,9 @@ def inserted(conn):
 
 
 def in_transaction(conn):
-    if conn.pgconn.transaction_status == conn.TransactionStatus.IDLE:
+    if conn.pgconn.transaction_status == pq.TransactionStatus.IDLE:
         return False
-    elif conn.pgconn.transaction_status == conn.TransactionStatus.INTRANS:
+    elif conn.pgconn.transaction_status == pq.TransactionStatus.INTRANS:
         return True
     else:
         assert False, conn.pgconn.transaction_status

--- a/tests/crdb/test_cursor.py
+++ b/tests/crdb/test_cursor.py
@@ -37,7 +37,7 @@ def test_changefeed(conn_cls, dsn, conn, testfeed, fmt_out):
                     for row in cur.stream(f"experimental changefeed for {testfeed}"):
                         q.put_nowait(row)
                 except e.QueryCanceled:
-                    assert conn.info.transaction_status == conn.TransactionStatus.IDLE
+                    assert conn.info.transaction_status == pq.TransactionStatus.IDLE
                     q.put_nowait(None)
         except Exception as ex:
             q.put_nowait(ex)

--- a/tests/crdb/test_cursor_async.py
+++ b/tests/crdb/test_cursor_async.py
@@ -38,7 +38,7 @@ async def test_changefeed(aconn_cls, dsn, aconn, testfeed, fmt_out):
                     ):
                         q.put_nowait(row)
                 except e.QueryCanceled:
-                    assert conn.info.transaction_status == conn.TransactionStatus.IDLE
+                    assert conn.info.transaction_status == pq.TransactionStatus.IDLE
                     q.put_nowait(None)
         except Exception as ex:
             q.put_nowait(ex)

--- a/tests/test_cursor_common.py
+++ b/tests/test_cursor_common.py
@@ -13,7 +13,7 @@ from packaging.version import parse as ver
 import pytest
 
 import psycopg
-from psycopg import sql, rows
+from psycopg import pq, sql, rows
 from psycopg.adapt import PyFormat
 from psycopg.types import TypeInfo
 
@@ -229,7 +229,7 @@ def test_execute_sequence(conn):
 def test_execute_empty_query(conn, query):
     cur = conn.cursor()
     cur.execute(query)
-    assert cur.pgresult.status == cur.ExecStatus.EMPTY_QUERY
+    assert cur.pgresult.status == pq.ExecStatus.EMPTY_QUERY
     with pytest.raises(psycopg.ProgrammingError):
         cur.fetchone()
 
@@ -744,7 +744,7 @@ def test_stream_error_tx(conn):
     with pytest.raises(psycopg.ProgrammingError):
         for rec in cur.stream("wat"):
             pass
-    assert conn.info.transaction_status == conn.TransactionStatus.INERROR
+    assert conn.info.transaction_status == pq.TransactionStatus.INERROR
 
 
 def test_stream_error_notx(conn):
@@ -753,7 +753,7 @@ def test_stream_error_notx(conn):
     with pytest.raises(psycopg.ProgrammingError):
         for rec in cur.stream("wat"):
             pass
-    assert conn.info.transaction_status == conn.TransactionStatus.IDLE
+    assert conn.info.transaction_status == pq.TransactionStatus.IDLE
 
 
 def test_stream_error_python_to_consume(conn):
@@ -763,8 +763,8 @@ def test_stream_error_python_to_consume(conn):
             for rec in gen:
                 1 / 0
     assert conn.info.transaction_status in (
-        conn.TransactionStatus.INTRANS,
-        conn.TransactionStatus.INERROR,
+        pq.TransactionStatus.INTRANS,
+        pq.TransactionStatus.INERROR,
     )
 
 
@@ -776,7 +776,7 @@ def test_stream_error_python_consumed(conn):
             1 / 0
 
     gen.close()
-    assert conn.info.transaction_status == conn.TransactionStatus.INTRANS
+    assert conn.info.transaction_status == pq.TransactionStatus.INTRANS
 
 
 @pytest.mark.parametrize("autocommit", [False, True])

--- a/tests/test_cursor_common_async.py
+++ b/tests/test_cursor_common_async.py
@@ -10,7 +10,7 @@ from packaging.version import parse as ver
 import pytest
 
 import psycopg
-from psycopg import sql, rows
+from psycopg import pq, sql, rows
 from psycopg.adapt import PyFormat
 from psycopg.types import TypeInfo
 
@@ -229,7 +229,7 @@ async def test_execute_sequence(aconn):
 async def test_execute_empty_query(aconn, query):
     cur = aconn.cursor()
     await cur.execute(query)
-    assert cur.pgresult.status == cur.ExecStatus.EMPTY_QUERY
+    assert cur.pgresult.status == pq.ExecStatus.EMPTY_QUERY
     with pytest.raises(psycopg.ProgrammingError):
         await cur.fetchone()
 
@@ -751,7 +751,7 @@ async def test_stream_error_tx(aconn):
     with pytest.raises(psycopg.ProgrammingError):
         async for rec in cur.stream("wat"):
             pass
-    assert aconn.info.transaction_status == aconn.TransactionStatus.INERROR
+    assert aconn.info.transaction_status == pq.TransactionStatus.INERROR
 
 
 async def test_stream_error_notx(aconn):
@@ -760,7 +760,7 @@ async def test_stream_error_notx(aconn):
     with pytest.raises(psycopg.ProgrammingError):
         async for rec in cur.stream("wat"):
             pass
-    assert aconn.info.transaction_status == aconn.TransactionStatus.IDLE
+    assert aconn.info.transaction_status == pq.TransactionStatus.IDLE
 
 
 async def test_stream_error_python_to_consume(aconn):
@@ -770,8 +770,8 @@ async def test_stream_error_python_to_consume(aconn):
             async for rec in gen:
                 1 / 0
     assert aconn.info.transaction_status in (
-        aconn.TransactionStatus.INTRANS,
-        aconn.TransactionStatus.INERROR,
+        pq.TransactionStatus.INTRANS,
+        pq.TransactionStatus.INERROR,
     )
 
 
@@ -783,7 +783,7 @@ async def test_stream_error_python_consumed(aconn):
             1 / 0
 
     await gen.aclose()
-    assert aconn.info.transaction_status == aconn.TransactionStatus.INTRANS
+    assert aconn.info.transaction_status == pq.TransactionStatus.INTRANS
 
 
 @pytest.mark.parametrize("autocommit", [False, True])

--- a/tests/test_cursor_server.py
+++ b/tests/test_cursor_server.py
@@ -4,8 +4,7 @@
 import pytest
 
 import psycopg
-from psycopg import rows, errors as e
-from psycopg.pq import Format
+from psycopg import pq, rows, errors as e
 
 
 pytestmark = pytest.mark.crdb_skip("server-side cursor")
@@ -73,11 +72,11 @@ def test_description(conn):
 
 def test_format(conn):
     cur = conn.cursor("foo")
-    assert cur.format == Format.TEXT
+    assert cur.format == pq.Format.TEXT
     cur.close()
 
     cur = conn.cursor("foo", binary=True)
-    assert cur.format == Format.BINARY
+    assert cur.format == pq.Format.BINARY
     cur.close()
 
 
@@ -138,7 +137,7 @@ def test_binary_cursor_text_override(conn):
 
 
 def test_close(conn, recwarn):
-    if conn.info.transaction_status == conn.TransactionStatus.INTRANS:
+    if conn.info.transaction_status == pq.TransactionStatus.INTRANS:
         # connection dirty from previous failure
         conn.execute("close foo")
     recwarn.clear()
@@ -225,7 +224,7 @@ def test_close_on_error(conn):
     cur.execute("select 1")
     with pytest.raises(e.ProgrammingError):
         conn.execute("wat")
-    assert conn.info.transaction_status == conn.TransactionStatus.INERROR
+    assert conn.info.transaction_status == pq.TransactionStatus.INERROR
     cur.close()
 
 

--- a/tests/test_cursor_server_async.py
+++ b/tests/test_cursor_server_async.py
@@ -1,8 +1,7 @@
 import pytest
 
 import psycopg
-from psycopg import rows, errors as e
-from psycopg.pq import Format
+from psycopg import pq, rows, errors as e
 
 from .acompat import alist
 
@@ -76,11 +75,11 @@ async def test_description(aconn):
 
 async def test_format(aconn):
     cur = aconn.cursor("foo")
-    assert cur.format == Format.TEXT
+    assert cur.format == pq.Format.TEXT
     await cur.close()
 
     cur = aconn.cursor("foo", binary=True)
-    assert cur.format == Format.BINARY
+    assert cur.format == pq.Format.BINARY
     await cur.close()
 
 
@@ -141,7 +140,7 @@ async def test_binary_cursor_text_override(aconn):
 
 
 async def test_close(aconn, recwarn):
-    if aconn.info.transaction_status == aconn.TransactionStatus.INTRANS:
+    if aconn.info.transaction_status == pq.TransactionStatus.INTRANS:
         # connection dirty from previous failure
         await aconn.execute("close foo")
     recwarn.clear()
@@ -230,7 +229,7 @@ async def test_close_on_error(aconn):
     await cur.execute("select 1")
     with pytest.raises(e.ProgrammingError):
         await aconn.execute("wat")
-    assert aconn.info.transaction_status == aconn.TransactionStatus.INERROR
+    assert aconn.info.transaction_status == pq.TransactionStatus.INERROR
     await cur.close()
 
 

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -6,7 +6,7 @@ import logging
 import pytest
 
 from psycopg import Rollback
-from psycopg import errors as e
+from psycopg import pq, errors as e
 
 from ._test_transaction import in_transaction, insert_row, inserted, get_exc_info
 from ._test_transaction import ExpectedException, crdb_skip_external_observer
@@ -117,7 +117,7 @@ def test_context_active_rollback_no_clobber(conn_cls, dsn, caplog):
             with conn.transaction():
                 conn.pgconn.exec_(b"copy (select generate_series(1, 10)) to stdout")
                 status = conn.info.transaction_status
-                assert status == conn.TransactionStatus.ACTIVE
+                assert status == pq.TransactionStatus.ACTIVE
                 1 / 0
 
         assert len(caplog.records) == 1

--- a/tests/test_transaction_async.py
+++ b/tests/test_transaction_async.py
@@ -3,7 +3,7 @@ import logging
 import pytest
 
 from psycopg import Rollback
-from psycopg import errors as e
+from psycopg import pq, errors as e
 
 from ._test_transaction import in_transaction, insert_row, inserted, get_exc_info
 from ._test_transaction import ExpectedException, crdb_skip_external_observer
@@ -117,7 +117,7 @@ async def test_context_active_rollback_no_clobber(aconn_cls, dsn, caplog):
             async with conn.transaction():
                 conn.pgconn.exec_(b"copy (select generate_series(1, 10)) to stdout")
                 status = conn.info.transaction_status
-                assert status == conn.TransactionStatus.ACTIVE
+                assert status == pq.TransactionStatus.ACTIVE
                 1 / 0
 
         assert len(caplog.records) == 1


### PR DESCRIPTION
Unused in the codebase, and not documented. Only used in the test suite.

Because they haven't been documented I think we can drop them safely.