### PR TITLE
ci: fix bad expansion of an array variable in build_libpq.sh

### DIFF
--- a/tools/ci/build_libpq.sh
+++ b/tools/ci/build_libpq.sh
@@ -118,7 +118,7 @@ if [ "$ID" == "centos" ] || [ "$ID" == "macos" ]; then
         if [ -z "${MACOSX_ARCHITECTURE:-}" ]; then
             ./config ${options[*]}
         else
-            ./configure "darwin64-$MACOSX_ARCHITECTURE-cc" ${options[*]}
+            ./config "darwin64-$MACOSX_ARCHITECTURE-cc" ${options[*]}
         fi
 
         make -s depend


### PR DESCRIPTION
The `options` array variable have been introduced in `adb8336a392a71a3cb2ddf18bd9b17238a01a06e` but is used with `$options` which only expand the 1st value (for bash).

The full expansion have to be done with `${options[*]}`

Note that `-shared` and `-fPIC` options are still used as they are enabled by default by `./Configure`, but the `zlib` option is not taken into account (disabled by default)