### PR TITLE
docs: fix typo in Basic module usage

### DIFF
--- a/docs/basic/usage.rst
+++ b/docs/basic/usage.rst
@@ -214,7 +214,7 @@ developer is free to use (and responsible for calling) `~Connection.commit()`,
 but be careful about its quirkiness: see :ref:`async-with` for details.
 
 
-Adapting pyscopg to your program
+Adapting psycopg to your program
 --------------------------------
 
 The above :ref:`pattern of use <usage>` only shows the default behaviour of


### PR DESCRIPTION
really tripped me out