### PR TITLE
Add Typing for Pool Stats

### DIFF
--- a/psycopg_pool/psycopg_pool/base.py
+++ b/psycopg_pool/psycopg_pool/base.py
@@ -192,7 +192,7 @@ class BasePool:
         stats, self._stats = self._stats, Counter()
         rv = dict(stats)
         rv.update(self._get_measures())
-        return rv
+        return cast(_PoolStats, rv)
 
     def _get_measures(self) -> dict[str, int]:
         """

--- a/psycopg_pool/psycopg_pool/base.py
+++ b/psycopg_pool/psycopg_pool/base.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from time import monotonic
 from random import random
-from typing import Any, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING, TypedDict, cast
 
 from psycopg import errors as e
 
@@ -18,6 +18,23 @@ from ._compat import Counter, Deque
 if TYPE_CHECKING:
     from psycopg._connection_base import BaseConnection
 
+
+class _PoolStats(TypedDict):
+    pool_min: int
+    pool_max: int
+    pool_size: int
+    pool_available: int
+    requests_waiting: int
+    requests_num: int
+    requests_queued: int
+    requests_wait_ms: int
+    requests_errors: int
+    usage_ms: int
+    returns_bad: int
+    connections_num: int
+    connections_ms: int
+    connections_errors: int
+    connections_lost: int
 
 class BasePool:
     # Used to generate pool names
@@ -157,15 +174,15 @@ class BasePool:
             f"can't return connection to pool {self.name!r}, {msg}: {conn}"
         )
 
-    def get_stats(self) -> dict[str, int]:
+    def get_stats(self) -> _PoolStats:
         """
         Return current stats about the pool usage.
         """
         rv = dict(self._stats)
         rv.update(self._get_measures())
-        return rv
+        return cast(_PoolStats, rv)
 
-    def pop_stats(self) -> dict[str, int]:
+    def pop_stats(self) -> _PoolStats:
         """
         Return current stats about the pool usage.
 

--- a/psycopg_pool/psycopg_pool/base.py
+++ b/psycopg_pool/psycopg_pool/base.py
@@ -36,6 +36,7 @@ class _PoolStats(TypedDict):
     connections_errors: int
     connections_lost: int
 
+
 class BasePool:
     # Used to generate pool names
     _num_pool = 0


### PR DESCRIPTION
This PR adds improved typing for connection pooling stats - so that it's easier to work with the returned stats without having to look at the specific documentation.