### PR TITLE
Retain statusmessage after executemany with returning=False

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -17,6 +17,8 @@ Psycopg 3.3.4 (unreleased)
   in C extension (:ticket:`#1280`).
 - Fix client-side adaptation of enums whose name require quotes
   (:ticket:`#1298`).
+- Consistently populate `~Cursor.statusmessage` after `~Cursor.executemany()`
+  (:ticket:`#1302`).
 
 
 Current release

--- a/psycopg/psycopg/_cursor_base.py
+++ b/psycopg/psycopg/_cursor_base.py
@@ -49,7 +49,7 @@ class BaseCursor(Generic[ConnectionType, Row]):
     __slots__ = """
         _conn format _adapters arraysize _closed _results pgresult _pos
         _iresult _rowcount _query _tx _last_query _row_factory _make_row
-        _pgconn _execmany_returning
+        _pgconn _execmany_returning _statusmessage
         __weakref__
         """.split()
 
@@ -79,6 +79,7 @@ class BaseCursor(Generic[ConnectionType, Row]):
         self._pos = 0
         self._iresult = 0
         self._rowcount = -1
+        self._statusmessage: bytes | None = None
         self._query: PostgresQuery | None
         # None if executemany() not executing, True/False according to returning state
         self._execmany_returning: bool | None = None
@@ -178,8 +179,7 @@ class BaseCursor(Generic[ConnectionType, Row]):
 
         `!None` if the cursor doesn't have a result available.
         """
-        msg = self.pgresult.command_status if self.pgresult else None
-        return msg.decode() if msg else None
+        return self._statusmessage.decode() if self._statusmessage else None
 
     def _make_row_maker(self) -> RowMaker[Row]:
         raise NotImplementedError
@@ -525,6 +525,7 @@ class BaseCursor(Generic[ConnectionType, Row]):
             nrows = self.pgresult.command_tuples
             self._rowcount = nrows if nrows is not None else -1
 
+        self._statusmessage = res.command_status
         self._make_row = self._make_row_maker()
 
     def _set_results(self, results: list[PGresult]) -> None:
@@ -540,9 +541,12 @@ class BaseCursor(Generic[ConnectionType, Row]):
                 self._select_current_result(0)
         else:
             # In non-returning case, set rowcount to the cumulated number of
-            # rows of executed queries.
-            for res in results:
-                self._rowcount += res.command_tuples or 0
+            # rows of executed queries. Keep the last result's command_status
+            # so that statusmessage is available after the batch completes.
+            if results:
+                self._statusmessage = results[-1].command_status
+                for res in results:
+                    self._rowcount += res.command_tuples or 0
 
     @classmethod
     def _loaders_changed(

--- a/tests/test_cursor_common.py
+++ b/tests/test_cursor_common.py
@@ -150,6 +150,9 @@ def test_statusmessage(conn):
     cur.execute("select generate_series(1, 10)")
     assert cur.statusmessage == "SELECT 10"
 
+    cur.execute("")
+    assert cur.statusmessage is None
+
     cur.execute("create table statusmessage ()")
     assert cur.statusmessage == "CREATE TABLE"
 
@@ -396,6 +399,26 @@ def test_executemany_rowcount(conn, execmany):
         [(10, "hello"), (20, "world")],
     )
     assert cur.rowcount == 2
+
+
+@pytest.mark.parametrize("returning", [False, True])
+def test_executemany_statusmessage(conn, execmany, returning):
+    cur = conn.cursor()
+    cur.executemany(
+        ph(cur, "insert into execmany(num, data) values (%s, %s)"),
+        [(10, "hello"), (20, "world")],
+        returning=returning,
+    )
+    assert cur.rowcount == (1 if returning else 2)
+    assert cur.statusmessage is not None
+    assert cur.statusmessage.startswith("INSERT")
+
+    cur.executemany(
+        ph(cur, "insert into execmany(num, data) values (%s, %s)"),
+        [],
+        returning=returning,
+    )
+    assert cur.statusmessage is None
 
 
 def test_executemany_returning(conn, execmany):

--- a/tests/test_cursor_common_async.py
+++ b/tests/test_cursor_common_async.py
@@ -148,6 +148,9 @@ async def test_statusmessage(aconn):
     await cur.execute("select generate_series(1, 10)")
     assert cur.statusmessage == "SELECT 10"
 
+    await cur.execute("")
+    assert cur.statusmessage is None
+
     await cur.execute("create table statusmessage ()")
     assert cur.statusmessage == "CREATE TABLE"
 
@@ -398,6 +401,26 @@ async def test_executemany_rowcount(aconn, execmany):
         [(10, "hello"), (20, "world")],
     )
     assert cur.rowcount == 2
+
+
+@pytest.mark.parametrize("returning", [False, True])
+async def test_executemany_statusmessage(aconn, execmany, returning):
+    cur = aconn.cursor()
+    await cur.executemany(
+        ph(cur, "insert into execmany(num, data) values (%s, %s)"),
+        [(10, "hello"), (20, "world")],
+        returning=returning,
+    )
+    assert cur.rowcount == (1 if returning else 2)
+    assert cur.statusmessage is not None
+    assert cur.statusmessage.startswith("INSERT")
+
+    await cur.executemany(
+        ph(cur, "insert into execmany(num, data) values (%s, %s)"),
+        [],
+        returning=returning,
+    )
+    assert cur.statusmessage is None
 
 
 async def test_executemany_returning(aconn, execmany):


### PR DESCRIPTION
After an `executemany()`, `statusmessage` is not set. It gets set as a side effect if returning=True. It seems good to complete the picture populating it consistently.