### PR TITLE
fix: adapters: avoid race condition when replacing class name with itself

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -10,6 +10,12 @@
 Current release
 ---------------
 
+Psycopg 3.3.2
+^^^^^^^^^^^^^
+
+Fix race condition in adapters at startup (:ticket:`#1230`).
+
+
 Psycopg 3.3.1
 ^^^^^^^^^^^^^
 

--- a/psycopg/psycopg/_adapters_map.py
+++ b/psycopg/psycopg/_adapters_map.py
@@ -217,9 +217,10 @@ class AdaptersMap:
 
             # If the adapter is not found, look for its name as a string
             fqn = scls.__module__ + "." + scls.__qualname__
-            if fqn in dmap:
+            if (d := dmap.get(fqn)) is not None:
                 # Replace the class name with the class itself
-                d = dmap[scls] = dmap.pop(fqn)
+                dmap[scls] = d
+                dmap.pop(fqn, None)
                 return d
 
         format = PyFormat(format)


### PR DESCRIPTION
Another thread may be switched to between the dmap.pop(fqn) instruction and the dmap[scls] one, typically at program startup when multiple threads are making their "first" queries.

Close #1230