### PR TITLE
Fix ValueError when server sends ErrorResponse during Sync after Parse

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -13,8 +13,10 @@ Current release
 Psycopg 3.3.3 (unreleased)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Retain `Error.pgconn` when raising a single exception for multiple connection
-attempt errors (:ticket:`#1246`).
+- Retain `Error.pgconn` when raising a single exception for multiple connection
+  attempt errors (:ticket:`#1246`).
+- Return a proper error when server sends ``ErrorResponse`` for a ``Sync`` after
+  a ``Parse`` (:ticket:`#1260`).
 
 
 Psycopg 3.3.2

--- a/psycopg/psycopg/_cursor_base.py
+++ b/psycopg/psycopg/_cursor_base.py
@@ -289,9 +289,10 @@ class BaseCursor(Generic[ConnectionType, Row]):
             if prep is Prepare.SHOULD:
                 self._send_prepare(name, pgq)
                 if not self._conn._pipeline:
-                    (result,) = yield from execute(self._pgconn)
-                    if result.status == FATAL_ERROR:
-                        raise e.error_from_result(result, encoding=self._encoding)
+                    results = yield from execute(self._pgconn)
+                    for result in results:
+                        if result.status == FATAL_ERROR:
+                            raise e.error_from_result(result, encoding=self._encoding)
             # Then execute it.
             self._send_query_prepared(name, pgq, binary=binary)
 


### PR DESCRIPTION
This PR fixes a minor bug.

**Problem**

When using `prepare=True` (or auto-prepare), psycopg sends `Parse + Sync` via libpq's `PQsendPrepare`. The code assumes libpq returns exactly one `PGresult`:

    (result,) = yield from execute(self._pgconn)

The PostgreSQL wire protocol explicitly allows `ErrorResponse` during Sync processing. From [the docs](https://www.postgresql.org/docs/current/protocol-flow.html):

> "But note that no skipping occurs if an error is detected while processing Sync — this ensures that there is one and only one ReadyForQuery sent for each Sync."

When the server sends `ParseComplete + ErrorResponse + ReadyForQuery` (i.e. Parse succeeds, but Sync encounters an error during implicit transaction commit), libpq returns two `PGresult` objects, causing the following error in psycopg:

    ValueError: too many values to unpack (expected 1)

This probably can't happen with PostgreSQL itself, because `Parse` doesn't start implicit transactions or modify state, so `Sync` after a bare `Parse` has nothing to commit and can never fail. However, other PostgreSQL-compatible backends can produce this sequence — we observed it with Materialize, where a concurrent role drop causes `end_transaction` to fail during Sync — and the protocol does allow it in general. (I'm one of the Materialize developers, and the bug is frustrating our testing frameworks that rely on psycopg.)

**Fix**

Accept multiple results from `PQsendPrepare` and check each for errors, consistent with how the non-prepare path already handles results.

**Test**

Added a test (generated by Claude) with a minimal mock PostgreSQL server that reproduces the exact protocol sequence (`ParseComplete + ErrorResponse + ReadyForQuery` in response to `Parse + Sync`). The test confirms that a proper `DatabaseError` is raised instead of `ValueError`. Let me know if there is a more idiomatic way to test this.