### PR TITLE
Improve loading performance by transposing row-col loading order

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -20,6 +20,7 @@ Psycopg 3.2.11 (unreleased)
   the Python version (:ticket:`#1153`).
 - Don't raise warning, and don't leak resources, if a builtin function is used
   as JSON dumper/loader function (:ticket:`#1165`).
+- Improve performance of Python conversion on results loading (:ticket:`#1155`).
 
 
 Current release


### PR DESCRIPTION
This MR replaces #1163, which has the entire history of attempting pagination, fine-tuning the page size, and then figuring out that it wasn't needed. So it simply transposes the row-col load order.

Because the history of what happened in #1163 might be useful, we will keep that branch around ([here](https://github.com/dvarrazzo/psycopg/tree/fix/speedregression-fetchall), for example).

Close #1163
Close #1155

Attn. @jerch
