### PR TITLE
test: mark more tests as 'timing'

### DIFF
--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -133,6 +133,7 @@ def test_notify_timeout(conn_cls, conn, dsn):
 
 
 @pytest.mark.slow
+@pytest.mark.timing
 def test_notify_timeout_0(conn_cls, conn, dsn):
     conn.set_autocommit(True)
     conn.execute("listen foo")
@@ -149,6 +150,7 @@ def test_notify_timeout_0(conn_cls, conn, dsn):
 
 
 @pytest.mark.slow
+@pytest.mark.timing
 def test_stop_after(conn_cls, conn, dsn):
     conn.set_autocommit(True)
     conn.execute("listen foo")
@@ -175,6 +177,7 @@ def test_stop_after(conn_cls, conn, dsn):
     assert ns[0].payload == "3"
 
 
+@pytest.mark.timing
 def test_stop_after_batch(conn_cls, conn, dsn):
     conn.set_autocommit(True)
     conn.execute("listen foo")
@@ -196,6 +199,7 @@ def test_stop_after_batch(conn_cls, conn, dsn):
 
 
 @pytest.mark.slow
+@pytest.mark.timing
 def test_notifies_blocking(conn):
 
     def listener():

--- a/tests/test_notify_async.py
+++ b/tests/test_notify_async.py
@@ -130,6 +130,7 @@ async def test_notify_timeout(aconn_cls, aconn, dsn):
 
 
 @pytest.mark.slow
+@pytest.mark.timing
 async def test_notify_timeout_0(aconn_cls, aconn, dsn):
     await aconn.set_autocommit(True)
     await aconn.execute("listen foo")
@@ -146,6 +147,7 @@ async def test_notify_timeout_0(aconn_cls, aconn, dsn):
 
 
 @pytest.mark.slow
+@pytest.mark.timing
 async def test_stop_after(aconn_cls, aconn, dsn):
     await aconn.set_autocommit(True)
     await aconn.execute("listen foo")
@@ -172,6 +174,7 @@ async def test_stop_after(aconn_cls, aconn, dsn):
     assert ns[0].payload == "3"
 
 
+@pytest.mark.timing
 async def test_stop_after_batch(aconn_cls, aconn, dsn):
     await aconn.set_autocommit(True)
     await aconn.execute("listen foo")
@@ -193,6 +196,7 @@ async def test_stop_after_batch(aconn_cls, aconn, dsn):
 
 
 @pytest.mark.slow
+@pytest.mark.timing
 async def test_notifies_blocking(aconn):
     async def listener():
         async for _ in aconn.notifies(timeout=1):


### PR DESCRIPTION
# Description 

When the machine is under load, any tests relying on a timeout or a sleep is subject to fail. Let's mark some of them as 'timing'.

I followed the recommandation in [a comment on a similar issue](https://github.com/psycopg/psycopg/issues/692#issuecomment-1838118714).

Context: these failing tests have been discovered when automatically testing a geos update on nixpkgs. The process rebuilds all geos dependencies, and put my laptop under a quite high load. That being said, I reproduce sometimes even when limiting the number of workers `nixpkgs-review` is able to use.

Thanks for the awesome lib!
