### PR TITLE
Fix `Dumper.get_key` method return type

### DIFF
--- a/psycopg/psycopg/abc.py
+++ b/psycopg/psycopg/abc.py
@@ -30,7 +30,7 @@ Query: TypeAlias = Union[LiteralString, bytes, "sql.SQL", "sql.Composed"]
 Params: TypeAlias = Union[Sequence[Any], Mapping[str, Any]]
 ConnectionType = TypeVar("ConnectionType", bound="BaseConnection[Any]")
 PipelineCommand: TypeAlias = Callable[[], None]
-DumperKey: TypeAlias = Union[type, "tuple[DumperKey, ...]"]
+DumperKey: TypeAlias = Union[type, tuple["DumperKey", ...]]
 ConnParam: TypeAlias = Union[str, int, None]
 ConnDict: TypeAlias = dict[str, ConnParam]
 ConnMapping: TypeAlias = Mapping[str, ConnParam]


### PR DESCRIPTION
May fix the issue #921 .

Won't work in Py3.8, follows the #976 .

UPD: Should go after #982 .