### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/3rd-party-tests.yml
+++ b/.github/workflows/3rd-party-tests.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         python-version:
           - "3.13"
-          - "3.9"
+          - "3.10"
         sqlalchemy_label:
           # what version of sqlalchemy to download is defined in the "include" section below,
           # in the variable pip_sqlalchemy
@@ -138,7 +138,7 @@ jobs:
           # Test with min and max Python supported versions
           - django_label: lts
             impl: c
-            python-version: "3.9"
+            python-version: "3.10"
           - django_label: lts
             impl: python
             python-version: "3.13"

--- a/.github/workflows/packages-bin.yml
+++ b/.github/workflows/packages-bin.yml
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: [x86_64, i686, ppc64le, aarch64]
-        pyver: [cp39, cp310, cp311, cp312, cp313]
+        pyver: [cp310, cp311, cp312, cp313]
         platform: [manylinux, musllinux]
 
     steps:
@@ -126,7 +126,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: [x86_64, arm64]
-        pyver: [cp39, cp310, cp311, cp312, cp313]
+        pyver: [cp310, cp311, cp312, cp313]
 
     steps:
       - name: Checkout repos
@@ -180,7 +180,7 @@ jobs:
       matrix:
         # Might want to add win32, untested at the moment.
         arch: [win_amd64]
-        pyver: [cp39, cp310, cp311, cp312, cp313]
+        pyver: [cp310, cp311, cp312, cp313]
 
     defaults:
       run:

--- a/.github/workflows/packages-pool.yml
+++ b/.github/workflows/packages-pool.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.10
 
       - name: Install the build package
         run: pip install build

--- a/.github/workflows/packages-src.yml
+++ b/.github/workflows/packages-src.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.10
 
       - name: Install the build package
         run: pip install build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,20 +26,18 @@ jobs:
       matrix:
         include:
           # Test different combinations of Python, Postgres, libpq.
-          - {impl: python, python: "3.9", postgres: "postgres:17", libpq: oldest}
-          - {impl: python, python: "3.10", postgres: "postgres:16", libpq: master}
-          - {impl: python, python: "3.11", postgres: "postgres:15"}
-          - {impl: python, python: "3.12", postgres: "postgres:14", libpq: newest}
-          - {impl: python, python: "3.13", postgres: "postgres:12"}
+          - {impl: python, python: "3.10", postgres: "postgres:17"}
+          - {impl: python, python: "3.11", postgres: "postgres:16", libpq: master}
+          - {impl: python, python: "3.12", postgres: "postgres:15", libpq: newest}
+          - {impl: python, python: "3.13", postgres: "postgres:13"}
 
-          - {impl: c, python: "3.9", postgres: "postgres:12", libpq: master}
-          - {impl: c, python: "3.10", postgres: "postgres:13"}
+          - {impl: c, python: "3.10", postgres: "postgres:13", libpq: master}
           - {impl: c, python: "3.11", postgres: "postgres:15", libpq: oldest}
           - {impl: c, python: "3.12", postgres: "postgres:16", libpq: newest}
           - {impl: c, python: "3.13", postgres: "postgres:17"}
 
-          - {impl: python, python: "3.9", ext: gevent, postgres: "postgres:17"}
-          - {impl: python, python: "3.9", ext: dns, postgres: "postgres:14"}
+          - {impl: python, python: "3.10", ext: gevent, postgres: "postgres:17"}
+          - {impl: python, python: "3.10", ext: dns, postgres: "postgres:14"}
           - {impl: python, python: "3.12", ext: postgis, postgres: "postgis/postgis"}
           - {impl: python, python: "3.10", ext: numpy, postgres: "postgres:14"}
           - {impl: c, python: "3.11", ext: numpy, postgres: "postgres:15"}
@@ -47,15 +45,14 @@ jobs:
 
           # Test with minimum dependencies versions
           # WARNING: when bumping min version, make sure that the dependencies
