### PR TITLE
Collect notifies only if no handler is registered

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -7,6 +7,11 @@
 ``psycopg`` release notes
 =========================
 
+Future releases
+---------------
+
+.. _psycopg-3.2.10:
+
 Psycopg 3.2.10 (unreleased)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -17,6 +22,24 @@ Psycopg 3.2.10 (unreleased)
   (:ticket:`#1108`).
 - Fix coordination of `~Cursor.executemany()` with other concurrent operations
   on other cursors (:ticket:`#1130`).
+- Fix leak receiving notifications if the `~Connection.notifies()` generator
+  is not called (:ticket:`#1091`).
+
+  .. warning::
+
+    This bugfix required the introduction of a change in :ref:`notifies
+    reception <async-notify>` behaviour.
+
+    If a notification is received when a handler is registered via
+    `~Connection.add_notify_handler()` and the `~Connection.notifies()`
+    generator is not running the notification will not be yielded by the
+    generator. This is a behaviour similar to before `Psycopg 3.2.4`_, but
+    *notifications are not lost if no handler is registered*.
+
+    Using both the generator and handlers to receive notifications on the same
+    connection is therefore deprecated and will now generate a runtime
+    warning.
+
 - Add support for Python 3.14 (:ticket:`#1053`).
 - Fix `psycopg_binary.__version__`.
 - Raise a warning if a GSSAPI connection is obtained using the
@@ -83,11 +106,20 @@ Psycopg 3.2.5
 - 3x faster UUID loading thanks to C implementation (:tickets:`#447, #998`).
 
 
+.. _psycopg-3.2.4:
+
 Psycopg 3.2.4
 ^^^^^^^^^^^^^
 
 - Don't lose notifies received whilst the `~Connection.notifies()` iterator
   is not running (:ticket:`#962`).
+
+  .. warning::
+
+    If you were using notifications to bridge the time between issuing a LISTEN
+    on a channel and starting the iterator you might receive duplicate
+    notifications.
+
 - Make sure that the notifies callback is called during the use of the
   `~Connection.notifies()` generator (:ticket:`#972`).
 - Raise the correct error returned by the database (such as `!AdminShutdown`

--- a/psycopg/psycopg/_connection_base.py
+++ b/psycopg/psycopg/_connection_base.py
@@ -376,12 +376,13 @@ class BaseConnection(Generic[Row]):
         enc = self.pgconn._encoding
         n = Notify(pgn.relname.decode(enc), pgn.extra.decode(enc), pgn.be_pid)
 
-        # `_notifies_backlog` is None if the `notifies()` generator is running
-        if (d := self._notifies_backlog) is not None:
-            d.append(n)
-
-        for cb in self._notify_handlers:
-            cb(n)
+        if self._notify_handlers:
+            for cb in self._notify_handlers:
+                cb(n)
+        else:
+            # `_notifies_backlog` is None if the `notifies()` generator is running
+            if (d := self._notifies_backlog) is not None:
+                d.append(n)
 
     @property
     def prepare_threshold(self) -> int | None:

--- a/psycopg/psycopg/connection.py
+++ b/psycopg/psycopg/connection.py
@@ -354,6 +354,12 @@ class Connection(BaseConnection[Row]):
 
         nreceived = 0
 
+        if self._notify_handlers:
+            warnings.warn(
+                "using 'notifies()' together with notifies handlers on the same connection is not reliable. Please use only one of thees methods",
+                RuntimeWarning,
+            )
+
         with self.lock:
             enc = self.pgconn._encoding
 

--- a/psycopg/psycopg/connection_async.py
+++ b/psycopg/psycopg/connection_async.py
@@ -383,6 +383,14 @@ class AsyncConnection(BaseConnection[Row]):
 
         nreceived = 0
 
+        if self._notify_handlers:
+            warnings.warn(
+                "using 'notifies()' together with notifies handlers on the"
+                " same connection is not reliable."
+                " Please use only one of thees methods",
+                RuntimeWarning,
+            )
+
         async with self.lock:
             enc = self.pgconn._encoding
 

--- a/tests/test_notify_async.py
+++ b/tests/test_notify_async.py
@@ -219,7 +219,13 @@ async def test_notifies_blocking(aconn):
 
 
 @pytest.mark.slow
-async def test_generator_and_handler(aconn, aconn_cls, dsn):
+async def test_generator_and_handler(aconn, aconn_cls, dsn, recwarn):
+    # NOTE: we don't support generator+handlers anymore. So, if in the future
+    # this behaviour will change, we will not consider it a regression. However
+    # we will want to keep the warning check.
+
+    recwarn.clear()
+
     await aconn.set_autocommit(True)
     await aconn.execute("listen foo")
 
@@ -251,6 +257,9 @@ async def test_generator_and_handler(aconn, aconn_cls, dsn):
 
     assert n1
     assert n2
+
+    msg = str(recwarn.pop(RuntimeWarning).message)
+    assert "notifies()" in msg
 
 
 @pytest.mark.parametrize("query_between", [True, False])
@@ -286,25 +295,41 @@ async def test_notify_query_notify(aconn_cls, dsn, sleep_on, listen_by):
                 await aconn.execute("select pg_notify('counter', %s)", (str(i),))
                 await asleep(0.2)
 
-    async def listener():
-        async with await aconn_cls.connect(dsn, autocommit=True) as aconn:
-            if listen_by == "callback":
+    async def nap(aconn):
+        if sleep_on == "server":
+            await aconn.execute("select pg_sleep(0.2)")
+        else:
+            assert sleep_on == "client"
+            await asleep(0.2)
+
+    if listen_by == "callback":
+
+        async def listener():
+            async with await aconn_cls.connect(dsn, autocommit=True) as aconn:
                 aconn.add_notify_handler(lambda n: notifies.append(int(n.payload)))
 
-            await aconn.execute("listen counter")
-            e.set()
-            async for n in aconn.notifies(timeout=0.2):
-                if listen_by == "generator":
+                await aconn.execute("listen counter")
+                e.set()
+
+                await nap(aconn)
+                await aconn.execute("")
+                await nap(aconn)
+                await aconn.execute("")
+                await nap(aconn)
+                await aconn.execute("")
+
+    else:
+
+        async def listener():
+            async with await aconn_cls.connect(dsn, autocommit=True) as aconn:
+                await aconn.execute("listen counter")
+                e.set()
+                async for n in aconn.notifies(timeout=0.2):
                     notifies.append(int(n.payload))
 
-            if sleep_on == "server":
-                await aconn.execute("select pg_sleep(0.2)")
-            else:
-                assert sleep_on == "client"
-                await asleep(0.2)
+                await nap(aconn)
 
-            async for n in aconn.notifies(timeout=0.2):
-                if listen_by == "generator":
+                async for n in aconn.notifies(timeout=0.2):
                     notifies.append(int(n.payload))
 
     workers.append(spawn(listener))


### PR DESCRIPTION
Opening this MR to look into this way to fix the issue is reasonable and if it doesn't cause problems somewhere else.

If someone is listening to notifications by using an handler, the notifies backlog would fill without ever being emptied: see #1091.

This change has the risk of breaking something if someone is relying on notifies being received both via callback and via generator, but I don't know how to satisfy it without creating a leak to users who don't use the generator.

The MR changes the tests because `test_notify_query_notify` doesn't pass anymore. The test is now split in two testing notifies and generator separately.