### PR TITLE
Drop string TypeAlias

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -7,6 +7,16 @@
 ``psycopg`` release notes
 =========================
 
+Future releases
+---------------
+
+Psycopg 3.2.2 (unreleased)
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Drop `!TypeDef` specifications as string from public modules, as they cannot
+  be composed by users as `!typing` objects previously could (:ticket:`#860`).
+
+
 Current release
 ---------------
 

--- a/psycopg/psycopg/abc.py
+++ b/psycopg/psycopg/abc.py
@@ -8,32 +8,32 @@ from __future__ import annotations
 
 from typing import Any, Callable, Generator, Mapping
 from typing import Protocol, Sequence, TYPE_CHECKING
+from typing import Dict, Union  # drop with Python 3.8
 
 from . import pq
 from ._enums import PyFormat as PyFormat
-from ._compat import TypeAlias, TypeVar
+from ._compat import LiteralString, TypeAlias, TypeVar
 
 if TYPE_CHECKING:
     from . import sql  # noqa: F401
     from .rows import Row, RowMaker
     from .pq.abc import PGresult
     from .waiting import Wait, Ready  # noqa: F401
-    from ._compat import LiteralString  # noqa: F401
     from ._adapters_map import AdaptersMap
     from ._connection_base import BaseConnection
 
 NoneType: type = type(None)
 
 # An object implementing the buffer protocol
-Buffer: TypeAlias = "bytes | bytearray | memoryview"
+Buffer: TypeAlias = Union[bytes, bytearray, memoryview]
 
-Query: TypeAlias = "LiteralString | bytes | sql.SQL | sql.Composed"
-Params: TypeAlias = "Sequence[Any] | Mapping[str, Any]"
+Query: TypeAlias = Union[LiteralString, bytes, "sql.SQL", "sql.Composed"]
+Params: TypeAlias = Union[Sequence[Any], Mapping[str, Any]]
 ConnectionType = TypeVar("ConnectionType", bound="BaseConnection[Any]")
 PipelineCommand: TypeAlias = Callable[[], None]
-DumperKey: TypeAlias = "type | tuple[DumperKey, ...]"
-ConnParam: TypeAlias = "str | int | None"
-ConnDict: TypeAlias = "dict[str, ConnParam]"
+DumperKey: TypeAlias = Union[type, "tuple[DumperKey, ...]"]
+ConnParam: TypeAlias = Union[str, int, None]
+ConnDict: TypeAlias = Dict[str, ConnParam]
 ConnMapping: TypeAlias = Mapping[str, ConnParam]
 
 

--- a/psycopg/psycopg/pq/abc.py
+++ b/psycopg/psycopg/pq/abc.py
@@ -7,6 +7,7 @@ Protocol objects to represent objects exposed by different pq implementations.
 from __future__ import annotations
 
 from typing import Any, Callable, Protocol, Sequence, TYPE_CHECKING
+from typing import Union  # drop with Python 3.8
 
 from ._enums import Format, Trace
 from .._compat import Self, TypeAlias
@@ -15,7 +16,7 @@ if TYPE_CHECKING:
     from .misc import PGnotify, ConninfoOption, PGresAttDesc
 
 # An object implementing the buffer protocol (ish)
-Buffer: TypeAlias = "bytes | bytearray | memoryview"
+Buffer: TypeAlias = Union[bytes, bytearray, memoryview]
 
 
 class PGconn(Protocol):

--- a/psycopg/psycopg/rows.py
+++ b/psycopg/psycopg/rows.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import functools
 from typing import Any, Callable, NamedTuple, NoReturn
 from typing import TYPE_CHECKING, Protocol, Sequence
+from typing import Dict, Tuple  # drop with Python 3.8
 from collections import namedtuple
 
 from . import pq
@@ -82,13 +83,13 @@ class BaseRowFactory(Protocol[Row]):
     def __call__(self, __cursor: BaseCursor[Any, Any]) -> RowMaker[Row]: ...
 
 
