### PR TITLE
Clarify docstring for BaseCursor.statusmessage

### DIFF
--- a/docs/api/cursors.rst
+++ b/docs/api/cursors.rst
@@ -263,10 +263,9 @@ The `!Cursor` class
     .. attribute:: pgresult
         :type: Optional[psycopg.pq.PGresult]
 
-        The result returned by the last query and currently exposed by the
-        cursor, if available, else `!None`.
+        Representation of the current result set, if available, else `!None`.
 
-        It can be used to obtain low level info about the last query result
+        It can be used to obtain low level info about the current result set
         and to access to features not currently wrapped by Psycopg.
 
 

--- a/docs/api/cursors.rst
+++ b/docs/api/cursors.rst
@@ -244,7 +244,7 @@ The `!Cursor` class
             for record in cursor:
                 ...
 
-        syntax will iterate on the records in the current recordset.
+        syntax will iterate on the records in the current result set.
 
     .. autoattribute:: row_factory
 

--- a/docs/api/cursors.rst
+++ b/docs/api/cursors.rst
@@ -232,7 +232,7 @@ The `!Cursor` class
 
     .. rubric:: Methods to retrieve results
 
-    Fetch methods are only available if the last operation produced results,
+    Fetch methods are only available if the current result set contains results,
     e.g. a :sql:`SELECT` or a command with :sql:`RETURNING`. They will raise
     an exception if used with operations that don't return result, such as an
     :sql:`INSERT` with no :sql:`RETURNING` or an :sql:`ALTER TABLE`.

--- a/psycopg/psycopg/_cursor_base.py
+++ b/psycopg/psycopg/_cursor_base.py
@@ -164,7 +164,7 @@ class BaseCursor(Generic[ConnectionType, Row]):
     @property
     def statusmessage(self) -> str | None:
         """
-        The command status tag from the last SQL command executed.
+        The status tag of the first command in the last `execute` call.
 
         `!None` if the cursor doesn't have a result available.
         """

--- a/psycopg/psycopg/_cursor_base.py
+++ b/psycopg/psycopg/_cursor_base.py
@@ -164,7 +164,7 @@ class BaseCursor(Generic[ConnectionType, Row]):
     @property
     def statusmessage(self) -> str | None:
         """
-        The status tag of the first command in the last `execute` call.
+        The status tag of the first command in the last `execute()` call.
 
         `!None` if the cursor doesn't have a result available.
         """

--- a/psycopg/psycopg/_cursor_base.py
+++ b/psycopg/psycopg/_cursor_base.py
@@ -127,12 +127,15 @@ class BaseCursor(Generic[ConnectionType, Row]):
 
     @property
     def rowcount(self) -> int:
-        """Number of records affected by the precedent operation."""
+        """
+        Number of records affected by the operation that produced
+        the current result set.
+        """
         return self._rowcount
 
     @property
     def rownumber(self) -> int | None:
-        """Index of the next row to fetch in the current result.
+        """Index of the next row to fetch in the current result set.
 
         `!None` if there is no result to fetch.
         """
@@ -164,7 +167,7 @@ class BaseCursor(Generic[ConnectionType, Row]):
     @property
     def statusmessage(self) -> str | None:
         """
-        The status tag of the first command in the last `execute()` call.
+        The status tag of the current result set.
 
         `!None` if the cursor doesn't have a result available.
         """

--- a/psycopg/psycopg/cursor.py
+++ b/psycopg/psycopg/cursor.py
@@ -179,9 +179,9 @@ class Cursor(BaseCursor["Connection[Any]", Row]):
 
     def fetchone(self) -> Row | None:
         """
-        Return the next record from the current recordset.
+        Return the next record from the current result set.
 
-        Return `!None` the recordset is finished.
+        Return `!None` the result set is finished.
 
         :rtype: Row | None, with Row defined by `row_factory`
         """
@@ -193,7 +193,7 @@ class Cursor(BaseCursor["Connection[Any]", Row]):
 
     def fetchmany(self, size: int = 0) -> list[Row]:
         """
-        Return the next `!size` records from the current recordset.
+        Return the next `!size` records from the current result set.
 
         `!size` default to `!self.arraysize` if not specified.
 
@@ -213,7 +213,7 @@ class Cursor(BaseCursor["Connection[Any]", Row]):
 
     def fetchall(self) -> list[Row]:
         """
-        Return all the remaining records from the current recordset.
+        Return all the remaining records from the current result set.
 
         :rtype: Sequence[Row], with Row defined by `row_factory`
         """

--- a/psycopg/psycopg/cursor_async.py
+++ b/psycopg/psycopg/cursor_async.py
@@ -183,9 +183,9 @@ class AsyncCursor(BaseCursor["AsyncConnection[Any]", Row]):
 
     async def fetchone(self) -> Row | None:
         """
-        Return the next record from the current recordset.
+        Return the next record from the current result set.
 
-        Return `!None` the recordset is finished.
+        Return `!None` the result set is finished.
 
         :rtype: Row | None, with Row defined by `row_factory`
         """
@@ -197,7 +197,7 @@ class AsyncCursor(BaseCursor["AsyncConnection[Any]", Row]):
 
     async def fetchmany(self, size: int = 0) -> list[Row]:
         """
-        Return the next `!size` records from the current recordset.
+        Return the next `!size` records from the current result set.
 
         `!size` default to `!self.arraysize` if not specified.
 
@@ -217,7 +217,7 @@ class AsyncCursor(BaseCursor["AsyncConnection[Any]", Row]):
 
     async def fetchall(self) -> list[Row]:
         """
-        Return all the remaining records from the current recordset.
+        Return all the remaining records from the current result set.
 
         :rtype: Sequence[Row], with Row defined by `row_factory`
         """


### PR DESCRIPTION
The original definition can be confusing (at least it was for me) because if you run several commands separated by `;` in a single `cursor.execute`, the `cursor.statusmessage` attribute retains the tag from the first command. For example:

```py
query = """
CREATE TABLE table1 (val INT, val2 INT);
INSERT INTO table1 (val, val2) VALUES (10, 20);
"""
cursor.execute(query=query)
print("Execute 1:", cursor.statusmessage)

cursor.execute(query="DROP TABLE table1;")
print("Execute 2:", cursor.statusmessage)
```

This will result in:

```
Execute 1: CREATE TABLE
Execute 2: DROP TABLE
```

But according to the original description, it should be:

```
Execute 1: INSERT
Execute 2: DROP TABLE
```
