### PR TITLE
Fix RecursionError: maximum recursion depth exceeded when close_return=True

### DIFF
--- a/psycopg_pool/psycopg_pool/pool.py
+++ b/psycopg_pool/psycopg_pool/pool.py
@@ -449,6 +449,7 @@ class ConnectionPool(Generic[CT], BasePool):
 
         # Close the connections that were still in the pool
         for conn in connections:
+            conn._pool = None
             conn.close()
 
         # Signal to eventual clients in the queue that business is closed.
@@ -521,6 +522,7 @@ class ConnectionPool(Generic[CT], BasePool):
             # Check for expired connections
             if conn._expire_at <= monotonic():
                 logger.info("discarding expired connection %s", conn)
+                conn._pool = None
                 conn.close()
                 self.run_task(AddConnection(self))
                 continue
@@ -700,6 +702,7 @@ class ConnectionPool(Generic[CT], BasePool):
         if conn._expire_at <= monotonic():
             self.run_task(AddConnection(self))
             logger.info("discarding expired connection")
+            conn._pool = None
             conn.close()
             return
 
@@ -773,10 +776,12 @@ class ConnectionPool(Generic[CT], BasePool):
                     ex,
                     conn,
                 )
+                conn._pool = None
                 conn.close()
         elif status == TransactionStatus.ACTIVE:
             # Connection returned during an operation. Bad... just close it.
             logger.warning("closing returned connection: %s", conn)
+            conn._pool = None
             conn.close()
 
         if self._reset:
@@ -789,6 +794,7 @@ class ConnectionPool(Generic[CT], BasePool):
                     )
             except Exception as ex:
                 logger.warning(f"error resetting connection: {ex}")
+                conn._pool = None
                 conn.close()
 
     def _shrink_pool(self) -> None:
@@ -813,6 +819,7 @@ class ConnectionPool(Generic[CT], BasePool):
                 nconns_min,
                 self.max_idle,
             )
+            to_close._pool = None
             to_close.close()
 
     def _get_measures(self) -> dict[str, int]:
@@ -939,7 +946,6 @@ class StopWorker(MaintenanceTask):
 
 
 class AddConnection(MaintenanceTask):
-
     def __init__(
         self,
         pool: ConnectionPool[Any],

--- a/psycopg_pool/psycopg_pool/pool_async.py
+++ b/psycopg_pool/psycopg_pool/pool_async.py
@@ -488,6 +488,7 @@ class AsyncConnectionPool(Generic[ACT], BasePool):
 
         # Close the connections that were still in the pool
         for conn in connections:
+            conn._pool = None
             await conn.close()
 
         # Signal to eventual clients in the queue that business is closed.
@@ -560,6 +561,7 @@ class AsyncConnectionPool(Generic[ACT], BasePool):
             # Check for expired connections
             if conn._expire_at <= monotonic():
                 logger.info("discarding expired connection %s", conn)
+                conn._pool = None
                 await conn.close()
                 self.run_task(AddConnection(self))
                 continue
@@ -752,6 +754,7 @@ class AsyncConnectionPool(Generic[ACT], BasePool):
         if conn._expire_at <= monotonic():
             self.run_task(AddConnection(self))
             logger.info("discarding expired connection")
+            conn._pool = None
             await conn.close()
             return
 
@@ -782,7 +785,6 @@ class AsyncConnectionPool(Generic[ACT], BasePool):
         # Critical section: if there is a client waiting give it the connection
         # otherwise put it back into the pool.
         async with self._lock:
-
             # Check if the pool was closed by the time we arrived here. It is
             # unlikely but it doesn't seem impossible, if the worker was adding
             # this connection while the main process is closing the pool.
@@ -827,11 +829,13 @@ class AsyncConnectionPool(Generic[ACT], BasePool):
                     ex,
                     conn,
                 )
+                conn._pool = None
                 await conn.close()
 
         elif status == TransactionStatus.ACTIVE:
             # Connection returned during an operation. Bad... just close it.
             logger.warning("closing returned connection: %s", conn)
+            conn._pool = None
             await conn.close()
 
         if self._reset:
@@ -845,6 +849,7 @@ class AsyncConnectionPool(Generic[ACT], BasePool):
                     )
             except Exception as ex:
                 logger.warning(f"error resetting connection: {ex}")
+                conn._pool = None
                 await conn.close()
 
     async def _shrink_pool(self) -> None:
@@ -870,6 +875,7 @@ class AsyncConnectionPool(Generic[ACT], BasePool):
                 nconns_min,
                 self.max_idle,
             )
+            to_close._pool = None
             await to_close.close()
 
     def _get_measures(self) -> dict[str, int]:

