### PR TITLE
build: avoid installing tomli on recent python

### DIFF
--- a/psycopg_c/build_backend/cython_backend.py
+++ b/psycopg_c/build_backend/cython_backend.py
@@ -10,10 +10,15 @@ otherwise it only relies on the c files to have been precompiled.
 from __future__ import annotations
 
 import os
+import sys
 from typing import Any
 
-import tomli
 from setuptools import build_meta
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 
 def get_requires_for_build_wheel(config_settings: Any = None) -> list[str]:
@@ -26,7 +31,7 @@ def get_requires_for_build_wheel(config_settings: Any = None) -> list[str]:
     # to build. Get the version from the pyproject itself to keep things in the
     # same place.
     with open("pyproject.toml", "rb") as f:
-        pyprj = tomli.load(f)
+        pyprj = tomllib.load(f)
 
     rv: list[str] = pyprj["cython-backend"]["cython-requires"]
     return rv

--- a/psycopg_c/pyproject.toml
+++ b/psycopg_c/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 49.2.0", "wheel >= 0.37", "tomli >= 2.0.1"]
+requires = ["setuptools >= 49.2.0", "wheel >= 0.37", "tomli >= 2.0.1 ; python_version<'3.11'"]
 
 # The cython_backend is a build backend adding a Cython dependency if the c
 # source must be build from pxd files (when building from git checkout), and

--- a/psycopg_c/pyproject.toml
+++ b/psycopg_c/pyproject.toml
@@ -1,5 +1,9 @@
 [build-system]
-requires = ["setuptools >= 49.2.0", "wheel >= 0.37", "tomli >= 2.0.1 ; python_version<'3.11'"]
+requires = [
+    "setuptools >= 49.2.0",
+    "wheel >= 0.37",
+    "tomli >= 2.0.1; python_version < '3.11'",
+]
 
 # The cython_backend is a build backend adding a Cython dependency if the c
 # source must be build from pxd files (when building from git checkout), and


### PR DESCRIPTION
It is in the stdlib. No need to have wheel building require downloading yet another build dependency.