### PR TITLE
Add pre-commit hooks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,20 +27,11 @@ jobs:
       - name: install packages to tests
         run: pip install ./psycopg[dev,test]
 
-      - name: Run black
-        run: black --check --diff .
-
-      - name: Run flake8
-        run: flake8
-
-      - name: Run mypy
-        run: mypy
+      - name: Lint codebase
+        run: pre-commit run -a --color=always
 
       - name: Check for sync/async inconsistencies
         run: ./tools/async_to_sync.py --check --all
-
-      - name: Check spelling
-        run: codespell
 
       - name: Install requirements to generate docs
         run: sudo apt-get install -y libgeos-dev

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,5 +22,5 @@ repos:
       - id: mypy
         name: mypy
         language: system
-        entry: mypy --pretty
+        entry: mypy --pretty --follow-imports=silent
         files: \.py[i]?$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+# See https://pre-commit.com for more information
+repos:
+  - repo: local
+    hooks:
+      - id: black
+        name: black
+        language: system
+        entry: black --check --diff
+        files: \.py[i]?$
+
+      - id: codespell
+        name: codespell
+        language: system
+        entry: codespell
+
+      - id: flake8
+        name: flake8
+        language: system
+        entry: flake8
+        files: \.py$
+
+      - id: mypy
+        name: mypy
+        language: system
+        entry: mypy --pretty
+        files: \.py[i]?$

--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,15 @@ Now hack away! You can run the tests using::
     export PSYCOPG_TEST_DSN="dbname=psycopg_test"
     pytest
 
+The library includes some pre-commit hooks to check that the code is valid
+according to the project coding convention. Please make sure to install them
+by running::
+
+    pre-commit install
+
+This will allow to check lint errors before submitting merge requests, which
+will save you time and frustrations.
+
 
 Cross-compiling
 ---------------

--- a/docs/lib/libpq_docs.py
+++ b/docs/lib/libpq_docs.py
@@ -1,3 +1,4 @@
+# mypy: ignore-errors
 """
 Sphinx plugin to link to the libpq documentation.
 

--- a/docs/lib/pg3_docs.py
+++ b/docs/lib/pg3_docs.py
@@ -1,3 +1,4 @@
+# mypy: ignore-errors
 """
 Customisation for docs generation.
 """

--- a/docs/lib/sql_role.py
+++ b/docs/lib/sql_role.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# mypy: ignore-errors
 """
     sql role
     ~~~~~~~~

--- a/psycopg/psycopg/_cmodule.py
+++ b/psycopg/psycopg/_cmodule.py
@@ -1,3 +1,4 @@
+# mypy: disable-error-code="import-not-found, attr-defined"
 """
 Simplify access to the _psycopg module
 """
@@ -6,19 +7,29 @@ Simplify access to the _psycopg module
 
 from __future__ import annotations
 
+from types import ModuleType
 from . import pq
 
 __version__: str | None = None
+_psycopg: ModuleType
 
 # Note: "c" must the first attempt so that mypy associates the variable the
 # right module interface. It will not result Optional, but hey.
 if pq.__impl__ == "c":
-    from psycopg_c import _psycopg as _psycopg
-    from psycopg_c import __version__ as __version__  # noqa: F401
+    import psycopg_c._psycopg
+
+    _psycopg = psycopg_c._psycopg
+    __version__ = psycopg_c.__version__
+
 elif pq.__impl__ == "binary":
-    from psycopg_binary import _psycopg as _psycopg  # type: ignore
-    from psycopg_binary import __version__ as __version__  # type: ignore  # noqa: F401
+    import psycopg_binary._psycopg
+
+    _psycopg = psycopg_binary._psycopg
+    __version__ = psycopg_binary.__version__
+
 elif pq.__impl__ == "python":
-    _psycopg = None  # type: ignore
+
+    _psycopg = None  # type: ignore[assignment]
+
 else:
     raise ImportError(f"can't find _psycopg optimised module in {pq.__impl__!r}")

--- a/psycopg/psycopg/_connection_base.py
+++ b/psycopg/psycopg/_connection_base.py
@@ -482,7 +482,7 @@ class BaseConnection(Generic[Row]):
         else:
             self.pgconn.send_query_params(command, None, result_format=result_format)
 
