### PR TITLE
Align timedelta seconds to PostgreSQL interval epoch

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -21,6 +21,8 @@ Psycopg 3.2.8 (unreleased)
   `AsyncServerCursor` (:ticket:`#1066`).
 - Fix interval parsing with days or other parts and negative time in C module
   (:ticket:`#1071`).
+- Make sure that intervals with days and months have the same epoch as
+  PostgreSQL (:ticket:`#1073`).
 
 
 Current release


### PR DESCRIPTION
While fixing #1071 I noticed that Postgres returns an approximation of leap years in intervals with specified months and years. More precisely:

- Postgres internal representation keeps separate (micros, days, months) (as can be seen in the binary adapter).

- Years are converted to months. When pressed for an equivalence with days, this shows with:
```
    =# select '1 year'::interval = '360 days'::interval;
     ?column?
    ----------
     t
```
- When converting the interval to seconds, Postgres adds 1/4 of a day every 12 months (rounding to an integer number of years towards 0).
```
    =# select extract('epoch' from '23 months'::interval) / 60. / 60 / 24 - (365 + 11 * 30);
          ?column?
    --------------------
     0.2500000000000000
    (1 row)

    =# select extract('epoch' from '24 months'::interval) / 60. / 60 / 24 - (2 * 365);
          ?column?
    --------------------
     0.5000000000000000
    (1 row)
```
This MR implements a conversion from Postgres interval to Python following the same rule. As a consequence, the `extract('epoch' from interval)` function now returns the same number of seconds returned by the `datetime.timedelta.total_seconds()` of the value returned. The difference though is that the hours shows in the seconds:
```python
    >>> conn.execute("select '1 year'::interval").fetchone()[0]
    datetime.timedelta(days=365, seconds=21600)

    >>> conn.execute("select '4 year'::interval").fetchone()[0].days, 365 * 4
    (1461, 1460)
```
This changeset only changes the Python implementation, not the C one.

Is it worth to make this change?