### PR TITLE
fix: retain pgconn on OperationalError

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -10,6 +10,13 @@
 Current release
 ---------------
 
+Psyocpg 3.3.3 (unreleased)
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Retain `Error.pgconn` when raising a single exception for multiple connection
+attempt errors (:ticket:`#1246`).
+
+
 Psycopg 3.3.2
 ^^^^^^^^^^^^^
 

--- a/psycopg/psycopg/connection.py
+++ b/psycopg/psycopg/connection.py
@@ -126,7 +126,8 @@ class Connection(BaseConnection[Row]):
             lines = [str(last_ex)]
             lines.append("Multiple connection attempts failed. All failures were:")
             lines.extend((f"- {descr}: {error}" for error, descr in conn_errors))
-            raise type(last_ex)("\n".join(lines)).with_traceback(None)
+            new_ex = type(last_ex)("\n".join(lines), pgconn=last_ex.pgconn)
+            raise new_ex.with_traceback(None)
 
         if (
             capabilities.has_used_gssapi()

--- a/psycopg/psycopg/connection_async.py
+++ b/psycopg/psycopg/connection_async.py
@@ -142,7 +142,8 @@ class AsyncConnection(BaseConnection[Row]):
             lines = [str(last_ex)]
             lines.append("Multiple connection attempts failed. All failures were:")
             lines.extend(f"- {descr}: {error}" for error, descr in conn_errors)
-            raise type(last_ex)("\n".join(lines)).with_traceback(None)
+            new_ex = type(last_ex)("\n".join(lines), pgconn=last_ex.pgconn)
+            raise new_ex.with_traceback(None)
 
         if (
             capabilities.has_used_gssapi()


### PR DESCRIPTION
Fixes #1246.

When performing multiple connection attempts and all fail, a new `OperationalError` with the combined attempt errors is raised.  But the `pgconn` attribute from the original attempt errors is lost.  Fix this by including the `pgconn` from the last attempt error.