-        result = (yield from generators.execute(self.pgconn))[-1]
+        result: PGresult = (yield from generators.execute(self.pgconn))[-1]
         if result.status != COMMAND_OK and result.status != TUPLES_OK:
             if result.status == FATAL_ERROR:
                 raise e.error_from_result(result, encoding=self.pgconn._encoding)

--- a/psycopg/psycopg/_copy_base.py
+++ b/psycopg/psycopg/_copy_base.py
@@ -216,10 +216,11 @@ class TextFormatter(Formatter):
         self._encoding = encoding
 
     def parse_row(self, data: Buffer) -> tuple[Any, ...] | None:
+        rv: tuple[Any, ...] | None = None
         if data:
-            return parse_row_text(data, self.transformer)
-        else:
-            return None
+            rv = parse_row_text(data, self.transformer)
+
+        return rv
 
     def write(self, buffer: Buffer | str) -> Buffer:
         data = self._ensure_bytes(buffer)
@@ -260,6 +261,8 @@ class BinaryFormatter(Formatter):
         self._signature_sent = False
 
     def parse_row(self, data: Buffer) -> tuple[Any, ...] | None:
+        rv: tuple[Any, ...] | None = None
+
         if not self._signature_sent:
             if data[: len(_binary_signature)] != _binary_signature:
                 raise e.DataError(
@@ -268,10 +271,10 @@ class BinaryFormatter(Formatter):
             self._signature_sent = True
             data = data[len(_binary_signature) :]
 
-        elif data == _binary_trailer:
-            return None
+        if data != _binary_trailer:
+            rv = parse_row_binary(data, self.transformer)
 
-        return parse_row_binary(data, self.transformer)
+        return rv
 
     def write(self, buffer: Buffer | str) -> Buffer:
         data = self._ensure_bytes(buffer)

--- a/psycopg/psycopg/_cursor_base.py
+++ b/psycopg/psycopg/_cursor_base.py
@@ -334,7 +334,7 @@ class BaseCursor(Generic[ConnectionType, Row]):
         yield from send(self._pgconn)
 
     def _stream_fetchone_gen(self, first: bool) -> PQGen[PGresult | None]:
-        res = yield from fetch(self._pgconn)
+        res: PGresult | None = yield from fetch(self._pgconn)
         if res is None:
             return None
 

--- a/psycopg/psycopg/pq/_pq_ctypes.py
+++ b/psycopg/psycopg/pq/_pq_ctypes.py
@@ -58,11 +58,11 @@ Oid = c_uint
 
 
 class PGconn_struct(Structure):
-    _fields_: list[tuple[str, type]] = []
+    _fields_ = []
 
 
 class PGresult_struct(Structure):
-    _fields_: list[tuple[str, type]] = []
+    _fields_ = []
 
 
 class PQconninfoOption_struct(Structure):
@@ -86,11 +86,11 @@ class PGnotify_struct(Structure):
 
 
 class PGcancelConn_struct(Structure):
-    _fields_: list[tuple[str, type]] = []
+    _fields_ = []
 
 
 class PGcancel_struct(Structure):
-    _fields_: list[tuple[str, type]] = []
+    _fields_ = []
 
 
 class PGresAttDesc_struct(Structure):

--- a/psycopg/psycopg/pq/pq_ctypes.py
+++ b/psycopg/psycopg/pq/pq_ctypes.py
@@ -1,3 +1,5 @@
+# mypy: ignore-errors
+
 """
 libpq Python wrapper using ctypes bindings.
 

--- a/psycopg/pyproject.toml
+++ b/psycopg/pyproject.toml
@@ -84,6 +84,7 @@ dev = [
     "dnspython >= 2.1",
     "flake8 >= 4.0",
     "mypy >= 1.14",
+    "pre-commit >= 4.0.1",
     "types-setuptools >= 57.4",
     "wheel >= 0.37",
 ]

--- a/psycopg_c/build_backend/psycopg_build_ext.py
+++ b/psycopg_c/build_backend/psycopg_build_ext.py
@@ -49,7 +49,7 @@ class psycopg_build_ext(build_ext):
         # In the sdist there are not .pyx, only c, so we don't need Cython.
         # Otherwise Cython is a requirement and it is used to compile pyx to c.
         if os.path.exists("psycopg_c/_psycopg.pyx"):
-            from Cython.Build import cythonize  # type: ignore[import-untyped]
+            from Cython.Build import cythonize  # type: ignore
 
             for ext in self.distribution.ext_modules:
                 for i in range(len(ext.sources)):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,16 +37,21 @@ show_error_codes = true
 disable_bytearray_promotion = true
 disable_memoryview_promotion = true
 strict = true
+exclude = '''(?x)(
+    ^ build/
+    | docs/lib/.*\.py
+    | psycopg/build/
+    | psycopg_binary/build/
+    | psycopg_c/build/
+    | psycopg_pool/build/
+    | tools/build/pg_config_vcpkg_stub/build/
+)'''
 
 [[tool.mypy.overrides]]
 module = [
-    "shapely.*",
     "numpy.*",
+    "shapely.*",
 ]
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = "uvloop"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ exclude = '''(?x)(
 [[tool.mypy.overrides]]
 module = [
     "numpy.*",
+    "polib",
     "shapely.*",
 ]
 ignore_missing_imports = true

--- a/tests/scripts/pipeline-demo.py
+++ b/tests/scripts/pipeline-demo.py
@@ -190,10 +190,7 @@ def pipeline_demo_pq(rows_to_send: int, logger: logging.Logger) -> None:
     ):
         while results_queue:
             fetched = waiting.wait(
-                pipeline_communicate(
-                    pgconn,  # type: ignore[arg-type]
-                    commands,
-                ),
+                pipeline_communicate(pgconn, commands),
                 pgconn.socket,
             )
             assert not commands, commands
@@ -216,10 +213,7 @@ async def pipeline_demo_pq_async(rows_to_send: int, logger: logging.Logger) -> N
     ):
         while results_queue:
             fetched = await waiting.wait_async(
-                pipeline_communicate(
-                    pgconn,  # type: ignore[arg-type]
-                    commands,
-                ),
+                pipeline_communicate(pgconn, commands),
                 pgconn.socket,
             )
             assert not commands, commands

--- a/tests/test_adapt.py
+++ b/tests/test_adapt.py
@@ -427,10 +427,7 @@ def test_optimised_adapters():
         obj = getattr(_psycopg, n)
         if not isinstance(obj, type):
             continue
-        if not issubclass(
-            obj,
-            (_psycopg.CDumper, _psycopg.CLoader),  # type: ignore[attr-defined]
-        ):
+        if not issubclass(obj, (_psycopg.CDumper, _psycopg.CLoader)):
             continue
         c_adapters[n] = obj
 

--- a/tests/types/test_array.py
+++ b/tests/types/test_array.py
@@ -8,6 +8,7 @@ from decimal import Decimal
 import pytest
 
 import psycopg
+import psycopg.types.numeric
 from psycopg import pq
 from psycopg import sql
 from psycopg.adapt import PyFormat, Transformer, Dumper

--- a/tools/update_backer.py
+++ b/tools/update_backer.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-r"""Add or edit github users in the backers file
+# mypy: ignore-errors
+"""Add or edit github users in the backers file
 """
 
 import sys


### PR DESCRIPTION
This MR adds pre-commit hooks to run black, codespell, flake8, mypy. This allows contributors to find issues before submitting changes that will be rejected by the lint step.

The linters are executed in the dev virtualenv, instead of in a separate virualenv as pre-commit does. In my experience, a separate environment creates problems and makes the behaviour more obscure.

Note that it's not easy to add async-to-sync to the pre-commit hook in a generic way because it depends either on a specific system python version installed or on docker/podman.

Note that running:

- `mypy` (uses the files in `pyproject.toml`)
- `mypy .` (runs on every file)
- `mypy FILE1.py` (typically run by an editor)
- `mypy FILE1.py FILE2.py` (typically run by `pre-commit run -a`)

seem to yield different result. The current state is meta-stable and mypy seems to pass in every case. The amount of typing changes in MR is due to `mypy` working differently if running with a set of files.

Close #978.