### PR TITLE
build_macos_arm64.sh: Upgrade to Python 3.13 production release

### DIFF
--- a/tools/build/build_macos_arm64.sh
+++ b/tools/build/build_macos_arm64.sh
@@ -9,7 +9,7 @@
 
 set -euo pipefail
 
-python_versions="3.8.19 3.9.19 3.10.14 3.11.9 3.12.5 3.13.0rc1"
+python_versions="3.8.19 3.9.19 3.10.14 3.11.9 3.12.5 3.13.0"
 pg_version=17
 
 function log {


### PR DESCRIPTION
```diff
- python_versions="3.8.19 3.9.19 3.10.14 3.11.9 3.12.5 3.13.0rc1"
+ python_versions="3.8.19 3.9.19 3.10.14 3.11.9 3.12.5 3.13.0"
```