### PR TITLE
Update openssl to 3.3.1

### DIFF
--- a/.github/workflows/packages-bin.yml
+++ b/.github/workflows/packages-bin.yml
@@ -12,8 +12,10 @@ jobs:
     if: true
 
     env:
+      # Latest release: https://www.postgresql.org/ftp/source/
       LIBPQ_VERSION: "16.3"
-      OPENSSL_VERSION: "1.1.1w"
+      # Latest release: https://www.openssl.org/source/
+      OPENSSL_VERSION: "3.3.1"
 
     strategy:
       fail-fast: false
@@ -67,7 +69,7 @@ jobs:
             PGPASSWORD=password
             LIBPQ_BUILD_PREFIX=/host/tmp/libpq.build
             PATH="$LIBPQ_BUILD_PREFIX/bin:$PATH"
-            LD_LIBRARY_PATH="$LIBPQ_BUILD_PREFIX/lib"
+            LD_LIBRARY_PATH="$LIBPQ_BUILD_PREFIX/lib:$LIBPQ_BUILD_PREFIX/lib64"
             PSYCOPG_TEST_WANT_LIBPQ_BUILD=${{ env.LIBPQ_VERSION }}
             PSYCOPG_TEST_WANT_LIBPQ_IMPORT=${{ env.LIBPQ_VERSION }}
 

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -59,6 +59,7 @@ Psycopg 3.1.20 (unreleased)
   (:ticket:`#820`).
 - Avoid unneeded escaping checks and memory over-allocation in text copy
   (:ticket:`#829`).
+- Bundle binary package with OpenSSL 3.3.x (:ticket:`#847`).
 
 
 Current release

--- a/tools/build/build_libpq.sh
+++ b/tools/build/build_libpq.sh
@@ -8,7 +8,7 @@ postgres_version="${LIBPQ_VERSION}"
 openssl_version="${OPENSSL_VERSION}"
 
 # Latest release: https://openldap.org/software/download/
-ldap_version="2.6.6"
+ldap_version="2.6.8"
 
 # Latest release: https://github.com/cyrusimap/cyrus-sasl/releases
 sasl_version="2.1.28"

--- a/tools/build/build_libpq.sh
+++ b/tools/build/build_libpq.sh
@@ -46,32 +46,36 @@ case "$ID" in
 esac
 
 if [ "$ID" == "centos" ]; then
+  if [[ ! -f "${LIBPQ_BUILD_PREFIX}/openssl.cnf" ]]; then
 
     # Build openssl if needed
     openssl_tag="OpenSSL_${openssl_version//./_}"
     openssl_dir="openssl-${openssl_tag}"
-    if [ ! -d "${openssl_dir}" ]; then curl -sL \
+    if [ ! -d "${openssl_dir}" ]; then
+        curl -fsSL \
             https://github.com/openssl/openssl/archive/${openssl_tag}.tar.gz \
             | tar xzf -
 
-        cd "${openssl_dir}"
+        pushd "${openssl_dir}"
 
         ./config --prefix=${LIBPQ_BUILD_PREFIX} --openssldir=${LIBPQ_BUILD_PREFIX} \
             zlib -fPIC shared
         make depend
         make
     else
-        cd "${openssl_dir}"
+        pushd "${openssl_dir}"
     fi
 
     # Install openssl
     make install_sw
-    cd ..
+    popd
 
+  fi
 fi
 
 
 if [ "$ID" == "centos" ]; then
+  if [[ ! -f "${LIBPQ_BUILD_PREFIX}/lib/libsasl2.so" ]]; then
 
     # Build libsasl2 if needed
     # The system package (cyrus-sasl-devel) causes an amazing error on i686:
@@ -80,40 +84,42 @@ if [ "$ID" == "centos" ]; then
     sasl_tag="cyrus-sasl-${sasl_version}"
     sasl_dir="cyrus-sasl-${sasl_tag}"
     if [ ! -d "${sasl_dir}" ]; then
-        curl -sL \
+        curl -fsSL \
             https://github.com/cyrusimap/cyrus-sasl/archive/${sasl_tag}.tar.gz \
             | tar xzf -
 
