### PR TITLE
Update DEFAULT_AUTO_FIELD setting in Django CI workflow

### DIFF
--- a/.github/workflows/3rd-party-tests.yml
+++ b/.github/workflows/3rd-party-tests.yml
@@ -135,8 +135,10 @@ jobs:
             pip_django: git+https://github.com/django/django.git#egg=Django
           - django_label: lts4
             pip_django: "'Django >= 4.2, < 4.3'"
+            default_auto_fields: 'DEFAULT_AUTO_FIELD = "django.db.models.AutoField"'
           - django_label: lts5
             pip_django: "'Django >= 5.2, < 5.3'"
+            default_auto_fields: 'DEFAULT_AUTO_FIELD = "django.db.models.AutoField"'
 
           # Test with min and max Python supported versions
           - django_label: lts4
@@ -239,6 +241,7 @@ jobs:
               "django.contrib.auth.hashers.MD5PasswordHasher",
           ]
 
+          ${{ matrix.default_auto_fields }}
           USE_TZ = False
           HERE
 


### PR DESCRIPTION
Django 6.0 made adjustments to its tests to allow tests to be launched with the new default value for `DEFAULT_AUTO_FIELD`, which became `BigAutoField` in 6.0 (https://github.com/django/django/pull/19753)


Refs https://github.com/django/django-docker-box/pull/59 for an analogous change to Django's docker configuration for running tests.

Hoping this change is enough to make this workflow pass again. Thanks for testing against Django pre-releases!