### PR TITLE
Fixes for recent python versions

### DIFF
--- a/psycopg/pyproject.toml
+++ b/psycopg/pyproject.toml
@@ -93,8 +93,8 @@ dev = [
     "wheel >= 0.37",
 ]
 docs = [
-    "Sphinx >= 5.0",
-    "furo == 2022.6.21",
+    "Sphinx >= 7.2",
+    "furo >= 2024.1.29",
     "sphinx-autobuild >= 2021.3.14",
     "sphinx-autodoc-typehints >= 1.12",
 ]

--- a/psycopg_c/build_backend/psycopg_build_ext.py
+++ b/psycopg_c/build_backend/psycopg_build_ext.py
@@ -9,9 +9,11 @@ libpq and accounting for other platform differences.
 
 import os
 import sys
+import logging
 import subprocess as sp
-from distutils import log
 from distutils.command.build_ext import build_ext
+
+log = logging.getLogger(__name__)
 
 
 def get_config(what: str) -> str:


### PR DESCRIPTION
Please see the two commits, these handle issues with Python 3.12 and 3.13 in the build

## Replace distutils.log with stdlib logging in psycopg_c build backend
    
    distutils.log was deprecated in Python 3.10 and removed in 3.12.
    The psycopg_c build extension imported it for diagnostic messages
    (e.g. pg_config errors), causing an ImportError at build time on
    Python 3.12+.
    
    Replace it with a standard logging.getLogger(__name__) logger, which
    is the idiomatic replacement and has no compatibility concerns.


## Fix docs build on Python 3.13+
    
    Python 3.13 removed the `imghdr` module from the standard library.
    Sphinx 5.x still imports it, causing the docs
    build to fail immediately with:
    
        No module named 'imghdr'
    
    Bump the Sphinx lower bound to 7.2 (the first release that dropped the
    imghdr dependency) and furo to 2024.1.29.