### PR TITLE
Improve error message trying to fetch from a no recordset result

### DIFF
--- a/tests/test_cursor_common.py
+++ b/tests/test_cursor_common.py
@@ -867,3 +867,21 @@ def test_message_0x33(conn):
 def test_typeinfo(conn):
     info = TypeInfo.fetch(conn, "jsonb")
     assert info is not None
+
+
+def test_error_no_result(conn):
+    cur = conn.cursor()
+    with pytest.raises(psycopg.ProgrammingError, match="no result available"):
+        cur.fetchone()
+
+    cur.execute("set timezone to utc")
+    with pytest.raises(
+        psycopg.ProgrammingError, match="last operation.*command status: SET"
+    ):
+        cur.fetchone()
+
+    cur.execute("")
+    with pytest.raises(
+        psycopg.ProgrammingError, match="last operation.*result status: EMPTY_QUERY"
+    ):
+        cur.fetchone()

--- a/tests/test_cursor_common_async.py
+++ b/tests/test_cursor_common_async.py
@@ -874,3 +874,21 @@ async def test_message_0x33(aconn):
 async def test_typeinfo(aconn):
     info = await TypeInfo.fetch(aconn, "jsonb")
     assert info is not None
+
+
+async def test_error_no_result(aconn):
+    cur = aconn.cursor()
+    with pytest.raises(psycopg.ProgrammingError, match="no result available"):
+        await cur.fetchone()
+
+    await cur.execute("set timezone to utc")
+    with pytest.raises(
+        psycopg.ProgrammingError, match="last operation.*command status: SET"
+    ):
+        await cur.fetchone()
+
+    await cur.execute("")
+    with pytest.raises(
+        psycopg.ProgrammingError, match="last operation.*result status: EMPTY_QUERY"
+    ):
+        await cur.fetchone()


### PR DESCRIPTION
Print the last command status with the error. For example:

    the last operation didn't produce records (command status: NOTIFY)

or, if the result doesn't even have a command status:

    the last operation didn't produce records (result status: EMPTY_QUERY)

Related to #1062.