### PR TITLE
fix: make make_conninfo()'s first argument positional only

### DIFF
--- a/psycopg/psycopg/conninfo.py
+++ b/psycopg/psycopg/conninfo.py
@@ -25,7 +25,7 @@ conninfo_attempts_async = _conninfo_attempts_async.conninfo_attempts_async
 _DEFAULT_CONNECT_TIMEOUT = 130
 
 
-def make_conninfo(conninfo: str = "", **kwargs: ConnParam) -> str:
+def make_conninfo(conninfo: str = "", /, **kwargs: ConnParam) -> str:
     """
     Merge a string and keyword params into a single conninfo string.
 

--- a/tests/test_conninfo.py
+++ b/tests/test_conninfo.py
@@ -39,6 +39,17 @@ def test_make_conninfo(conninfo, kwargs, exp):
     assert conninfo_to_dict(out) == conninfo_to_dict(exp)
 
 
+def test_make_conninfo_kwargs_only():
+    """Check that typing is correct when calling with kwargs only."""
+    kwargs: dict[str, str | int] = {"dbname": "foo", "port": 15432}
+    assert make_conninfo(**kwargs) == "dbname=foo port=15432"
+
+
+def test_make_conninfo_conninfo_postitional_only():
+    with pytest.raises(ProgrammingError, match="invalid connection option"):
+        make_conninfo(conninfo="")
+
+
 @pytest.mark.parametrize(
     "conninfo, kwargs",
     [


### PR DESCRIPTION
From commit c170851ab85f63935c0709ff0bfd7c1e7e9dd0c0, invoking `conninfo.make_conninfo(**kwargs)` (with no `conninfo` argument) produces a typing (Mypy) error:

    error: Argument 1 to "make_conninfo" has incompatible type "**dict[str, str | int]"; expected "str"  [arg-type]

(here with `kwargs: dict[str, str | int]`).

Not specifying `conninfo=""`, the default, is arguably a common pattern and the only workaround on user side is to change the call to `make_conninfo("", **kwargs)`, which is quite cumbersome.

By making `make_conninfo()'`s `conninfo` argument positional only, the typing error is resolved.

Added test serves as a non-regression, but mostly for typing.