### PR TITLE
Fix binary copy

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -39,6 +39,7 @@ Psycopg 3.2.10 (unreleased)
 - Fix memory leak when lambda/local functions are used as argument for
   `~.psycopg.types.json.set_json_dumps()`, `~.psycopg.types.json.set_json_loads()`
   (:ticket:`#1108`).
+- Fix bad data on error in binary copy (:ticket:`#1147`).
 - Fix `psycopg_binary.__version__`.
 
 

--- a/psycopg/psycopg/_copy.py
+++ b/psycopg/psycopg/_copy.py
@@ -136,8 +136,9 @@ class Copy(BaseCopy["Connection[Any]"]):
         using the `Copy` object outside a block.
         """
         if self._direction == COPY_IN:
-            if data := self.formatter.end():
-                self._write(data)
+            if not exc:
+                if data := self.formatter.end():
+                    self._write(data)
             self.writer.finish(exc)
             self._finished = True
         else:

--- a/psycopg/psycopg/_copy_async.py
+++ b/psycopg/psycopg/_copy_async.py
@@ -133,8 +133,9 @@ class AsyncCopy(BaseCopy["AsyncConnection[Any]"]):
         using the `Copy` object outside a block.
         """
         if self._direction == COPY_IN:
-            if data := self.formatter.end():
-                await self._write(data)
+            if not exc:
+                if data := self.formatter.end():
+                    await self._write(data)
             await self.writer.finish(exc)
             self._finished = True
         else:

--- a/psycopg_c/psycopg_c/_psycopg/copy.pyx
+++ b/psycopg_c/psycopg_c/_psycopg/copy.pyx
@@ -34,10 +34,7 @@ def format_row_binary(
     else:
         pos = PyByteArray_GET_SIZE(out)
 
-    # let's start from a nice chunk
-    # (larger than most fixed size; for variable ones, oh well, we'll resize it)
-    cdef char *target = CDumper.ensure_size(
-        out, pos, sizeof(berowlen) + 20 * rowlen)
+    cdef char *target = CDumper.ensure_size(out, pos, sizeof(berowlen))
 
     # Write the number of fields as network-order 16 bits
     memcpy(target, <void *>&berowlen, sizeof(berowlen))


### PR DESCRIPTION
Avoid generating spurious exceptions in binary copy if there is an error in a dumper.

Close #1147