### PR TITLE
respect set_types in c-version in text format

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,9 +6,7 @@ on:
     # on.<push|pull_request>.<branches|tags> GitHub Actions docs.
     branches:
       - "*"
-  # Note: trying to exclude pull requests because it results in duplicate job
-  # on the commits belonging to pull requests.
-  # pull_request:
+  pull_request:
   schedule:
     - cron: '48 6 * * *'
 

--- a/psycopg_c/psycopg_c/_psycopg/copy.pyx
+++ b/psycopg_c/psycopg_c/_psycopg/copy.pyx
@@ -130,6 +130,11 @@ def format_row_text(
     cdef PyObject *fmt = <PyObject *>PG_TEXT
     cdef PyObject *row_dumper
 
+    # try to get preloaded dumpers from set_types
+    #if not tx._row_dumpers:
+    #    tx._row_dumpers = PyList_New(rowlen)
+    dumpers = tx._row_dumpers
+
     for i in range(rowlen):
         # Include the tab before the data, so it gets included in the resizes
         with_tab = i > 0
@@ -139,7 +144,16 @@ def format_row_text(
             _append_text_none(out, &pos, with_tab)
             continue
 
-        row_dumper = tx.get_row_dumper(<PyObject *>item, fmt)
+        #row_dumper = PyList_GET_ITEM(dumpers, i)
+        #if not row_dumper:
+        #    row_dumper = tx.get_row_dumper(<PyObject *>item, fmt)
+        #    Py_INCREF(<object>row_dumper)
+        #    PyList_SET_ITEM(dumpers, i, <object>row_dumper)
+        if dumpers:
+            row_dumper = PyList_GET_ITEM(dumpers, i)
+        else:
+            row_dumper = tx.get_row_dumper(<PyObject *>item, fmt)
+
         if (<RowDumper>row_dumper).cdumper is not None:
             # A cdumper can resize if necessary and copy in place
             size = (<RowDumper>row_dumper).cdumper.cdump(

--- a/psycopg_c/psycopg_c/_psycopg/copy.pyx
+++ b/psycopg_c/psycopg_c/_psycopg/copy.pyx
@@ -131,8 +131,8 @@ def format_row_text(
     cdef PyObject *row_dumper
 
     # try to get preloaded dumpers from set_types
-    #if not tx._row_dumpers:
-    #    tx._row_dumpers = PyList_New(rowlen)
+    if not tx._row_dumpers:
+        tx._row_dumpers = PyList_New(rowlen)
     dumpers = tx._row_dumpers
 
     for i in range(rowlen):
@@ -144,15 +144,11 @@ def format_row_text(
             _append_text_none(out, &pos, with_tab)
             continue
 
-        #row_dumper = PyList_GET_ITEM(dumpers, i)
-        #if not row_dumper:
-        #    row_dumper = tx.get_row_dumper(<PyObject *>item, fmt)
-        #    Py_INCREF(<object>row_dumper)
-        #    PyList_SET_ITEM(dumpers, i, <object>row_dumper)
-        if dumpers:
-            row_dumper = PyList_GET_ITEM(dumpers, i)
-        else:
+        row_dumper = PyList_GET_ITEM(dumpers, i)
+        if not row_dumper:
             row_dumper = tx.get_row_dumper(<PyObject *>item, fmt)
+            Py_INCREF(<object>row_dumper)
+            PyList_SET_ITEM(dumpers, i, <object>row_dumper)
 
         if (<RowDumper>row_dumper).cdumper is not None:
             # A cdumper can resize if necessary and copy in place

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -116,6 +116,15 @@ def test_rows(conn, format):
     assert conn.info.transaction_status == pq.TransactionStatus.INTRANS
 
 
+@pytest.mark.parametrize("format", pq.Format)
+def test_set_types(conn, format):
+    cur = conn.cursor()
+    ensure_table(cur, "id serial primary key, data jsonb")
+    with cur.copy(f"copy copy_in (data) from stdin (format {format.name})") as copy:
+        copy.set_types(["jsonb"])
+        copy.write_row([{"foo": "bar"}])
+
+
 def test_set_custom_type(conn, hstore):
     command = """copy (select '"a"=>"1", "b"=>"2"'::hstore) to stdout"""
     cur = conn.cursor()

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -119,10 +119,10 @@ def test_rows(conn, format):
 @pytest.mark.parametrize("format", pq.Format)
 def test_set_types(conn, format):
     cur = conn.cursor()
-    ensure_table(cur, "id serial primary key, data jsonb")
-    with cur.copy(f"copy copy_in (data) from stdin (format {format.name})") as copy:
-        copy.set_types(["jsonb"])
-        copy.write_row([{"foo": "bar"}])
+    ensure_table(cur, "id serial primary key, data jsonb, data2 bigint")
+    with cur.copy(f"copy copy_in (data, data2) from stdin (format {format.name})") as copy:
+        copy.set_types(["jsonb", "bigint"])
+        copy.write_row([{"foo": "bar"}, 123])
 
 
 def test_set_custom_type(conn, hstore):

--- a/tests/test_copy_async.py
+++ b/tests/test_copy_async.py
@@ -120,6 +120,17 @@ async def test_rows(aconn, format):
     assert aconn.info.transaction_status == pq.TransactionStatus.INTRANS
 
 
+@pytest.mark.parametrize("format", pq.Format)
+async def test_set_types(aconn, format):
+    cur = aconn.cursor()
+    await ensure_table_async(cur, "id serial primary key, data jsonb")
+    async with cur.copy(
+        f"copy copy_in (data) from stdin (format {format.name})"
+    ) as copy:
+        copy.set_types(["jsonb"])
+        await copy.write_row([{"foo": "bar"}])
+
+
 async def test_set_custom_type(aconn, hstore):
     command = """copy (select '"a"=>"1", "b"=>"2"'::hstore) to stdout"""
     cur = aconn.cursor()

--- a/tests/test_copy_async.py
+++ b/tests/test_copy_async.py
@@ -123,12 +123,12 @@ async def test_rows(aconn, format):
 @pytest.mark.parametrize("format", pq.Format)
 async def test_set_types(aconn, format):
     cur = aconn.cursor()
-    await ensure_table_async(cur, "id serial primary key, data jsonb")
+    await ensure_table_async(cur, "id serial primary key, data jsonb, data2 bigint")
     async with cur.copy(
-        f"copy copy_in (data) from stdin (format {format.name})"
+        f"copy copy_in (data, data2) from stdin (format {format.name})"
     ) as copy:
-        copy.set_types(["jsonb"])
-        await copy.write_row([{"foo": "bar"}])
+        copy.set_types(["jsonb", "bigint"])
+        await copy.write_row([{"foo": "bar"}, 123])
 
 
 async def test_set_custom_type(aconn, hstore):


### PR DESCRIPTION
`set_types` is currently ignored in the c version in text format. This PR harmonizes the behavior with the binary version:
- respect `set_types`
- if no `set_types`, set fxied col dumper from first non-None value

Should fix https://github.com/psycopg/psycopg/discussions/1153