### PR TITLE
Avoid a TypeError shadowing CancelledError on task cancellation

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -10,6 +10,8 @@
 Psycopg 3.2.10 (unreleased)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- Fix `!TypeError` shadowing `~asyncio.CancelledError` upon task cancellation
+  during pipeline execution (:ticket:`#1005`).
 - Fix memory leak when lambda/local functions are used as argument for
   `~.psycopg.types.json.set_json_dumps()`, `~.psycopg.types.json.set_json_loads()`
   (:ticket:`#1108`).


### PR DESCRIPTION
Repro kindly provided by @zzzeek and @coby-astsec in MagicStack/asyncpg#1265 and converted for our test suite. Thank you very much!

Fix #1005.