### PR TITLE
Set gssencmode default to disable in binary package builds

### DIFF
--- a/.github/workflows/packages-bin.yml
+++ b/.github/workflows/packages-bin.yml
@@ -35,6 +35,13 @@ env:
   # Latest release: https://www.openssl.org/source/
   OPENSSL_VERSION: "3.5.0"
 
+  # A string to differentiate build cacke keys to allow building different
+  # flavours of libpq in different branches without mixups. Currently used to
+  # make sure that libpq packages built for Psycopg 3.2 and 3.3 don't mix (in
+  # order to change the gssencmode default only on 3.3). We may use it for
+  # different reasons in the future.
+  PQ_FLAGS: "-gssencmode-disable"
+
 concurrency:
   # Cancel older requests of the same workflow in the same branch.
   group: ${{ github.workflow }}-${{ github.ref_name }}
@@ -67,7 +74,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/libpq.build
-          key: libpq-${{ matrix.platform }}-${{ matrix.arch }}-${{ env.LIBPQ_VERSION }}-${{ env.OPENSSL_VERSION }}
+          key: libpq-${{ matrix.platform }}-${{ matrix.arch }}-${{ env.LIBPQ_VERSION }}-${{ env.OPENSSL_VERSION }}${{ env.PQ_FLAGS }}
 
       - name: Create the binary package source tree
         run: python3 ./tools/ci/copy_to_binary.py
@@ -140,7 +147,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/libpq.build
-          key: libpq-${{ env.LIBPQ_VERSION }}-macos-${{ matrix.arch }}-${{ env.OPENSSL_VERSION }}
+          key: libpq-${{ env.LIBPQ_VERSION }}-macos-${{ matrix.arch }}-${{ env.OPENSSL_VERSION }}${{ env.PQ_FLAGS }}
 
       - name: Create the binary package source tree
         run: python3 ./tools/ci/copy_to_binary.py

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -30,6 +30,15 @@ Psycopg 3.3.0 (unreleased)
 
 .. rubric:: Other changes
 
+- Disable default GSSAPI preferential connection in the binary package
+  (:ticket:`#1136`).
+
+  .. warning::
+
+    Please explicitly set the gssencmode_ connection parameter or the
+    :envvar:`PGGSSENCMODE` environment variable to interact reliably with the
+    GSSAPI.
+
 - Drop support for Python 3.8 (:ticket:`#976`) and 3.9 (:ticket:`#1056`).
 
 
@@ -72,9 +81,11 @@ Psycopg 3.2.10 (unreleased)
 
     In a future Psycopg version the default in the binary package will be
     changed to ``disable``. If you need to interact with the GSSAPI reliably
-    you should explicitly set the ``gssencmode`` parameter in the connection
+    you should explicitly set the gssencmode_ parameter in the connection
     string or the :envvar:`PGGSSENCMODE` environment variable to ``prefer`` or
     ``require``.
+
+.. _gssencmode: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-GSSENCMODE
 
 
 Current release

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -65,6 +65,16 @@ Psycopg 3.2.10 (unreleased)
 
 - Add support for Python 3.14 (:ticket:`#1053`).
 - Fix `psycopg_binary.__version__`.
+- Raise a warning if a GSSAPI connection is obtained using the
+  ``gssencmode=prefer`` libpq default (see :ticket:`#1136`).
+
+  .. warning::
+
+    In a future Psycopg version the default in the binary package will be
+    changed to ``disable``. If you need to interact with the GSSAPI reliably
+    you should explicitly set the ``gssencmode`` parameter in the connection
+    string or the :envvar:`PGGSSENCMODE` environment variable to ``prefer`` or
+    ``require``.
 
 
 Current release

--- a/psycopg/psycopg/_conninfo_utils.py
+++ b/psycopg/psycopg/_conninfo_utils.py
@@ -120,3 +120,8 @@ def is_ip_address(s: str) -> bool:
     except ValueError:
         return False
     return True
+
+
+def gssapi_requested(params: ConnDict) -> bool:
+    """Return `true` if `gssencmode` was specified explicitly."""
+    return bool(get_param(params, "gssencmode"))

--- a/tests/pq/test_pq.py
+++ b/tests/pq/test_pq.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 import pytest
 
@@ -16,6 +17,13 @@ def test_version():
 
 def test_build_version():
     assert pq.__build_version__ and pq.__build_version__ >= 70400
+
+
+@pytest.mark.skipif('pq.__impl__ != "binary"')
+@pytest.mark.skipif(sys.platform == "win32", reason="libpq currently not built by us")
+def test_gssencmode_default():
+    d = [d for d in pq.Conninfo.get_defaults() if d.keyword == b"gssencmode"][0]
+    assert (d.compiled or b"").decode() == "disable"
 
 
 @pytest.mark.skipif("not os.environ.get('PSYCOPG_TEST_WANT_LIBPQ_BUILD')")

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -16,6 +16,7 @@ from psycopg import errors as e
 from psycopg import pq
 from psycopg.rows import tuple_row
 from psycopg.conninfo import conninfo_to_dict, timeout_from_conninfo
+from psycopg._conninfo_utils import get_param
 
 from .acompat import skip_async, skip_sync, sleep
 from .fix_crdb import crdb_anydb
@@ -961,3 +962,16 @@ def test_connect_tsa_bad(conn_cls, dsn, mode):
     params = conninfo_to_dict(dsn, target_session_attrs=mode)
     with pytest.raises(psycopg.OperationalError, match=mode):
         conn_cls.connect(**params)
+
+
+@pytest.mark.libpq(">= 16")
+@pytest.mark.skipif(pq.__impl__ != "python", reason="can't monkeypatch C module")
+def test_implicit_gssapi_warning(conn_cls, dsn, recwarn, monkeypatch):
+    if get_param(conninfo_to_dict(dsn), "gssencmode"):
+        pytest.skip("gssencmode parameter explicitly set in test connection string")
+
+    monkeypatch.setattr(pq.PGconn, "used_gssapi", lambda: True)
+    with conn_cls.connect(dsn):
+        pass
+
+    assert "gssencmode" in str(recwarn.pop(RuntimeWarning).message)

--- a/tools/ci/build_libpq.sh
+++ b/tools/ci/build_libpq.sh
@@ -233,6 +233,24 @@ if [ ! -d "${postgres_dir}" ]; then
 
     pushd "${postgres_dir}"
 
+    # Change the gssencmode default to 'disable' to avoid various troubles
+    # related to unwanted GSSAPI interaction. See #1136.
+    patch -f -p1 <<HERE
+diff --git a/src/interfaces/libpq/fe-connect.c b/src/interfaces/libpq/fe-connect.c
+index 454d2ea3fb7..52c64ba3292 100644
+--- a/src/interfaces/libpq/fe-connect.c
++++ b/src/interfaces/libpq/fe-connect.c
+@@ -132,7 +132,7 @@ static int	ldapServiceLookup(const char *purl, PQconninfoOption *options,
+ #define DefaultSSLNegotiation	"postgres"
+ #ifdef ENABLE_GSS
+ #include "fe-gssapi-common.h"
+-#define DefaultGSSMode "prefer"
++#define DefaultGSSMode "disable"
+ #else
+ #define DefaultGSSMode "disable"
+ #endif
+HERE
+
     if [ "$ID" != "macos" ]; then
         # Match the default unix socket dir default with what defined on Ubuntu and
         # Red Hat, which seems the most common location


### PR DESCRIPTION
The MR builds on top of #1137, but it targets the master branch.
Tentatively scheduled for release in 3.3.
 
Fix #1136