--- a/tests/pool/test_pool.py
+++ b/tests/pool/test_pool.py
@@ -1122,16 +1122,20 @@ def test_close_returns_no_loop(dsn):
         min_size=1,
         max_size=1,
         close_returns=True,
-        max_lifetime=0.1,
+        max_lifetime=0.05,
         open=False,
     )
     p.open()
     conn = p.getconn()
+    sleep(0.1)
     assert len(p._pool) == 0
-    sleep(0.2)  # wait for the connection to expire
+    sleep(0.1)  # wait for the connection to expire
     conn.close()
+    sleep(0.1)
     assert len(p._pool) == 1
     conn = p.getconn()
+    sleep(0.1)
     assert len(p._pool) == 0
     conn.close()
+    sleep(0.1)
     assert len(p._pool) == 1

--- a/tests/pool/test_pool.py
+++ b/tests/pool/test_pool.py
@@ -52,7 +52,6 @@ class MyRow(dict[str, Any]):
 
 
 def test_generic_connection_type(dsn):
-
     def configure(conn: psycopg.Connection[Any]) -> None:
         set_autocommit(conn, True)
 
@@ -85,12 +84,10 @@ def test_generic_connection_type(dsn):
 
 
 def test_non_generic_connection_type(dsn):
-
     def configure(conn: psycopg.Connection[Any]) -> None:
         set_autocommit(conn, True)
 
     class MyConnection(psycopg.Connection[MyRow]):
-
         def __init__(self, *args: Any, **kwargs: Any):
             kwargs["row_factory"] = class_row(MyRow)
             super().__init__(*args, **kwargs)
@@ -647,7 +644,6 @@ def test_uniform_use(dsn):
 @pytest.mark.slow
 @pytest.mark.timing
 def test_resize(dsn):
-
     def sampler():
         sleep(0.05)  # ensure sampling happens after shrink check
         while True:
@@ -1024,7 +1020,6 @@ def test_check_backoff(dsn, caplog, monkeypatch):
 @pytest.mark.slow
 @pytest.mark.parametrize("status", ["ERROR", "INTRANS"])
 def test_check_returns_an_ok_connection(dsn, status):
-
     def check(conn):
         if status == "ERROR":
             conn.execute("wat")
@@ -1055,7 +1050,6 @@ def test_override_close(dsn):
     # https://github.com/psycopg/psycopg/issues/1046
 
     class MyConnection(psycopg.Connection[Row]):
-
         def close(self) -> None:
             if pool := getattr(self, "_pool", None):
                 # Connection currently checked out from the pool.
@@ -1095,7 +1089,6 @@ def test_close_returns(dsn):
 
 @pytest.mark.skipif(PSYCOPG_VERSION < (3, 3), reason="psycopg >= 3.3 behaviour")
 def test_close_returns_custom_class(dsn):
-
     class MyConnection(psycopg.Connection):
         pass
 
@@ -1115,9 +1108,30 @@ def test_close_returns_custom_class(dsn):
 
 @pytest.mark.skipif(PSYCOPG_VERSION >= (3, 3), reason="psycopg < 3.3 behaviour")
 def test_close_returns_custom_class_old(dsn):
-
     class MyConnection(psycopg.Connection):
         pass
 
     with pytest.raises(TypeError, match="close_returns=True"):
         pool.ConnectionPool(dsn, connection_class=MyConnection, close_returns=True)
+
+
+@pytest.mark.skipif(PSYCOPG_VERSION < (3, 3), reason="psycopg >= 3.3 behaviour")
+def test_close_returns_no_loop(dsn):
+    p = pool.ConnectionPool(
+        dsn,
+        min_size=1,
+        max_size=1,
+        close_returns=True,
+        max_lifetime=0.1,
+        open=False,
+    )
+    p.open()
+    conn = p.getconn()
+    assert len(p._pool) == 0
+    sleep(0.2)  # wait for the connection to expire
+    conn.close()
+    assert len(p._pool) == 1
+    conn = p.getconn()
+    assert len(p._pool) == 0
+    conn.close()
+    assert len(p._pool) == 1

--- a/tests/pool/test_pool_async.py
+++ b/tests/pool/test_pool_async.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import weakref
 from time import time
@@ -1082,7 +1083,6 @@ async def test_override_close(dsn):
 
 
 async def test_close_returns(dsn):
-
     async with pool.AsyncConnectionPool(dsn, min_size=2, close_returns=True) as p:
         await p.wait()
         assert len(p._pool) == 2
@@ -1122,3 +1122,25 @@ async def test_close_returns_custom_class_old(dsn):
 
     with pytest.raises(TypeError, match="close_returns=True"):
         pool.AsyncConnectionPool(dsn, connection_class=MyConnection, close_returns=True)
