### PR TITLE
Add support for `next(cursor)`

### DIFF
--- a/docs/api/cursors.rst
+++ b/docs/api/cursors.rst
@@ -239,12 +239,20 @@ The `!Cursor` class
 
     .. note::
 
-        Cursors are iterable objects, so just using the::
+        Cursors are iterators, so just using the::
 
             for record in cursor:
                 ...
 
         syntax will iterate on the records in the current result set.
+
+        .. versionchanged:: 3.3
+
+            it is now possible to use `!next(cursor)`. Previously, cursors were
+            iterables__, not iterators__.
+
+            .. __: https://docs.python.org/3/glossary.html#term-iterable
+            .. __: https://docs.python.org/3/glossary.html#term-iterator
 
     .. autoattribute:: row_factory
 

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -13,6 +13,8 @@ Future releases
 Psycopg 3.3.0 (unreleased)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- Cursors are now iterators, not only iterables. This means you can call
+  ``next(cur)`` to fetch the next row (:ticket:`#1064`).
 - Drop support for Python 3.8 (:ticket:`#976`) and 3.9 (:ticket:`#1056`).
 
 

--- a/psycopg/psycopg/cursor.py
+++ b/psycopg/psycopg/cursor.py
@@ -224,16 +224,13 @@ class Cursor(BaseCursor["Connection[Any]", Row]):
         self._pos = self.pgresult.ntuples
         return records
 
-    def __iter__(self) -> Iterator[Row]:
-        self._fetch_pipeline()
-        self._check_result_for_fetch()
+    def __iter__(self) -> Self:
+        return self
 
-        def load(pos: int) -> Row | None:
-            return self._tx.load_row(pos, self._make_row)
-
-        while (row := load(self._pos)) is not None:
-            self._pos += 1
-            yield row
+    def __next__(self) -> Row:
+        if (rec := self.fetchone()) is not None:
+            return rec
+        raise StopIteration("no more records to return")
 
     def scroll(self, value: int, mode: str = "relative") -> None:
         """

--- a/tests/test_cursor_common.py
+++ b/tests/test_cursor_common.py
@@ -162,6 +162,14 @@ def test_execute_sql(conn):
     assert cur.fetchone() == ("hello",)
 
 
+def test_next(conn):
+    cur = conn.cursor()
+    cur.execute("select 1")
+    assert next(cur) == (1,)
+    with pytest.raises(StopIteration):
+        next(cur)
+
+
 def test_query_parse_cache_size(conn):
     cur = conn.cursor()
     cls = type(cur)

--- a/tests/test_cursor_common_async.py
+++ b/tests/test_cursor_common_async.py
@@ -160,6 +160,14 @@ async def test_execute_sql(aconn):
     assert (await cur.fetchone()) == ("hello",)
 
 
+async def test_next(aconn):
+    cur = aconn.cursor()
+    await cur.execute("select 1")
+    assert await anext(cur) == (1,)
+    with pytest.raises(StopAsyncIteration):
+        await anext(cur)
+
+
 async def test_query_parse_cache_size(aconn):
     cur = aconn.cursor()
     cls = type(cur)

--- a/tests/test_cursor_server.py
+++ b/tests/test_cursor_server.py
@@ -431,6 +431,7 @@ def test_iter(conn):
 
 def test_iter_rownumber(conn):
     with conn.cursor("foo") as cur:
+        cur.itersize = 2
         cur.execute(ph(cur, "select generate_series(1, %s) as bar"), (3,))
         for row in cur:
             assert cur.rownumber == row[0]
@@ -448,6 +449,14 @@ def test_itersize(conn, commands):
         assert len(cmds) == 2
         for cmd in cmds:
             assert "fetch forward 2" in cmd.lower()
+
+
+def test_next(conn):
+    with conn.cursor() as cur:
+        cur.execute("select 1")
+        assert next(cur) == (1,)
+        with pytest.raises(StopIteration):
+            next(cur)
 
 
 def test_cant_scroll_by_default(conn):

--- a/tests/test_cursor_server_async.py
+++ b/tests/test_cursor_server_async.py
@@ -437,6 +437,7 @@ async def test_iter(aconn):
 
 async def test_iter_rownumber(aconn):
     async with aconn.cursor("foo") as cur:
+        cur.itersize = 2
         await cur.execute(ph(cur, "select generate_series(1, %s) as bar"), (3,))
         async for row in cur:
             assert cur.rownumber == row[0]
@@ -454,6 +455,14 @@ async def test_itersize(aconn, acommands):
         assert len(cmds) == 2
         for cmd in cmds:
             assert "fetch forward 2" in cmd.lower()
+
+
+async def test_next(aconn):
+    async with aconn.cursor() as cur:
+        await cur.execute("select 1")
+        assert await anext(cur) == (1,)
+        with pytest.raises(StopAsyncIteration):
+            await anext(cur)
 
 
 async def test_cant_scroll_by_default(aconn):

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -248,14 +248,17 @@ obj = {curs}
         ("many", "list[{type}]"),
         ("all", "list[{type}]"),
         ("iter", "{type}"),
+        ("next", "{type}"),
     ],
 )
 def test_fetch_type(conn_class, server_side, factory, type, fetch, typemod, mypy):
     if "Async" in conn_class:
         async_ = "async "
         await_ = "await "
+        next_ = "anext"
     else:
         async_ = await_ = ""
+        next_ = "next"
 
     curs = f"conn.cursor({factory})"
     if server_side:
@@ -273,6 +276,8 @@ curs = {curs}
         stmts += f"obj = {await_} curs.fetchall()"
     elif fetch == "iter":
         stmts += f"{async_}for obj in curs: pass"
+    elif fetch == "next":
+        stmts += f"obj = {await_} {next_}(curs)"
     else:
         pytest.fail(f"unexpected fetch: {fetch}")
 

--- a/tools/async_to_sync.py
+++ b/tools/async_to_sync.py
@@ -296,9 +296,11 @@ class RenameAsyncToSync(ast.NodeTransformer):  # type: ignore
         "AsyncServerCursor": "ServerCursor",
         "AsyncTransaction": "Transaction",
         "AsyncWriter": "Writer",
+        "StopAsyncIteration": "StopIteration",
         "__aenter__": "__enter__",
         "__aexit__": "__exit__",
         "__aiter__": "__iter__",
+        "__anext__": "__next__",
         "_copy_async": "_copy",
         "_server_cursor_async": "_server_cursor",
         "aclose": "close",
@@ -363,6 +365,7 @@ class RenameAsyncToSync(ast.NodeTransformer):  # type: ignore
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> ast.AST:
         self._fix_docstring(node.body)
+        node.name = self.names_map.get(node.name, node.name)
         if node.decorator_list:
             self._fix_decorator(node.decorator_list)
         self.generic_visit(node)


### PR DESCRIPTION
This MR transforms the cursor from an iterable (supporting `iter()`) to an iterator (supporting `iter()` and `next()`).

`next(cursor)` behaves like `cursor.fetchone()`, but its result is `Row`, not `Row | None`. That's because, if there is no row to fetch, it will raise `StopIteration`.

This makes simpler to write strictly typed code using the result when there is a 100% guarantee that a query will return a record (or will raise an exception), for example when fetching `count(*)`, which always returns a result even if the counted records are 0. The type checker is not aware of that, therefore you need to guard for None with an `if`, or an `assert`, or you need to do something horrible like `(rec,) = cur.fetchall()` in order to convince Mypy that `rec` will never be none.