### PR TITLE
fix: show all messages associated with connection failures

### DIFF
--- a/psycopg/psycopg/connection.py
+++ b/psycopg/psycopg/connection.py
@@ -95,29 +95,43 @@ class Connection(BaseConnection[Row]):
         timeout = timeout_from_conninfo(params)
         rv = None
         attempts = conninfo_attempts(params)
+        connection_errors: list[tuple[e.Error, str]] = []
         for attempt in attempts:
             try:
                 conninfo = make_conninfo("", **attempt)
                 gen = cls._connect_gen(conninfo, timeout=timeout)
                 rv = waiting.wait_conn(gen, interval=_WAIT_INTERVAL)
             except e.Error as ex:
-                if len(attempts) > 1:
-                    logger.debug(
-                        "connection attempt failed: host: %r port: %r, hostaddr %r: %s",
-                        attempt.get("host"),
-                        attempt.get("port"),
-                        attempt.get("hostaddr"),
-                        str(ex),
-                    )
-                last_ex = ex
+                attempt_details = "host: {}, port: {}, hostaddr: {}".format(
+                    repr(attempt.get("host")),
+                    repr(attempt.get("port")),
+                    repr(attempt.get("hostaddr")),
+                )
+                connection_errors.append((ex, attempt_details))
             except e._NO_TRACEBACK as ex:
                 raise ex.with_traceback(None)
             else:
                 break
 
         if not rv:
-            assert last_ex
-            raise last_ex.with_traceback(None)
+            last_exception, _ = connection_errors[-1]
+            if len(connection_errors) == 1:
+                raise last_exception.with_traceback(None)
+            else:
+                formatted_attempts = []
+                for error, attempt_details in connection_errors:
+                    formatted_attempts.append(f"- {attempt_details}: {error}")
+                # Create a new exception with the same type as the last one, containing
+                # all attempt errors while preserving backward compatibility.
+                last_exception_type = type(last_exception)
+                message_lines = [
+                    f"{last_exception}",
+                    "Multiple connection attempts failed. All failures were:",
+                ]
+                message_lines.extend(formatted_attempts)
+                enhanced_message = "\n".join(message_lines)
+                enhanced_exception = last_exception_type(enhanced_message)
+                raise enhanced_exception.with_traceback(None)
 
         rv._autocommit = bool(autocommit)
         if row_factory:

--- a/tests/test_connection_async.py
+++ b/tests/test_connection_async.py
@@ -21,6 +21,8 @@ from ._test_connection import testctx  # noqa: F401  # fixture
 from ._test_connection import conninfo_params_timeout, tx_params, tx_params_isolation
 from ._test_connection import tx_values_map
 
+MULTI_FAILURE_MESSAGE = "Multiple connection attempts failed. All failures were:"
+
 
 async def test_connect(aconn_cls, dsn):
     conn = await aconn_cls.connect(dsn)
@@ -32,6 +34,44 @@ async def test_connect(aconn_cls, dsn):
 async def test_connect_bad(aconn_cls):
     with pytest.raises(psycopg.OperationalError):
         await aconn_cls.connect("dbname=nosuchdb")
+
+
+@pytest.mark.slow
+async def test_connect_error_single_host_original_message_preserved(aconn_cls, proxy):
+    with proxy.deaf_listen():
+        with pytest.raises(psycopg.OperationalError) as e:
+            await aconn_cls.connect(proxy.client_dsn, connect_timeout=2)
+
+    msg = str(e)
+    assert "connection timeout expired" in msg
+    assert MULTI_FAILURE_MESSAGE not in msg
+
+
+@pytest.mark.slow
+async def test_connect_error_multi_hosts_each_message_preserved(aconn_cls):
+    args = {
+        # IPv4 address blocks reserved for documentation.
+        # https://datatracker.ietf.org/doc/rfc5737/
+        "host": "192.0.2.1,198.51.100.1",
+        "port": "1234,5678",
+    }
+    with pytest.raises(psycopg.OperationalError) as e:
+        await aconn_cls.connect(**args, connect_timeout=2)
+
+    msg = str(e.value)
+    assert MULTI_FAILURE_MESSAGE in msg
+
+    host1, host2 = args["host"].split(",")
+    port1, port2 = args["port"].split(",")
+
+    msg_lines = msg.splitlines()
+
+    expected_host1 = f"host: '{host1}', port: '{port1}', hostaddr: '{host1}'"
+    expected_host2 = f"host: '{host2}', port: '{port2}', hostaddr: '{host2}'"
+    expected_error = "connection timeout expired"
+
+    assert any(expected_host1 in line and expected_error in line for line in msg_lines)
+    assert any(expected_host2 in line and expected_error in line for line in msg_lines)
 
 
 async def test_connect_str_subclass(aconn_cls, dsn):


### PR DESCRIPTION
This PR fixes #1069.

It updates the connection failure logic to preserve all error messages for the various attempts. Previously, only the message from the final attempt was shown the user, which created confusing situations as described in #1069.

Below is an example of the new message format:

```
psycopg.OperationalError: connection failed: connection to server at "1.2.3.4", port 5432 failed: FATAL:  unable to accept connection, access denied
DETAIL:  Session Id: ghijklmnp4yquucuzkab7hhka
Multiple connection attempts failed. All failures were:
- host: 'redacted.for.github', port: None, hostaddr: '2200:1f18:1f72:a404:61e8:e38a:6be2:fake': connection failed: connection to server at "2200:1f18:1f72:a404:61e8:e38a:6be2:fake", port 5432 failed: FATAL:  unable to accept connection, access denied
DETAIL:  Session Id: abcdefloavxpiw6oweks7x7fcu
- host: 'redacted.for.github', port: None, hostaddr: '1.2.3.4': connection failed: connection to server at "1.2.3.4", port 5432 failed: FATAL:  unable to accept connection, access denied
DETAIL:  Session Id: ghijklmnp4yquucuzkab7hhka
```

I made a few decisions which could be discussed:
- I decided to keep the `-` pushed to the left rather than indent it, as some messages contain multiple lines. We shouldn't need to worry about artificially indenting multi-line messages, and this is made more complicated by the fact that on my terminal the first line of these messages is long enough to wrap itself. I think it's easier to see the delineation if the `-` is pushed up against the left rather than indented in these cases of multi-line or wrapping messages.
- I replaced the debug message and included the connection information in the message itself. As a user that was trying to use these messages to diagnose a problem in #1069, I think having that information is super valuable for diagnostic purposes. Though the example I posted above includes duplicate information, not all messages do and it depends on the type of failure. A timeout exception for example doesn't show any information about which host/port it was trying to connect to. If you end up with different exceptions for different hosts, it's extremely valuable to know which host produced which error.
