### PR TITLE
Don't fail on commands rturning COPY_BOTH results

### DIFF
--- a/psycopg/psycopg/_cursor_base.py
+++ b/psycopg/psycopg/_cursor_base.py
@@ -475,8 +475,12 @@ class BaseCursor(Generic[ConnectionType, Row]):
             raise e.InternalError("got no result from the query")
 
         for res in results:
-            status = res.status
-            if status != TUPLES_OK and status != COMMAND_OK and status != EMPTY_QUERY:
+            if (
+                (status := res.status) != TUPLES_OK
+                and status != COMMAND_OK
+                and status != EMPTY_QUERY
+                and status != COPY_BOTH
+            ):
                 self._raise_for_result(res)
 
     def _raise_for_result(self, result: PGresult) -> NoReturn:


### PR DESCRIPTION
This change only allows to execute a `START_REPLICATION` command on a suitable configured database, i.e. the following commands would work:

```python
    conn = psycopg.connect(DSN, replication="database", autocommit=True)
    conn.execute(
        """
        START_REPLICATION SLOT "my_replication_slot"
        LOGICAL 0/0 (proto_version '1',publication_names 'my_publication')
        """)
    # <psycopg.Cursor [COPY_BOTH] [ACTIVE] at 0x...>
```

instead of gettgin an error such as  "COPY cannot be used with this method".

Please check https://github.com/psycopg/psycopg/issues/71#issuecomment-3393722855 for the description of the db configuration required to make this command work.

No further support for logical replication is planned at this moment, but this change allows to play without needing to execute the command at libpq level.