### PR TITLE
Add support for server_cursor_factory to Connection.connect.

### DIFF
--- a/docs/api/connections.rst
+++ b/docs/api/connections.rst
@@ -42,6 +42,8 @@ The `!Connection` class
             :ref:`row-factories` for details.
         :param cursor_factory: Initial value for the `cursor_factory` attribute
             of the connection (new in Psycopg 3.1).
+        :param server_cursor_factory: Initial value for the `server_cursor_factory`
+            attribute of the connection (new in Psycopg 3.3).
         :param prepare_threshold: Initial value for the `prepare_threshold`
             attribute of the connection (new in Psycopg 3.1).
 
@@ -67,6 +69,9 @@ The `!Connection` class
 
         .. versionchanged:: 3.1
             added `!prepare_threshold` and `!cursor_factory` parameters.
+
+        .. versionchanged:: 3.3
+            added `!server_cursor_factory` parameter.
 
     .. automethod:: close
 

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -14,7 +14,7 @@ Python 3.3.0 (unreleased)
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Drop support for Python 3.8.
-
+- Add ``server_cursor_factory`` parameter to `Connection.connect`.
 
 Current release
 ---------------

--- a/psycopg/psycopg/connection.py
+++ b/psycopg/psycopg/connection.py
@@ -85,6 +85,7 @@ class Connection(BaseConnection[Row]):
         context: AdaptContext | None = None,
         row_factory: RowFactory[Row] | None = None,
         cursor_factory: type[Cursor[Row]] | None = None,
+        server_cursor_factory: type[ServerCursor[Row]] | None = None,
         **kwargs: ConnParam,
     ) -> Self:
         """
@@ -122,6 +123,8 @@ class Connection(BaseConnection[Row]):
             rv.row_factory = row_factory
         if cursor_factory:
             rv.cursor_factory = cursor_factory
+        if server_cursor_factory:
+            rv.server_cursor_factory = server_cursor_factory
         if context:
             rv._adapters = AdaptersMap(context.adapters)
         rv.prepare_threshold = prepare_threshold

--- a/psycopg/psycopg/connection_async.py
+++ b/psycopg/psycopg/connection_async.py
@@ -91,6 +91,7 @@ class AsyncConnection(BaseConnection[Row]):
         context: AdaptContext | None = None,
         row_factory: AsyncRowFactory[Row] | None = None,
         cursor_factory: type[AsyncCursor[Row]] | None = None,
+        server_cursor_factory: type[AsyncServerCursor[Row]] | None = None,
         **kwargs: ConnParam,
     ) -> Self:
         """
@@ -138,6 +139,8 @@ class AsyncConnection(BaseConnection[Row]):
             rv.row_factory = row_factory
         if cursor_factory:
             rv.cursor_factory = cursor_factory
+        if server_cursor_factory:
+            rv.server_cursor_factory = server_cursor_factory
         if context:
             rv._adapters = AdaptersMap(context.adapters)
         rv.prepare_threshold = prepare_threshold

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -625,6 +625,17 @@ def test_server_cursor_factory(conn):
         assert isinstance(cur, MyServerCursor)
 
 
+def test_server_cursor_factory_connect(conn_cls, dsn):
+
+    class MyCursor(psycopg.ServerCursor[psycopg.rows.Row]):
+        pass
+
+    with conn_cls.connect(dsn, server_cursor_factory=MyCursor) as conn:
+        assert conn.server_cursor_factory is MyCursor
+        with conn.cursor(name="n") as cur:
+            assert type(cur) is MyCursor
+
+
 @pytest.mark.parametrize("param", tx_params)
 def test_transaction_param_default(conn, param):
     assert getattr(conn, param.name) is None

--- a/tests/test_connection_async.py
+++ b/tests/test_connection_async.py
@@ -623,6 +623,16 @@ async def test_server_cursor_factory(aconn):
         assert isinstance(cur, MyServerCursor)
 
 
+async def test_server_cursor_factory_connect(aconn_cls, dsn):
+    class MyCursor(psycopg.AsyncServerCursor[psycopg.rows.Row]):
+        pass
+
+    async with await aconn_cls.connect(dsn, server_cursor_factory=MyCursor) as aconn:
+        assert aconn.server_cursor_factory is MyCursor
+        async with aconn.cursor(name="n") as cur:
+            assert type(cur) is MyCursor
+
+
 @pytest.mark.parametrize("param", tx_params)
 async def test_transaction_param_default(aconn, param):
     assert getattr(aconn, param.name) is None


### PR DESCRIPTION
I cannot run tests locally so I am using the CI, please excuse -- the changes are most likely to work :D

The error I get is:
```
Traceback (most recent call last):
  File "/home/florian/.local/share/pipx/venvs/pytest/lib64/python3.13/site-packages/_pytest/config/__init__.py", line 858, in import_plugin
    __import__(importspec)
    ~~~~~~~~~~^^^^^^^^^^^^
  File "/home/florian/.local/share/pipx/venvs/pytest/lib64/python3.13/site-packages/_pytest/assertion/rewrite.py", line 184, in exec_module
    exec(co, module.__dict__)
    ~~~~^^^^^^^^^^^^^^^^^^^^^
  File "/home/florian/sources/psycopg/tests/fix_db.py", line 13, in <module>
    from psycopg import pq, sql
ImportError: cannot import name 'pq' from 'psycopg' (unknown location)
```

No idea what is happening there :D Works fine in a shell but not with pytest, sigh.