### PR TITLE
fix buffer sizing for Int2BinaryDumper in c version

### DIFF
--- a/psycopg_c/psycopg_c/types/numeric.pyx
+++ b/psycopg_c/psycopg_c/types/numeric.pyx
@@ -758,7 +758,7 @@ cdef Py_ssize_t dump_int_to_int2_binary(
     obj, bytearray rv, Py_ssize_t offset
 ) except -1:
     cdef int16_t val = <int16_t>PyLong_AsLongLong(obj)
-    cdef int16_t *buf = <int16_t *>CDumper.ensure_size(rv, offset, sizeof(obj))
+    cdef int16_t *buf = <int16_t *>CDumper.ensure_size(rv, offset, sizeof(val))
     cdef uint16_t beval = endian.htobe16(val)  # swap bytes if needed
     memcpy(buf, &beval, sizeof(beval))
     return sizeof(val)


### PR DESCRIPTION
@dvarrazzo There is no testcase for this, as I dont know how to test this (it is a cdef function, the value gets immediately corrected by the only reachable outer dump function).