### PR TITLE
perf: Do less `if X in Y: return Y[X]`

### DIFF
--- a/psycopg/psycopg/_adapters_map.py
+++ b/psycopg/psycopg/_adapters_map.py
@@ -212,8 +212,10 @@ class AdaptersMap:
 
         # Look for the right class, including looking at superclasses
         for scls in cls.__mro__:
-            if scls in dmap:
+            try:
                 return dmap[scls]
+            except KeyError:
+                pass
 
             # If the adapter is not found, look for its name as a string
             fqn = scls.__module__ + "." + scls.__qualname__

--- a/psycopg/psycopg/_capabilities.py
+++ b/psycopg/psycopg/_capabilities.py
@@ -98,9 +98,9 @@ class Capabilities:
 
         The expletive messages, are left to the user.
         """
-        if feature in self._cache:
+        try:
             msg = self._cache[feature]
-        else:
+        except KeyError:
             msg = self._get_unsupported_message(feature, want_version)
             self._cache[feature] = msg
 

--- a/psycopg/psycopg/types/composite.py
+++ b/psycopg/psycopg/types/composite.py
@@ -206,8 +206,10 @@ class RecordBinaryLoader(Loader):
         return tx.load_sequence(record)
 
     def _get_transformer(self, key: tuple[int, ...]) -> abc.Transformer:
-        if key in self._txs:
+        try:
             return self._txs[key]
+        except KeyError:
+            pass
 
         tx = Transformer(self._ctx)
         tx.set_loader_types([*key], self.format)


### PR DESCRIPTION
Use more Python 3.11+ zero-cost exception handling (and technically less race conditions, I guess!)