-          # # in tests/constraints.txt are updated and that binary packages
+          # in tests/constraints.txt are updated and that binary packages
           # are available for such version.
-          - {impl: c, python: "3.9", ext: min, postgres: "postgres:15"}
+          - {impl: c, python: "3.10", ext: min, postgres: "postgres:15"}
 
           # Test memory alignment
           - {impl: c, python: "3.12", ext: align, postgres: "postgres:16"}
 
           # Test with PyPy.
-          - {impl: python, python: "pypy3.9", postgres: "postgres:13"}
           - {impl: python, python: "pypy3.10", postgres: "postgres:14"}
           - {impl: python, python: "pypy3.11", postgres: "postgres:15"}
 
@@ -219,8 +216,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {impl: python, python: "3.9"}
-          - {impl: c, python: "3.9"}
+          - {impl: python, python: "3.10"}
+          - {impl: c, python: "3.10"}
 
     env:
       PSYCOPG_IMPL: ${{ matrix.impl }}
@@ -278,12 +275,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {impl: python, python: "3.9"}
           - {impl: python, python: "3.10"}
           - {impl: python, python: "3.11"}
           - {impl: python, python: "3.12"}
           - {impl: python, python: "3.13"}
-          - {impl: c, python: "3.9"}
           - {impl: c, python: "3.10"}
           - {impl: c, python: "3.11"}
           - {impl: c, python: "3.12"}
@@ -378,7 +373,7 @@ jobs:
           #   | jq .tags | egrep 'latest-[^-]+-build' | sort
           - {impl: c, crdb: "master", python: "3.13"}
           - {impl: c, crdb: "v25.1", python: "3.13", libpq: newest}
-          - {impl: c, crdb: "v24.3", python: "3.9", libpq: newest}
+          - {impl: c, crdb: "v24.3", python: "3.10", libpq: newest}
           - {impl: python, crdb: "v23.2", python: "3.12"}
 
     env:

--- a/docs/basic/install.rst
+++ b/docs/basic/install.rst
@@ -22,14 +22,15 @@ Supported systems
 
 The Psycopg version documented here has *official and tested* support for:
 
-- Python: from version 3.9 to 3.13
+- Python: from version 3.10 to 3.13
 
-  - Python 3.8 supported before Psycopg 3.3
+  - Python 3.8 and 3.9 supported before Psycopg 3.3
   - Python 3.7 supported before Psycopg 3.2
   - Python 3.6 supported before Psycopg 3.1
 
-- PyPy: from version 3.9 to 3.11
+- PyPy: from version 3.10 to 3.11
 
+  - PyPy 3.9 supported before Psycopg 3.3
   - **Note:** Only the pure Python version is supported.
 
 - PostgreSQL: from version 10 to 17

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -13,7 +13,8 @@ Future releases
 Psycopg 3.3.0 (unreleased)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- Drop support for Python 3.8.
+- Drop support for Python 3.8 (:ticket:`#976`) and 3.9 (:ticket:`#1056`).
+
 
 Psycopg 3.2.8 (unreleased)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/psycopg/pyproject.toml
