### PR TITLE
Pass the entire info object to composite adapters customization functions

### DIFF
--- a/docs/basic/pgtypes.rst
+++ b/docs/basic/pgtypes.rst
@@ -41,7 +41,18 @@ using `~psycopg.types.composite.register_composite()`.
    documentation for the general usage, especially the
    `~psycopg.types.TypeInfo.fetch()` method.
 
+   .. attribute:: field_names
+       :type: tuple[str, ...]
+
+       Tuple containing the field names of the composite type.
+
+   .. attribute:: field_types
+       :type: tuple[int, ...]
+
+       Tuple containing the field OIDs of the composite type.
+
    .. attribute:: python_type
+       :type: Callable | None
 
        After `register_composite()` is called, it will contain the Python type
        adapting the registered composite.
@@ -58,16 +69,17 @@ using `~psycopg.types.composite.register_composite()`.
    If the `!factory` is a type (and not a generic callable) then dumpers for
    such type are created and registered too, so that passing objects of that
    type to a query will adapt them to the registered composite type. This
-   assumes that `!factory` is a sequence; if this is not the case you can
-   specify the `!make_sequence` parameter: a function taking the object to
-   dump and the list of field names of the composite and returning a sequence
-   of values. See :ref:`composite-non-sequence`.
+   assumes that the `!factory` type is a sequence; if this is not the case you
+   can specify the `!make_sequence` parameter: a function taking the object to
+   dump and the composite info and returning a sequence of values. See
+   :ref:`composite-non-sequence`.
 
    The `!factory` callable will be called with the sequence of value from the
    composite. If passing the sequence of positional arguments is not suitable
-   you can specify a `!make_object` callable, which takes the sequence of
-   composite values and field names and which should return a new instance of
-   the object to load. See :ref:`composite-non-sequence`.
+   for the `!factory` type you can specify the `!make_object` parameter: a
+   function taking the sequence of composite values and the type info, and
+   which should return a new instance of the object to load. See
+   :ref:`composite-non-sequence`.
 
    .. versionadded:: 3.3
         the `!make_object` and `!make_sequence` parameters.
@@ -122,8 +134,9 @@ Example: non-sequence Python object
 
 If your Python type takes keyword arguments, or if the sequence of value
 coming from the PostgreSQL type is not suitable for it, it is possible to
-specify a :samp:`make_object({values}, {names})` function to adapt the
-values from the composite to the right type requirements. For example::
+specify a :samp:`make_object({values}, {info})` function to adapt the values
+from the composite to the Python object to create, eventually making use of
+the information in the type `~types.composite.CompositeInfo`, for example::
 
     >>> from dataclasses import dataclass
     >>> from typing import Any, Sequence
@@ -133,8 +146,8 @@ values from the composite to the right type requirements. For example::
     ...     suit: str
     ...     value: int
 
-    >>> def card_from_db(values: Sequence[Any], names: Sequence[str]) -> Card:
-    ...     return Card(**dict(zip(names, values)))
+    >>> def card_from_db(values: Sequence[Any], info: CompositeInfo) -> Card:
+    ...     return Card(**dict(zip(info.field_names, values)))
 
     >>> register_composite(info, conn, make_object=card_from_db)
     >>> conn.execute("select '(1,spades)'::card").fetchone()[0]
@@ -144,11 +157,11 @@ The previous example only configures loaders to convert data from PostgreSQL
 to Python. If we are also interested in dumping Python `!Card` objects we need
 to specify `!Card` as the factory (to declare which object we want to dump)
 and, because `!Card` is not a sequence, we need to specify a
-:samp:`make_sequence({object}, {names})` to convert objects attributes into
-a sequence matching the composite fields::
+:samp:`make_sequence({object}, {info})` function to convert objects attributes
+into a sequence matching the composite fields::
 
-    >>> def card_to_db(card: Card, names: Sequence[str]) -> Sequence[Any]:
-    ...     return [getattr(card, name) for name in names]
+    >>> def card_to_db(card: Card, info: CompositeInfo) -> Sequence[Any]:
+    ...     return [getattr(card, name) for name in info.field_names]
 
     >>> register_composite(
     ...     info, conn, factory=Card,

--- a/tests/types/test_composite.py
+++ b/tests/types/test_composite.py
@@ -355,8 +355,8 @@ class MyKeywordThing:
 def test_load_keyword_composite_factory(conn, testcomp, fmt_out):
     info = CompositeInfo.fetch(conn, "testcomp")
 
-    def make_object(values, names):
-        return MyKeywordThing(**dict(zip(names, values)))
+    def make_object(values, info):
+        return MyKeywordThing(**dict(zip(info.field_names, values)))
 
     register_composite(info, conn, factory=MyKeywordThing, make_object=make_object)
     assert info.python_type is MyKeywordThing
@@ -432,8 +432,8 @@ def test_callable_dumper_not_registered(conn, testcomp):
 def test_dump_no_sequence(conn, testcomp, fmt_in, caplog):
     caplog.set_level(logging.WARNING, logger="psycopg")
 
-    def make_sequence(obj, names):
-        return [getattr(obj, attr) for attr in names]
+    def make_sequence(obj, info):
+        return [getattr(obj, attr) for attr in info.field_names]
 
     info = CompositeInfo.fetch(conn, "testcomp")
     register_composite(info, conn, factory=MyKeywordThing, make_sequence=make_sequence)


### PR DESCRIPTION
Previously we were passing only the names but this seems an unneeded specialization: pass the entire CompositeInfo object and let the user decide what they want to do of it.

`make_instance` attribute renamed to `make_object`, which seems less highbrow.