### PR TITLE
Extend `libpq` install instructions for cross-platform use

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,11 +17,12 @@ For further information about installation please check `the documentation`__.
 .. __: https://www.psycopg.org/psycopg3/docs/basic/install.html
 
 
-Hacking / Cross-platform use
+.. _Hacking:
+
+Hacking
 -------
 
-In order to work on the Psycopg source code, or to use cross-platform zipapps
-created with ``shiv`` that include Psycopg as a dependency, you must have the
+In order to work on the Psycopg source code, you must have the
 ``libpq`` PostgreSQL client library installed on the system. For instance, on
 Debian systems, you can obtain it by running::
 
@@ -82,3 +83,13 @@ Now hack away! You can run the tests using::
     psql -c 'create database psycopg_test'
     export PSYCOPG_TEST_DSN="dbname=psycopg_test"
     pytest
+
+
+Cross-compiling
+---------------
+
+To use cross-platform zipapps created with `shiv`__ that include Psycopg
+as a dependency you must also have ``libpq`` installed. See
+:ref:`the section above <Hacking>` for install instructions.
+
+.. __: https://github.com/linkedin/shiv

--- a/README.rst
+++ b/README.rst
@@ -17,16 +17,26 @@ For further information about installation please check `the documentation`__.
 .. __: https://www.psycopg.org/psycopg3/docs/basic/install.html
 
 
-Hacking
+Hacking / Cross-platform use
 -------
 
-In order to work on the Psycopg source code you need to have the ``libpq``
-PostgreSQL client library installed in the system. For instance, on Debian
-systems, you can obtain it by running::
+In order to work on the Psycopg source code, or to use cross-platform zipapps
+created with ``shiv`` that include Psycopg as a dependency, you must have the
+``libpq`` PostgreSQL client library installed on the system. For instance, on
+Debian systems, you can obtain it by running::
 
     sudo apt install libpq5
 
-After which you can clone this repository::
+On macOS, run::
+
+    brew install libpq
+
+On Windows you can use EnterpriseDB's `installers`__ to obtain ``libpq``
+which is included in the Command Line Tools.
+
+.. __: https://www.enterprisedb.com/downloads/postgres-postgresql-downloads
+
+You can then clone this repository to develop Psycopg::
 
     git clone https://github.com/psycopg/psycopg.git
     cd psycopg

--- a/README.rst
+++ b/README.rst
@@ -90,6 +90,6 @@ Cross-compiling
 
 To use cross-platform zipapps created with `shiv`__ that include Psycopg
 as a dependency you must also have ``libpq`` installed. See
-:ref:`the section above <Hacking>` for install instructions.
+`the section above <Hacking_>`_ for install instructions.
 
 .. __: https://github.com/linkedin/shiv


### PR DESCRIPTION
- Add macOS and Windows install instructions for `libpq`
    - This is also required e.g. to run cross-platform zipapps generated with https://github.com/linkedin/shiv that include Psycopg as a dependency, because I think that using any C code (e.g. `psycopg-binary`) is not a viable option in this case

If this is merged, could https://pypi.org/project/psycopg/#description be updated to include this README section? I would've helped me a lot because a zipapp that I generated with `shiv` wasn't working on another platform and I didn't know why.