### PR TITLE
fix: win32 libpq missing error message should be more clear

### DIFF
--- a/psycopg/psycopg/pq/misc.py
+++ b/psycopg/psycopg/pq/misc.py
@@ -53,6 +53,8 @@ class PGresAttDesc(NamedTuple):
 def find_libpq_full_path() -> str | None:
     if sys.platform == "win32":
         libname = ctypes.util.find_library("libpq.dll")
+        if libname is None:
+            return None
         libname = str(Path(libname).resolve())
 
     elif sys.platform == "darwin":


### PR DESCRIPTION
If we can't find `libpq.dll` on windows, `libname` will be `None`, and psycopg will raise a very unreadable error about `None` missing `__fspath__` instead of expected `ImportError("libpq library not found")`

see here, for example: https://github.com/psycopg/psycopg/actions/runs/13475336675/job/37653819602?pr=1012