+
+
+@pytest.mark.skipif(PSYCOPG_VERSION < (3, 3), reason="psycopg >= 3.3 behaviour")
+async def test_close_returns_no_loop(dsn):
+    p = pool.AsyncConnectionPool(
+        dsn,
+        min_size=1,
+        max_size=1,
+        close_returns=True,
+        max_lifetime=0.1,
+        open=False,
+    )
+    await p.open()
+    conn = await p.getconn()
+    assert len(p._pool) == 0
+    await asyncio.sleep(0.2)  # wait for the connection to expire
+    await conn.close()
+    assert len(p._pool) == 1
+    conn = await p.getconn()
+    assert len(p._pool) == 0
+    await conn.close()
+    assert len(p._pool) == 1

--- a/tests/pool/test_pool_async.py
+++ b/tests/pool/test_pool_async.py
@@ -1131,16 +1131,20 @@ async def test_close_returns_no_loop(dsn):
         min_size=1,
         max_size=1,
         close_returns=True,
-        max_lifetime=0.1,
+        max_lifetime=0.05,
         open=False,
     )
     await p.open()
     conn = await p.getconn()
+    await asyncio.sleep(0.1)
     assert len(p._pool) == 0
-    await asyncio.sleep(0.2)  # wait for the connection to expire
+    await asyncio.sleep(0.1)  # wait for the connection to expire
     await conn.close()
+    await asyncio.sleep(0.1)
     assert len(p._pool) == 1
     conn = await p.getconn()
+    await asyncio.sleep(0.1)
     assert len(p._pool) == 0
     await conn.close()
+    await asyncio.sleep(0.1)
     assert len(p._pool) == 1


### PR DESCRIPTION
I'm sorry, but I don't know how to use the built-in connection injection test script and this file was not submitted
And This test 
#1124 #1067
```python
import asyncio

import pytest
from psycopg_pool import pool,pool_async
from time import sleep
def test_close_returns_no_loop():
    dsn = "dbname=psycopg_test user=postgres port=5432 host=localhost"
    p = pool.ConnectionPool(
        dsn, min_size=1,max_size=1, close_returns=True,max_lifetime=0.05,open=False
    )
    p.open()
    conn = p.getconn()
    assert len(p._pool) == 0
    sleep(0.2)  # wait for the connection to expire
    conn.close()
    sleep(0.1)
    assert len(p._pool) == 1
    conn = p.getconn()
    assert len(p._pool) == 0
    conn.close()
    sleep(0.1)
    assert len(p._pool) == 1

@pytest.mark.asyncio
async def test_close_returns_no_loop_async():
    dsn = "dbname=psycopg_test user=postgres port=5432 host=localhost"
    p = pool_async.AsyncConnectionPool(
        dsn, min_size=1,max_size=1, close_returns=True,max_lifetime=0.05,open=False
    )
    await p.open()
    conn = await p.getconn()
    assert len(p._pool) == 0
    await asyncio.sleep(0.2)  # wait for the connection to expire
    await conn.close()
    await asyncio.sleep(0.1)
    assert len(p._pool) == 1
    conn = await p.getconn()
    assert len(p._pool) == 0
    await conn.close()
    await asyncio.sleep(0.1)
    assert len(p._pool) == 1
```
will trigger the error 
```log
tests/pool/test_test.py:2 (test_close_returns_no_loop)
def test_close_returns_no_loop():
        dsn = "dbname=psycopg_test user=postgres port=5432 host=localhost"
        p = pool.ConnectionPool(
            dsn, min_size=1,max_size=1, close_returns=True,max_lifetime=0.1,open=False
        )
        p.open()
        conn = p.getconn()
        assert len(p._pool) == 0
        sleep(0.2)  # wait for the connection to expire
>       conn.close()

test_test.py:12: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../.venv/lib/python3.13/site-packages/psycopg/connection.py:176: in close
    pool.putconn(self)
../../.venv/lib/python3.13/site-packages/psycopg_pool/pool.py:325: in putconn
    self._putconn(conn, from_getconn=False)
../../.venv/lib/python3.13/site-packages/psycopg_pool/pool.py:332: in _putconn
    self._return_connection(conn, from_getconn=from_getconn)
../../.venv/lib/python3.13/site-packages/psycopg_pool/pool.py:703: in _return_connection
    conn.close()
../../.venv/lib/python3.13/site-packages/psycopg/connection.py:176: in close
    pool.putconn(self)
E   RecursionError: maximum recursion depth exceeded
!!! Recursion detected (same locals & position)
```