+++ b/psycopg/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -35,7 +34,7 @@ classifiers = [
     "Topic :: Software Development",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-requires-python = ">= 3.9"
+requires-python = ">= 3.10"
 dependencies = [
     "typing-extensions >= 4.6; python_version < '3.13'",
     "tzdata; sys_platform == 'win32'",

--- a/psycopg_c/pyproject.toml
+++ b/psycopg_c/pyproject.toml
@@ -5,8 +5,7 @@ requires = [
     #   `[tool.setuptools.ext-modules]` in `pyproject.toml` is still
     #   *experimental* and likely to change in future releases
     #
-    "setuptools == 75.6.0; python_version >= '3.9'",
-    "setuptools == 75.3.0; python_version < '3.9'",  # last supported version
+    "setuptools == 75.6.0",
     "wheel >= 0.37",
     "tomli >= 2.0.1; python_version < '3.11'",
 ]
@@ -35,7 +34,6 @@ classifiers = [
     "Operating System :: POSIX",
     "Programming Language :: Cython",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -46,7 +44,7 @@ classifiers = [
     "Topic :: Software Development",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-requires-python = ">= 3.9"
+requires-python = ">= 3.10"
 
 [[project.authors]]
 name = "Daniele Varrazzo"

--- a/psycopg_pool/pyproject.toml
+++ b/psycopg_pool/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -31,7 +30,7 @@ classifiers = [
     "Topic :: Software Development",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-requires-python = ">= 3.9"
+requires-python = ">= 3.10"
 dependencies = [
     "typing-extensions >= 4.6",
 ]

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -21,7 +21,7 @@ Test options
 
       $ pytest
       ========================= test session starts =========================
-      platform linux -- Python 3.9, pytest-6.0.2, py-1.10.0, pluggy-0.13.1
+      platform linux -- Python 3.10, pytest-6.0.2, py-1.10.0, pluggy-0.13.1
       Using --randomly-seed=2416596601
       libpq available: 130002
       libpq wrapper implementation: c
@@ -80,7 +80,7 @@ a set of env vars working for your setup::
 
     $ docker run -ti --rm --volume `pwd`:/src --workdir /src \
       -e PSYCOPG_TEST_DSN -e PGHOST=172.17.0.1 -e PGUSER=`whoami` \
-      python:3.9 bash
+      python:3.10 bash
 
     # pip install -e "./psycopg[test]" ./psycopg_pool ./psycopg_c
     # pytest

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -42,6 +42,6 @@ tomli == 2.0.1
 # When the minimum supported Python version is increased, these dependencies
 # might need to be updated.
 #
-# Grep help: the current minimum supported version is Python 3.9.
+# Grep help: the current minimum supported version is Python 3.10.
 shapely == 1.8.0
-numpy == 1.20.0
+numpy == 1.22.0

--- a/tests/fix_faker.py
+++ b/tests/fix_faker.py
@@ -399,11 +399,11 @@ class Faker:
         if random() <= 0.99:
             # These exponents should generate no inf/overflow
             if size == 64:
-                s = f"{choice('-+')}0.{randrange(1 << 53)}e{randrange(-310,309)}"
+                s = f"{choice('-+')}0.{randrange(1 << 53)}e{randrange(-310, 309)}"
             elif size == 32:
-                s = f"{choice('-+')}0.{randrange(1 << 22)}e{randrange(-37,38)}"
+                s = f"{choice('-+')}0.{randrange(1 << 22)}e{randrange(-37, 38)}"
             elif size == 16:
-                s = f"{choice('-+')}0.{randrange(1 << 10)}e{randrange(-3,4)}"
+                s = f"{choice('-+')}0.{randrange(1 << 10)}e{randrange(-3, 4)}"
             else:
                 assert False, size
             return spec(s)
@@ -497,7 +497,7 @@ class Faker:
     def make_JsonFloat(self, spec):
         # A float limited to what json accepts
         # this exponent should generate no inf
-        return float(f"{choice('-+')}0.{randrange(1 << 20)}e{randrange(-15,15)}")
+        return float(f"{choice('-+')}0.{randrange(1 << 20)}e{randrange(-15, 15)}")
 
     def schema_list(self, cls):
         while True:

--- a/tests/scripts/bench-411.py
+++ b/tests/scripts/bench-411.py
@@ -129,7 +129,7 @@ def time_log(message: str) -> Generator[None]:
     start = time.monotonic()
     yield
     end = time.monotonic()
-    logger.info(f"Run {message} in {end-start} s")
+    logger.info(f"Run {message} in {end - start} s")
 
 
 def run_psycopg2(psycopg2: Any, args: Namespace) -> None:


### PR DESCRIPTION
Remove usage of Python 3.9 in the following directories:
- .github/workflows
- docs
- psycopg
- psycopg_c
- psycopg_pool
- tests

See #1056