### PR TITLE
Fix how `status` is inferenced in `connection_summary`

### DIFF
--- a/psycopg/psycopg/pq/misc.py
+++ b/psycopg/psycopg/pq/misc.py
@@ -153,7 +153,7 @@ def connection_summary(pgconn: abc.PGconn) -> str:
     parts = []
     if pgconn.status == OK:
         # Put together the [STATUS]
-        status = TransactionStatus(pgconn.transaction_status).name
+        status: str = TransactionStatus(pgconn.transaction_status).name
         if pgconn.pipeline_status:
             status += f", pipeline={PipelineStatus(pgconn.pipeline_status).name}"
 


### PR DESCRIPTION
Hi! I am working on mypy in https://github.com/python/mypy/pull/18797

And I've noticed a small thing in your code. Ideally, `SomeEnum.Item.name` should be inferenced as `Literal[NAME_ONE, NAME_TWO, ...]`

But, since you later modify `status` (which is the name of a enum item), it should be explicitly annotated as `str`, not `Literal`.