### PR TITLE
Fix clobbered error on disconnect

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -23,6 +23,9 @@ Psycopg 3.2.4 (unreleased)
   is not running (:ticket:`#962`).
 - Make sure that the notifies callback is called during the use of the
   `~Connection.notifies()` generator (:ticket:`#972`).
+- Raise `~errors.IdleInTransactionSessionTimeout` instead of a generic
+  `OperationalError` upon hitting an idle-in-transaction timeout
+  (:ticket:`#988`).
 
 
 Current release

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -23,8 +23,9 @@ Psycopg 3.2.4 (unreleased)
   is not running (:ticket:`#962`).
 - Make sure that the notifies callback is called during the use of the
   `~Connection.notifies()` generator (:ticket:`#972`).
-- Raise `~errors.IdleInTransactionSessionTimeout` instead of a generic
-  `OperationalError` upon hitting an idle-in-transaction timeout
+- Raise the correct error returned by the database (such as `!AdminShutdown`
+  or `!IdleInTransactionSessionTimeout`) instead of a generic
+  `OperationalError` when a server error causes a client disconnection
   (:ticket:`#988`).
 
 

--- a/psycopg/psycopg/pq/_debug.py
+++ b/psycopg/psycopg/pq/_debug.py
@@ -93,12 +93,17 @@ def debugging(f: Func) -> Func:
             reprs.append(f"{k}={v!r}")
 
         logger.info("PGconn.%s(%s)", f.__name__, ", ".join(reprs))
-        rv = f(*args, **kwargs)
-        # Display the return value only if the function is declared to return
-        # something else than None.
-        ra = inspect.signature(f).return_annotation
-        if ra is not None or rv is not None:
-            logger.info("    <- %r", rv)
-        return rv
+        try:
+            rv = f(*args, **kwargs)
+        except Exception as ex:
+            logger.info("    <- %r", ex)
+            raise
+        else:
+            # Display the return value only if the function is declared to return
+            # something else than None.
+            ra = inspect.signature(f).return_annotation
+            if ra is not None or rv is not None:
+                logger.info("    <- %r", rv)
+            return rv
 
     return debugging_  # type: ignore

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -884,8 +884,20 @@ def test_right_exception_on_server_disconnect(conn):
 
 
 @pytest.mark.slow
+@pytest.mark.crdb("skip", reason="error result not returned")
 def test_right_exception_on_session_timeout(conn):
+    want_ex: type[psycopg.Error] = e.IdleInTransactionSessionTimeout
+    if sys.platform == "win32":
+        # No idea why this is needed and `test_right_exception_on_server_disconnect`
+        # works instead. Maybe the difference lies in the server we are testing
+        # with, not in the client.
+        want_ex = psycopg.OperationalError
+
     conn.execute("SET SESSION idle_in_transaction_session_timeout = 100")
     sleep(0.2)
-    with pytest.raises(e.IdleInTransactionSessionTimeout):
+    with pytest.raises(want_ex) as ex:
         conn.execute("SELECT * from pg_tables")
+
+    # This check is here to monitor if the behaviour on Window chamge.
+    # Rreceiving the same exception of other platform will be acceptable.
+    assert type(ex.value) is want_ex

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -877,8 +877,14 @@ def test_resolve_hostaddr_conn(conn_cls, monkeypatch, fake_resolve):
     assert conninfo_to_dict(got) == {"host": "foo.com", "hostaddr": "1.1.1.1"}
 
 
-@pytest.mark.slow
+@pytest.mark.crdb_skip("pg_terminate_backend")
 def test_right_exception_on_server_disconnect(conn):
+    with pytest.raises(e.AdminShutdown):
+        conn.execute("select pg_terminate_backend(%s)", [conn.pgconn.backend_pid])
+
+
+@pytest.mark.slow
+def test_right_exception_on_session_timeout(conn):
     conn.execute("SET SESSION idle_in_transaction_session_timeout = 100")
     sleep(0.2)
     with pytest.raises(e.IdleInTransactionSessionTimeout):


### PR DESCRIPTION
Avoid that an exception caused by a disconnection clobbers a server error already received as result. This happens when the server returns an error and immediately closes the connection, such as when hitting an idle-in-transaction timeout.

Close #988.