### PR TITLE
perf: Speed up `_split_query`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __pycache__/
 .coverage
 htmlcov
 .idea
+.benchmarks
 
 .eggs/
 dist/

--- a/psycopg/psycopg/_queries.py
+++ b/psycopg/psycopg/_queries.py
@@ -376,45 +376,29 @@ _re_placeholder = re.compile(rb"""(?x)
 def _split_query(
     query: bytes, encoding: str = "ascii", collapse_double_percent: bool = True
 ) -> list[QueryPart]:
-    parts: list[tuple[bytes, re.Match[bytes] | None]] = []
+    parts: list[QueryPart] = []
     cur = 0
-
-    # pairs [(fragment, match], with the last match None
-    m = None
-    for m in _re_placeholder.finditer(query):
-        pre = query[cur : m.span(0)[0]]
-        parts.append((pre, m))
-        cur = m.span(0)[1]
-    if m:
-        parts.append((query[cur:], None))
-    else:
-        parts.append((query, None))
-
-    rv = []
-
-    # drop the "%%", validate
-    i = 0
+    pending_pre = b""
     phtype = None
-    while i < len(parts):
-        pre, m = parts[i]
-        if m is None:
-            # last part
-            rv.append(QueryPart(pre, 0, PyFormat.AUTO))
-            break
+    ph_index = 0
 
-        if (ph := m.group(0)) == b"%%":
-            # unescape '%%' to '%' if necessary, then merge the parts
-            if collapse_double_percent:
-                ph = b"%"
-            pre1, m1 = parts[i + 1]
-            parts[i + 1] = (pre + ph + pre1, m1)
-            del parts[i]
+    for m in _re_placeholder.finditer(query):
+        m_start, m_end = m.span()
+        pre = pending_pre + query[cur:m_start]
+        cur = m_end
+        ph = m.group(0)
+
+        if ph == b"%%":  # Accumulate into pending_pre for the next iteration
+            # unescape '%%' to '%' if necessary
+            pending_pre = pre + (b"%" if collapse_double_percent else b"%%")
             continue
+
+        pending_pre = b""
 
         if ph == b"%(":
             raise e.ProgrammingError(
                 "incomplete placeholder:"
-                f" '{query[m.span(0)[0]:].split()[0].decode(encoding)}'"
+                f" '{query[m_start:].split()[0].decode(encoding)}'"
             )
         elif ph == b"% ":
             # explicit message for a typical error
@@ -425,12 +409,11 @@ def _split_query(
         elif ph[-1:] not in b"sbt":
             raise e.ProgrammingError(
                 "only '%s', '%b', '%t' are allowed as placeholders, got"
-                f" '{m.group(0).decode(encoding)}'"
+                f" '{ph.decode(encoding)}'"
             )
 
         # Index or name
-        item: int | str
-        item = m.group(1).decode(encoding) if m.group(1) else i
+        item: int | str = m.group(1).decode(encoding) if m.group(1) else ph_index
 
         if not phtype:
             phtype = type(item)
@@ -440,10 +423,13 @@ def _split_query(
             )
 
         format = _ph_to_fmt[ph[-1:]]
-        rv.append(QueryPart(pre, item, format))
-        i += 1
+        parts.append(QueryPart(pre, item, format))
+        ph_index += 1
 
-    return rv
+    # last part (sentinel)
+    parts.append(QueryPart(pending_pre + query[cur:], 0, PyFormat.AUTO))
+
+    return parts
 
 
 _ph_to_fmt = {

--- a/psycopg/psycopg/_queries.py
+++ b/psycopg/psycopg/_queries.py
@@ -395,20 +395,20 @@ def _split_query(
 
         pending_pre = b""
 
-        if ph == b"%(":
-            raise e.ProgrammingError(
-                "incomplete placeholder:"
-                f" '{query[m_start:].split()[0].decode(encoding)}'"
-            )
-        elif ph == b"% ":
-            # explicit message for a typical error
-            raise e.ProgrammingError(
-                "incomplete placeholder: '%'; if you want to use '%' as an"
-                " operator you can double it up, i.e. use '%%'"
-            )
         try:
             format = _ph_to_fmt[ph[-1:]]
         except KeyError:
+            if ph == b"%(":
+                raise e.ProgrammingError(
+                    "incomplete placeholder:"
+                    f" '{query[m_start:].split()[0].decode(encoding)}'"
+                )
+            elif ph == b"% ":
+                # explicit message for a typical error
+                raise e.ProgrammingError(
+                    "incomplete placeholder: '%'; if you want to use '%' as an"
+                    " operator you can double it up, i.e. use '%%'"
+                )
             raise e.ProgrammingError(
                 "only '%s', '%b', '%t' are allowed as placeholders, got"
                 f" '{ph.decode(encoding)}'"

--- a/psycopg/psycopg/_queries.py
+++ b/psycopg/psycopg/_queries.py
@@ -376,6 +376,7 @@ _re_placeholder = re.compile(rb"""(?x)
 def _split_query(
     query: bytes, encoding: str = "ascii", collapse_double_percent: bool = True
 ) -> list[QueryPart]:
+    ph_byte_to_fmt = _ph_byte_to_fmt  # micro-optimize global lookup
     parts: list[QueryPart] = []
     cur = 0
     pending_pre = b""
@@ -396,7 +397,7 @@ def _split_query(
         pending_pre = b""
 
         try:
-            format = _ph_to_fmt[ph[-1:]]
+            format = ph_byte_to_fmt[ph[-1]]
         except KeyError:
             if ph == b"%(":
                 raise e.ProgrammingError(
@@ -432,10 +433,10 @@ def _split_query(
     return parts
 
 
-_ph_to_fmt = {
-    b"s": PyFormat.AUTO,
-    b"t": PyFormat.TEXT,
-    b"b": PyFormat.BINARY,
+_ph_byte_to_fmt = {
+    ord(b"s"): PyFormat.AUTO,
+    ord(b"t"): PyFormat.TEXT,
+    ord(b"b"): PyFormat.BINARY,
 }
 
 

--- a/psycopg/psycopg/_queries.py
+++ b/psycopg/psycopg/_queries.py
@@ -380,6 +380,7 @@ def _split_query(
     cur = 0
     pending_pre = b""
     phtype = None
+    double_percent_replacement = b"%" if collapse_double_percent else b"%%"
 
     for m in _re_placeholder.finditer(query):
         m_start, m_end = m.span()
@@ -389,7 +390,7 @@ def _split_query(
 
         if ph == b"%%":  # Accumulate into pending_pre for the next iteration
             # unescape '%%' to '%' if necessary
-            pending_pre = pre + (b"%" if collapse_double_percent else b"%%")
+            pending_pre = pre + double_percent_replacement
             continue
 
         pending_pre = b""

--- a/psycopg/psycopg/_queries.py
+++ b/psycopg/psycopg/_queries.py
@@ -396,9 +396,19 @@ def _split_query(
 
         pending_pre = b""
 
+        # Index or name
+        item: int | str = name.decode(encoding) if (name := m.group(1)) else len(parts)
+
+        if not phtype:
+            phtype = type(item)
+        elif phtype is not type(item):
+            raise e.ProgrammingError(
+                "positional and named placeholders cannot be mixed"
+            )
+
         try:
-            format = ph_byte_to_fmt[ph[-1]]
-        except KeyError:
+            parts.append(QueryPart(pre, item, ph_byte_to_fmt[ph[-1]]))
+        except KeyError:  # Not a valid format character (ph_byte_to_fmt lookup fails)
             if ph == b"%(":
                 raise e.ProgrammingError(
                     "incomplete placeholder:"
@@ -414,18 +424,6 @@ def _split_query(
                 "only '%s', '%b', '%t' are allowed as placeholders, got"
                 f" '{ph.decode(encoding)}'"
             )
-
-        # Index or name
-        item: int | str = name.decode(encoding) if (name := m.group(1)) else len(parts)
-
-        if not phtype:
-            phtype = type(item)
-        elif phtype is not type(item):
-            raise e.ProgrammingError(
-                "positional and named placeholders cannot be mixed"
-            )
-
-        parts.append(QueryPart(pre, item, format))
 
     # last part (sentinel)
     parts.append(QueryPart(pending_pre + query[cur:], 0, PyFormat.AUTO))

--- a/psycopg/psycopg/_queries.py
+++ b/psycopg/psycopg/_queries.py
@@ -415,7 +415,7 @@ def _split_query(
             )
 
         # Index or name
-        item: int | str = m.group(1).decode(encoding) if m.group(1) else ph_index
+        item: int | str = name.decode(encoding) if (name := m.group(1)) else ph_index
 
         if not phtype:
             phtype = type(item)

--- a/psycopg/psycopg/_queries.py
+++ b/psycopg/psycopg/_queries.py
@@ -406,7 +406,9 @@ def _split_query(
                 "incomplete placeholder: '%'; if you want to use '%' as an"
                 " operator you can double it up, i.e. use '%%'"
             )
-        elif ph[-1:] not in b"sbt":
+        try:
+            format = _ph_to_fmt[ph[-1:]]
+        except KeyError:
             raise e.ProgrammingError(
                 "only '%s', '%b', '%t' are allowed as placeholders, got"
                 f" '{ph.decode(encoding)}'"
@@ -422,7 +424,6 @@ def _split_query(
                 "positional and named placeholders cannot be mixed"
             )
 
-        format = _ph_to_fmt[ph[-1:]]
         parts.append(QueryPart(pre, item, format))
         ph_index += 1
 

--- a/psycopg/psycopg/_queries.py
+++ b/psycopg/psycopg/_queries.py
@@ -380,7 +380,7 @@ def _split_query(
     parts: list[QueryPart] = []
     cur = 0
     pending_pre = b""
-    phtype = None
+    seen_named = seen_positional = False
     double_percent_replacement = b"%" if collapse_double_percent else b"%%"
 
     for m in _re_placeholder.finditer(query):
@@ -397,14 +397,13 @@ def _split_query(
         pending_pre = b""
 
         # Index or name
-        item: int | str = name.decode(encoding) if (name := m.group(1)) else len(parts)
-
-        if not phtype:
-            phtype = type(item)
-        elif phtype is not type(item):
-            raise e.ProgrammingError(
-                "positional and named placeholders cannot be mixed"
-            )
+        item: int | str
+        if name := m.group(1):
+            seen_named = True
+            item = name.decode(encoding)
+        else:
+            seen_positional = True
+            item = len(parts)
 
         try:
             parts.append(QueryPart(pre, item, ph_byte_to_fmt[ph[-1]]))
@@ -424,6 +423,13 @@ def _split_query(
                 "only '%s', '%b', '%t' are allowed as placeholders, got"
                 f" '{ph.decode(encoding)}'"
             )
+
+    if seen_named and seen_positional:
+        # For less overhead, we only do this at the end of the loop;
+        # this means that a broken query will see some extra work done
+        # before the error is raised. We assume broken queries to be
+        # rarer than working ones, so that should be acceptable.
+        raise e.ProgrammingError("positional and named placeholders cannot be mixed")
 
     # last part (sentinel)
     parts.append(QueryPart(pending_pre + query[cur:], 0, PyFormat.AUTO))

--- a/psycopg/psycopg/_queries.py
+++ b/psycopg/psycopg/_queries.py
@@ -380,7 +380,6 @@ def _split_query(
     cur = 0
     pending_pre = b""
     phtype = None
-    ph_index = 0
 
     for m in _re_placeholder.finditer(query):
         m_start, m_end = m.span()
@@ -415,7 +414,7 @@ def _split_query(
             )
 
         # Index or name
-        item: int | str = name.decode(encoding) if (name := m.group(1)) else ph_index
+        item: int | str = name.decode(encoding) if (name := m.group(1)) else len(parts)
 
         if not phtype:
             phtype = type(item)
@@ -425,7 +424,6 @@ def _split_query(
             )
 
         parts.append(QueryPart(pre, item, format))
-        ph_index += 1
 
     # last part (sentinel)
     parts.append(QueryPart(pending_pre + query[cur:], 0, PyFormat.AUTO))

--- a/tests/benchmarks/__init__.py
+++ b/tests/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""pytest-benchmark benchmarks for psycopg."""

--- a/tests/benchmarks/benchmark_split_query.py
+++ b/tests/benchmarks/benchmark_split_query.py
@@ -1,0 +1,58 @@
+"""Benchmarks for query parsing and conversion functions."""
+
+import pytest
+
+from psycopg._queries import _split_query
+
+_report_cols = [f"col_{i}" for i in range(20)]
+
+queries = [
+    pytest.param(
+        b"SELECT id, name, email FROM users WHERE org_id = %s AND active = %s",
+        id="simple-positional",
+    ),
+    pytest.param(
+        b"INSERT INTO events (user_id, type, payload, created_at) "
+        b"VALUES (%s, %s, %s, %s)",
+        id="insert",
+    ),
+    pytest.param(
+        b"SELECT * FROM orders WHERE customer_id = %(customer_id)s"
+        b" AND status = %(status)s AND created_at > %(since)s",
+        id="named",
+    ),
+    pytest.param(
+        b"SELECT * FROM t WHERE a = %(x)s AND b = %(y)s AND c = %(x)s AND d = %(y)s",
+        id="named-repeat",
+    ),
+    pytest.param(
+        b"SELECT * FROM products WHERE name LIKE '%%' || %s || '%%' AND category = %s",
+        id="like-escapes",
+    ),
+    pytest.param(
+        b"INSERT INTO items (a, b, c, d, e) VALUES "
+        + b", ".join(b"(%s, %s, %s, %s, %s)" for _ in range(20)),
+        id="bulk-insert-100params",
+    ),
+    pytest.param(
+        b"SELECT * FROM t WHERE id %% 10 = 0 AND status %% 3 = 1",
+        id="modulo-no-params",
+    ),
+    pytest.param(
+        (
+            f"SELECT {', '.join(_report_cols)} FROM report WHERE "
+            + " AND ".join(f"{c} = %({c})s" for c in _report_cols)
+        ).encode(),
+        id="large-named-20params",
+    ),
+]
+
+
+@pytest.mark.parametrize("query", queries)
+def test_split_query(benchmark, query):
+    benchmark(_split_query, query, "utf-8")
+
+
+@pytest.mark.parametrize("query", queries)
+def test_split_query_no_collapse(benchmark, query):
+    benchmark(_split_query, query, "utf-8", collapse_double_percent=False)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -12,6 +12,17 @@ from psycopg._queries import PostgresQuery, _split_query
         (b"", [(b"", 0, PyFormat.AUTO)]),
         (b"foo bar", [(b"foo bar", 0, PyFormat.AUTO)]),
         (b"foo %% bar", [(b"foo % bar", 0, PyFormat.AUTO)]),
+        (b"foo %%%% bar", [(b"foo %% bar", 0, PyFormat.AUTO)]),
+        (b"foo %%", [(b"foo %", 0, PyFormat.AUTO)]),  # %% at the very end of query
+        (b"%%", [(b"%", 0, PyFormat.AUTO)]),  # %% as the entire query
+        # %% immediately before named placeholder
+        (b"%%%(name)s", [(b"%", "name", PyFormat.AUTO), (b"", 0, PyFormat.AUTO)]),
+        # consecutive %%%% then a placeholder
+        (b"%%%% %s", [(b"%% ", 0, PyFormat.AUTO), (b"", 0, PyFormat.AUTO)]),
+        # placeholder then trailing %%
+        (b"%s %%", [(b"", 0, PyFormat.AUTO), (b" %", 0, PyFormat.AUTO)]),
+        # multiple %% groups separated by text
+        (b"a %% b %% c", [(b"a % b % c", 0, PyFormat.AUTO)]),
         (b"%s", [(b"", 0, PyFormat.AUTO), (b"", 0, PyFormat.AUTO)]),
         (b"%s foo", [(b"", 0, PyFormat.AUTO), (b" foo", 0, PyFormat.AUTO)]),
         (b"%b foo", [(b"", 0, PyFormat.BINARY), (b" foo", 0, PyFormat.AUTO)]),


### PR DESCRIPTION
This PR speeds up `_split_query()` (which, it seems, is called for all queries that involve any sort of placeholder or variable (at least once, given the LRU caches for `_query2pg_*`), so pretty hot in general) by 30% to 66% in a micro-benchmark that exercises only that function. (I can also add the pytest-benchmark file if it could be useful.)

The optimization journey, if you will, is in atomic commits, but can be squashed into a single commit for `master`. 