### PR TITLE
Fix interval parsing with day/month/year and negative time

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -19,6 +19,8 @@ Psycopg 3.2.8 (unreleased)
   the local timezone (:ticket:`#1058`).
 - Fix `~Cursor.rownumber` after using `~AsyncServerCursor.scroll()` on
   `AsyncServerCursor` (:ticket:`#1066`).
+- Fix interval parsing with days or other parts and negative time in C module
+  (:ticket:`#1071`).
 
 
 Current release

--- a/tests/types/test_datetime.py
+++ b/tests/types/test_datetime.py
@@ -713,8 +713,16 @@ class TestInterval:
             ("60d", "2 month"),
             ("-90d", "-3 month"),
             ("186d", "6 mons 6 days"),
+            ("174d", "6 mons -6 days"),
             ("736d", "2 years 6 days"),
+            ("724d", "2 years -6 days"),
+            ("330d", "1 years -1 month"),
             ("83063d,81640s,447000m", "1993534:40:40.447"),
+            ("-1d,64800s", "41 days -990:00:00"),
+            ("0s", "10 days -240:00:00"),
+            ("20d", "10 days 240:00:00"),
+            ("0d", "-10 days 240:00:00"),
+            ("-20d", "-10 days -240:00:00"),
         ],
     )
     @pytest.mark.parametrize("fmt_out", pq.Format)


### PR DESCRIPTION
In the C code we were parsing the sign, then checking if day/month/years were specified, then parsing the time.

If day/month/year were present, we would have parsed them, applying the sign correctly, but then we wouldn't have missed the sign before the time.

Close #1071