### PR TITLE
Add connection log info

### DIFF
--- a/psycopg/psycopg/generators.py
+++ b/psycopg/psycopg/generators.py
@@ -65,7 +65,14 @@ def _connect(conninfo: str, *, timeout: float = 0.0) -> PQGenConn[PGconn]:
     """
     deadline = monotonic() + timeout if timeout else 0.0
 
+    # To debug slowdown during connection:
+    #
+    #   $ PSYCOPG_IMPL=python python
+    #   >>> import logging
+    #   >>> logging.basicConfig(level=logging.DEBUG, format='%(asctime)s %(message)s')
+
     conn = pq.PGconn.connect_start(conninfo.encode())
+    logger.debug("connection started: %s", conn)
     while True:
         if conn.status == BAD:
             encoding = conninfo_encoding(conninfo)
@@ -74,6 +81,7 @@ def _connect(conninfo: str, *, timeout: float = 0.0) -> PQGenConn[PGconn]:
             )
 
         status = conn.connect_poll()
+        logger.debug("connection polled: %s", conn)
 
         if status == POLL_READING or status == POLL_WRITING:
             wait = WAIT_R if status == POLL_READING else WAIT_W

--- a/psycopg/psycopg/generators.py
+++ b/psycopg/psycopg/generators.py
@@ -56,7 +56,7 @@ READY_R = Ready.R
 READY_W = Ready.W
 READY_RW = Ready.RW
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("psycopg")
 
 
 def _connect(conninfo: str, *, timeout: float = 0.0) -> PQGenConn[PGconn]:
@@ -70,6 +70,7 @@ def _connect(conninfo: str, *, timeout: float = 0.0) -> PQGenConn[PGconn]:
     #   $ PSYCOPG_IMPL=python python
     #   >>> import logging
     #   >>> logging.basicConfig(level=logging.DEBUG, format='%(asctime)s %(message)s')
+    #   >>> logging.getLogger("psycopg").setLevel(logging.DEBUG)
 
     conn = pq.PGconn.connect_start(conninfo.encode())
     logger.debug("connection started: %s", conn)

--- a/psycopg/psycopg/pq/misc.py
+++ b/psycopg/psycopg/pq/misc.py
@@ -162,7 +162,12 @@ def connection_summary(pgconn: abc.PGconn) -> str:
         parts.append(("database", pgconn.db.decode()))
 
     else:
-        status = ConnStatus(pgconn.status).name
+        try:
+            status = ConnStatus(pgconn.status).name
+        except ValueError:
+            # It might happen if a new status on connection appears
+            # before upgrading the ConnStatus enum.
+            status = f"status={pgconn.status} (unkndown)"
 
     if sparts := " ".join(("%s=%s" % part for part in parts)):
         sparts = f" ({sparts})"

--- a/psycopg_c/psycopg_c/_psycopg/generators.pyx
+++ b/psycopg_c/psycopg_c/_psycopg/generators.pyx
@@ -42,6 +42,7 @@ def connect(conninfo: str, *, timeout: float = 0.0) -> PQGenConn[abc.PGconn]:
     if timeout:
         deadline = monotonic() + timeout
 
+    logger.debug("connection started: %s", conn)
     while True:
         if conn_status == libpq.CONNECTION_BAD:
             encoding = conninfo_encoding(conninfo)
@@ -52,6 +53,7 @@ def connect(conninfo: str, *, timeout: float = 0.0) -> PQGenConn[abc.PGconn]:
 
         with nogil:
             poll_status = libpq.PQconnectPoll(pgconn_ptr)
+        logger.debug("connection polled: %s", conn)
 
         if poll_status == libpq.PGRES_POLLING_READING \
         or poll_status == libpq.PGRES_POLLING_WRITING:


### PR DESCRIPTION
Adding persistent debug logging at connection time.

```
>>> import logging
>>> logging.basicConfig(level=logging.DEBUG, format='%(asctime)s %(levelname)s %(message)s')
>>> logging.getLogger("psycopg").setLevel(logging.DEBUG)

>>> import psycopg
>>> conn = psycopg.connect("host=localhost")
2025-04-29 16:18:58,808 DEBUG connection started: <psycopg.pq.pq_ctypes.PGconn [STARTED] at 0x775278568810>
2025-04-29 16:18:58,808 DEBUG connection polled: <psycopg.pq.pq_ctypes.PGconn [AWAITING_RESPONSE] at 0x775278568810>
2025-04-29 16:18:58,808 DEBUG connection polled: <psycopg.pq.pq_ctypes.PGconn [NEEDED] at 0x775278568810>
2025-04-29 16:18:58,810 DEBUG connection polled: <psycopg.pq.pq_ctypes.PGconn [NEEDED] at 0x775278568810>
2025-04-29 16:18:58,811 DEBUG connection polled: <psycopg.pq.pq_ctypes.PGconn [NEEDED] at 0x775278568810>
2025-04-29 16:18:58,816 DEBUG connection polled: <psycopg.pq.pq_ctypes.PGconn [AWAITING_RESPONSE] at 0x775278568810>
2025-04-29 16:18:58,816 DEBUG connection polled: <psycopg.pq.pq_ctypes.PGconn [AUTH_OK] at 0x775278568810>
2025-04-29 16:18:58,818 DEBUG connection polled: <psycopg.pq.pq_ctypes.PGconn [IDLE] (host=localhost database=piro) at 0x775278568810>
```
