### PR TITLE
Fix polling for read+write

### DIFF
--- a/psycopg_c/psycopg_c/_psycopg/waiting.pyx
+++ b/psycopg_c/psycopg_c/_psycopg/waiting.pyx
@@ -88,8 +88,8 @@ retry_eintr:
 
     rv = 0;  /* success, maybe with timeout */
     if (select_rv >= 0) {
-        if (input_fd.events & POLLIN) { rv |= SELECT_EV_READ; }
-        if (input_fd.events & POLLOUT) { rv |= SELECT_EV_WRITE; }
+        if (input_fd.revents & POLLIN) { rv |= SELECT_EV_READ; }
+        if (input_fd.revents & POLLOUT) { rv |= SELECT_EV_WRITE; }
     }
 
 #else


### PR DESCRIPTION
Hi!

This change fixes an issue with using `poll` when checking for both read and write at the same time.

According to my understanding of `poll`, `events` contains the inputs to the `poll` function, whereas `revents` contains the actual results. This means that, with the previous code, when a poll would happen for both read and write (`events = 3`), but only one would be ready afterwards (e.g. `revents = 2`), the code would mistakenly assume both reads and writes were ready.

This issue breaks our [WASIX](https://wasix.org) fork of [psycopg-binary](https://pythonindex.wasix.org/simple/psycopg-binary/index.html) when a socket is ready to be written but no data is available for reading; the code gets a read-ready flag by mistake and makes a socket receive call, which times out.

TBH, I'm surprised as to how this issue hasn't been discovered. Perhaps most platforms use the `select`-based variant of `wait_c_impl`, or otherwise something in the socket flags causes the mistaken receive call to not time out? I find it strange enough that I did multiple searches to make sure I'm not wrong about `revents` vs. `events`.