### PR TITLE
Add the possibility to set an environment variable to set macOS deployment target

### DIFF
--- a/.github/workflows/packages-bin.yml
+++ b/.github/workflows/packages-bin.yml
@@ -109,6 +109,7 @@ jobs:
 
     env:
       PG_VERSION: "17"
+      MACOSX_DEPLOYMENT_TARGET: "12.0"
 
     steps:
       - uses: actions/checkout@v4
@@ -146,7 +147,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: macos-14-${{matrix.pyver}}-macosx_${{matrix.arch}}
+          name: macos-12-${{matrix.pyver}}-macosx_${{matrix.arch}}
           path: ./wheelhouse/*.whl
 
 

--- a/psycopg_c/setup.py
+++ b/psycopg_c/setup.py
@@ -7,11 +7,20 @@ PostgreSQL database adapter for Python - optimisation package
 
 import os
 import sys
+import sysconfig
 import subprocess as sp
 
 from setuptools import setup, Extension
 from distutils.command.build_ext import build_ext
 from distutils import log
+
+# For macos to be the version we specify in the environment
+# this is a bit of a dirty hack, but it works
+if "MACOSX_DEPLOYMENT_TARGET" in os.environ:
+    sysconfig.get_config_vars()["MACOSX_DEPLOYMENT_TARGET"] = os.environ[
+        "MACOSX_DEPLOYMENT_TARGET"
+    ]
+
 
 # Move to the directory of setup.py: executing this file from another location
 # (e.g. from the project root) will fail


### PR DESCRIPTION
This adds the support to set MACOSX_DEPLOYMENT_TARGET before building the psycopg extension.
I am not saying it necessarily is pretty but it seems to be doing the job. I tried locally to run setup.py and had set that variable to different values and I could see that with otool -l, it would show the right minimum version.

BTW, this is related to https://github.com/psycopg/psycopg/issues/858