-TupleRow: TypeAlias = "tuple[Any, ...]"
+TupleRow: TypeAlias = Tuple[Any, ...]
 """
 An alias for the type returned by `tuple_row()` (i.e. a tuple of any content).
 """
 
 
-DictRow: TypeAlias = "dict[str, Any]"
+DictRow: TypeAlias = Dict[str, Any]
 """
 An alias for the type returned by `dict_row()`
 

--- a/psycopg_pool/psycopg_pool/abc.py
+++ b/psycopg_pool/psycopg_pool/abc.py
@@ -7,6 +7,7 @@ Types used in the psycopg_pool package
 from __future__ import annotations
 
 from typing import Awaitable, Callable, TYPE_CHECKING
+from typing import Union  # drop with Python 3.8
 
 from ._compat import TypeAlias, TypeVar
 
@@ -26,8 +27,8 @@ ConnectionCB: TypeAlias = Callable[[CT], None]
 AsyncConnectionCB: TypeAlias = Callable[[ACT], Awaitable[None]]
 
 # Callbacks to pass the pool to on connection failure
-ConnectFailedCB: TypeAlias = "Callable[[ConnectionPool[Any]], None]"
-AsyncConnectFailedCB: TypeAlias = (
-    "Callable[[AsyncConnectionPool[Any]], None]"
-    "| Callable[[AsyncConnectionPool[Any]], Awaitable[None]]"
-)
+ConnectFailedCB: TypeAlias = Callable[["ConnectionPool[Any]"], None]
+AsyncConnectFailedCB: TypeAlias = Union[
+    Callable[["AsyncConnectionPool[Any]"], None],
+    Callable[["AsyncConnectionPool[Any]"], Awaitable[None]],
+]


### PR DESCRIPTION
I have looked for TypeAlias defined as strings by looking for `TypeAlias = "` in the codebase.

I have fixed the occurrences that causes #860, but left the internal ones as they are. String TypeAlias not fixed at the moment are the following ones. IMO they are not worth fixing.

```
psycopg_pool/psycopg_pool/_acompat.py
33:AWorker: TypeAlias = "asyncio.Task[None]"

psycopg/psycopg/errors.py
34:ErrorInfo: TypeAlias = "PGresult | dict[int, bytes | None] | None"

psycopg/psycopg/_py_transformer.py
32:DumperCache: TypeAlias = "dict[DumperKey, abc.Dumper]"
33:OidDumperCache: TypeAlias = "dict[int, abc.Dumper]"
34:LoaderCache: TypeAlias = "dict[int, abc.Loader]"

psycopg/psycopg/_preparing.py
22:Key: TypeAlias = "tuple[bytes, tuple[int, ...]]"

psycopg/psycopg/types/enum.py
25:EnumDumpMap: TypeAlias = "dict[E, bytes]"
26:EnumLoadMap: TypeAlias = "dict[bytes, E]"
27:EnumMapping: TypeAlias = "Mapping[E, str] | Sequence[tuple[E, str]] | None"
30:_HEnumDumpMap: TypeAlias = "tuple[tuple[E, bytes], ...]"
31:_HEnumLoadMap: TypeAlias = "tuple[tuple[bytes, E], ...]"

psycopg/psycopg/types/net.py
20:Address: TypeAlias = "ipaddress.IPv4Address | ipaddress.IPv6Address"
21:Interface: TypeAlias = "ipaddress.IPv4Interface | ipaddress.IPv6Interface"
22:Network: TypeAlias = "ipaddress.IPv4Network | ipaddress.IPv6Network"

psycopg/psycopg/types/hstore.py
39:Hstore: TypeAlias = "dict[str, str | None]"

psycopg/psycopg/_acompat.py
21:AWorker: TypeAlias = "asyncio.Task[None]"

psycopg/psycopg/_typeinfo.py
28:RegistryKey: TypeAlias = "str | int | tuple[type, int]"
```

@adebrecht661 does this changeset fix the issue for you?

Close #860 