-        cd "${sasl_dir}"
+        pushd "${sasl_dir}"
 
         autoreconf -i
         ./configure --prefix=${LIBPQ_BUILD_PREFIX} \
             CPPFLAGS=-I${LIBPQ_BUILD_PREFIX}/include/ LDFLAGS=-L${LIBPQ_BUILD_PREFIX}/lib
         make
     else
-        cd "${sasl_dir}"
+        pushd "${sasl_dir}"
     fi
 
     # Install libsasl2
     # requires missing nroff to build
     touch saslauthd/saslauthd.8
     make install
-    cd ..
+    popd
 
+  fi
 fi
 
 
 if [ "$ID" == "centos" ]; then
+  if [[ ! -f "${LIBPQ_BUILD_PREFIX}/lib/libldap.so" ]]; then
 
     # Build openldap if needed
     ldap_tag="${ldap_version}"
     ldap_dir="openldap-${ldap_tag}"
     if [ ! -d "${ldap_dir}" ]; then
-        curl -sL \
+        curl -fsSL \
             https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-${ldap_tag}.tgz \
             | tar xzf -
 
-        cd "${ldap_dir}"
+        pushd "${ldap_dir}"
 
         ./configure --prefix=${LIBPQ_BUILD_PREFIX} --enable-backends=no --enable-null \
             CPPFLAGS=-I${LIBPQ_BUILD_PREFIX}/include/ LDFLAGS=-L${LIBPQ_BUILD_PREFIX}/lib
@@ -123,7 +129,7 @@ if [ "$ID" == "centos" ]; then
         make -C libraries/liblber/
         make -C libraries/libldap/
     else
-        cd "${ldap_dir}"
+        pushd "${ldap_dir}"
     fi
 
     # Install openldap
@@ -131,8 +137,9 @@ if [ "$ID" == "centos" ]; then
     make -C libraries/libldap/ install
     make -C include/ install
     chmod +x ${LIBPQ_BUILD_PREFIX}/lib/{libldap,liblber}*.so*
-    cd ..
+    popd
 
+  fi
 fi
 
 
@@ -140,11 +147,11 @@ fi
 postgres_tag="REL_${postgres_version//./_}"
 postgres_dir="postgres-${postgres_tag}"
 if [ ! -d "${postgres_dir}" ]; then
-    curl -sL \
+    curl -fsSL \
         https://github.com/postgres/postgres/archive/${postgres_tag}.tar.gz \
         | tar xzf -
 
-    cd "${postgres_dir}"
+    pushd "${postgres_dir}"
 
     # Match the default unix socket dir default with what defined on Ubuntu and
     # Red Hat, which seems the most common location
@@ -163,13 +170,13 @@ if [ ! -d "${postgres_dir}" ]; then
     make -C src/bin/pg_config
     make -C src/include
 else
-    cd "${postgres_dir}"
+    pushd "${postgres_dir}"
 fi
 
 # Install libpq
 make -C src/interfaces/libpq install
 make -C src/bin/pg_config install
 make -C src/include install
-cd ..
+popd
 
 find ${LIBPQ_BUILD_PREFIX} -name \*.so.\* -type f -exec strip --strip-unneeded {} \;

--- a/tools/build/wheel_linux_before_all.sh
+++ b/tools/build/wheel_linux_before_all.sh
@@ -27,7 +27,7 @@ case "$ID" in
             # TODO: On 2021-11-09 curl fails on 'ppc64le' with:
             #   curl: (60) SSL certificate problem: certificate has expired
             # Test again later if -k can be removed.
-            curl -skf https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+            curl -fsSLk https://www.postgresql.org/media/keys/ACCC4CF8.asc \
                 > /etc/apt/trusted.gpg.d/postgresql.asc
         fi
 


### PR DESCRIPTION
This is a pretty long jump, previously used version was 1.1.1, which is now unsupported.

In the past, bundling openssl 0.9.8 was causing random segfaults when the python-bundled openssl was used too (e.g. requesting an https url via urllib). See https://github.com/psycopg/psycopg2/issues/543. A lot of time has passed, and hopefully the case shouldn't present again. Unfortunately it's not easy to test (I was never able to reproduce the bug above).