### PR TITLE
Rename some news.rst section headers from python to psycopg

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -10,14 +10,14 @@
 Future releases
 ---------------
 
-Python 3.3.0 (unreleased)
-^^^^^^^^^^^^^^^^^^^^^^^^^
+Psycopg 3.3.0 (unreleased)
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Drop support for Python 3.8.
 
 
-Python 3.2.7 (unreleased)
-^^^^^^^^^^^^^^^^^^^^^^^^^
+Psycopg 3.2.7 (unreleased)
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Add SRID support to shapely dumpers/loaders (:ticket:`#1028`).
 
@@ -25,8 +25,8 @@ Python 3.2.7 (unreleased)
 Current release
 ---------------
 
-Python 3.2.6
-^^^^^^^^^^^^
+Psycopg 3.2.6
+^^^^^^^^^^^^^
 
 - Fix connection semantic when using ``target_session_attrs=prefer-standby``
   (:ticket:`#1021`).


### PR DESCRIPTION
I seemed like these section headers were supposed to be psycopg not python in the webpage about releases.