### PR TITLE
Fixing a small typo

### DIFF
--- a/docs/basic/from_pg2.rst
+++ b/docs/basic/from_pg2.rst
@@ -94,8 +94,8 @@ use the `psycopg.sql` module::
     # This will quote the user and the password using the right quotes
     # e.g.: ALTER USER "foo" SET PASSWORD 'bar'
     >>> conn.execute(
-    ...     sql.SQL("ALTER USER {} SET PASSWORD {}"
-    ...     .format(sql.Identifier(username), password)))
+    ...     sql.SQL("ALTER USER {} SET PASSWORD {}")
+    ...     .format(sql.Identifier(username), password))
 
 
 .. index::
@@ -144,7 +144,7 @@ can compose a multiple query on the client side and run them all in the same
 
     >>> from psycopg import sql
     >>> conn.execute(
-    ...     sql.SQL("INSERT INTO foo VALUES ({}); INSERT INTO foo values ({})"
+    ...     sql.SQL("INSERT INTO foo VALUES ({}); INSERT INTO foo values ({})")
     ...     .format(10, 20))
 
 or a :ref:`client-side binding cursor <client-side-binding-cursors>`::


### PR DESCRIPTION
`.format()` was incorrectly placed out of `.SQL()`.