### PR TITLE
feat(pool): add dedicated_connection()

### DIFF
--- a/psycopg_pool/psycopg_pool/pool.py
+++ b/psycopg_pool/psycopg_pool/pool.py
@@ -191,6 +191,34 @@ class ConnectionPool(Generic[CT], BasePool):
             t1 = monotonic()
             self._stats[self._USAGE_MS] += int(1000.0 * (t1 - t0))
 
+    def dedicated_connection(self, timeout: float | None = None) -> CT:
+        """Return a new connection not managed by the pool.
+
+        The connection is created using the pool's conninfo, connection_class,
+        and configure callback, but the pool does not track it. The caller is
+        responsible for closing it.
+        """
+        conninfo = self._resolve_conninfo()
+        kwargs = self._resolve_kwargs()
+        if timeout:
+            kwargs = kwargs.copy()
+            kwargs["connect_timeout"] = max(round(timeout), 1)
+        conn = self.connection_class.connect(conninfo, **kwargs)
+        if self._configure:
+            try:
+                self._configure(conn)
+            except Exception:
+                conn.close()
+                raise
+            if (status := conn.pgconn.transaction_status) != TransactionStatus.IDLE:
+                sname = TransactionStatus(status).name
+                conn.close()
+                raise e.ProgrammingError(
+                    f"connection left in status {sname} by configure function"
+                    f" {self._configure}: discarded"
+                )
+        return conn
+
     def getconn(self, timeout: float | None = None) -> CT:
         """Obtain a connection from the pool.
 

--- a/psycopg_pool/psycopg_pool/pool_async.py
+++ b/psycopg_pool/psycopg_pool/pool_async.py
@@ -227,6 +227,34 @@ class AsyncConnectionPool(Generic[ACT], BasePool):
             t1 = monotonic()
             self._stats[self._USAGE_MS] += int(1000.0 * (t1 - t0))
 
+    async def dedicated_connection(self, timeout: float | None = None) -> ACT:
+        """Return a new connection not managed by the pool.
+
+        The connection is created using the pool's conninfo, connection_class,
+        and configure callback, but the pool does not track it. The caller is
+        responsible for closing it.
+        """
+        conninfo = await self._resolve_conninfo()
+        kwargs = await self._resolve_kwargs()
+        if timeout:
+            kwargs = kwargs.copy()
+            kwargs["connect_timeout"] = max(round(timeout), 1)
+        conn = await self.connection_class.connect(conninfo, **kwargs)
+        if self._configure:
+            try:
+                await self._configure(conn)
+            except Exception:
+                await conn.close()
+                raise
+            if (status := conn.pgconn.transaction_status) != TransactionStatus.IDLE:
+                sname = TransactionStatus(status).name
+                await conn.close()
+                raise e.ProgrammingError(
+                    f"connection left in status {sname} by configure function"
+                    f" {self._configure}: discarded"
+                )
+        return conn
+
     async def getconn(self, timeout: float | None = None) -> ACT:
         """Obtain a connection from the pool.
 

--- a/tests/pool/test_pool.py
+++ b/tests/pool/test_pool.py
@@ -1177,6 +1177,90 @@ def test_get_config_rotates_connections(dsn):
         p.close()
 
 
+def test_dedicated_connection(dsn):
+    with pool.ConnectionPool(dsn, min_size=1) as p:
+        conn = p.dedicated_connection()
+        try:
+            res = conn.execute("select 1")
+            assert res.fetchone() == (1,)
+            assert getattr(conn, "_pool", None) is None
+        finally:
+            conn.close()
+
+
+def test_dedicated_connection_not_in_stats(dsn):
+    with pool.ConnectionPool(dsn, min_size=1) as p:
+        p.wait(timeout=1.0)
+        stats_before = p.get_stats()
+
+        conn = p.dedicated_connection()
+        try:
+            stats_after = p.get_stats()
+            assert stats_after["connections_num"] == stats_before["connections_num"]
+        finally:
+            conn.close()
+
+
+def test_dedicated_connection_configure(dsn):
+    def configure(conn):
+        with conn.transaction():
+            conn.execute("set default_transaction_read_only to on")
+
+    with pool.ConnectionPool(dsn, min_size=1, configure=configure) as p:
+        conn = p.dedicated_connection()
+        try:
+            res = conn.execute("show default_transaction_read_only")
+            assert res.fetchone()[0] == "on"
+        finally:
+            conn.close()
+
+
+def test_dedicated_connection_survives_pool_close(dsn):
+    with pool.ConnectionPool(dsn, min_size=1) as p:
+        conn = p.dedicated_connection()
+
+    try:
+        res = conn.execute("select 1")
+        assert res.fetchone() == (1,)
+    finally:
+        conn.close()
+
+
+def test_dedicated_connection_configure_bad_state(dsn):
+    def configure(conn):
+        conn.execute("begin")
+
+    with pool.ConnectionPool(dsn, min_size=1, configure=configure) as p:
+        with pytest.raises(psycopg.ProgrammingError, match="configure function"):
+            p.dedicated_connection()
+
+
+def test_dedicated_connection_callable_conninfo(dsn):
+    def get_conninfo():
+        return dsn
+
+    with pool.ConnectionPool(get_conninfo, min_size=1) as p:
+        conn = p.dedicated_connection()
+        try:
+            res = conn.execute("select 1")
+            assert res.fetchone() == (1,)
+        finally:
+            conn.close()
+
+
+def test_dedicated_connection_pool_unaffected(dsn):
+    with pool.ConnectionPool(dsn, min_size=2) as p:
+        p.wait(timeout=1.0)
+        stats_before = p.get_stats()
+
+        conn = p.dedicated_connection()
+        try:
+            stats_after = p.get_stats()
+            assert stats_after["pool_available"] == stats_before["pool_available"]
+        finally:
+            conn.close()
+
+
 @pytest.mark.slow
 def test_get_config_raise_exception(dsn, caplog):
 

--- a/tests/pool/test_pool_async.py
+++ b/tests/pool/test_pool_async.py
@@ -1296,6 +1296,90 @@ async def test_get_config_rotates_connections(dsn):
         await p.close()
 
 
+async def test_dedicated_connection(dsn):
+    async with pool.AsyncConnectionPool(dsn, min_size=1) as p:
+        conn = await p.dedicated_connection()
+        try:
+            res = await conn.execute("select 1")
+            assert (await res.fetchone()) == (1,)
+            assert getattr(conn, "_pool", None) is None
+        finally:
+            await conn.close()
+
+
+async def test_dedicated_connection_not_in_stats(dsn):
+    async with pool.AsyncConnectionPool(dsn, min_size=1) as p:
+        await p.wait(timeout=1.0)
+        stats_before = p.get_stats()
+
+        conn = await p.dedicated_connection()
+        try:
+            stats_after = p.get_stats()
+            assert stats_after["connections_num"] == stats_before["connections_num"]
+        finally:
+            await conn.close()
+
+
+async def test_dedicated_connection_configure(dsn):
+    async def configure(conn):
+        async with conn.transaction():
+            await conn.execute("set default_transaction_read_only to on")
+
+    async with pool.AsyncConnectionPool(dsn, min_size=1, configure=configure) as p:
+        conn = await p.dedicated_connection()
+        try:
+            res = await conn.execute("show default_transaction_read_only")
+            assert (await res.fetchone())[0] == "on"
+        finally:
+            await conn.close()
+
+
+async def test_dedicated_connection_survives_pool_close(dsn):
+    async with pool.AsyncConnectionPool(dsn, min_size=1) as p:
+        conn = await p.dedicated_connection()
+
+    try:
+        res = await conn.execute("select 1")
+        assert (await res.fetchone()) == (1,)
+    finally:
+        await conn.close()
+
+
+async def test_dedicated_connection_configure_bad_state(dsn):
+    async def configure(conn):
+        await conn.execute("begin")
+
+    async with pool.AsyncConnectionPool(dsn, min_size=1, configure=configure) as p:
+        with pytest.raises(psycopg.ProgrammingError, match="configure function"):
+            await p.dedicated_connection()
+
+
+async def test_dedicated_connection_callable_conninfo(dsn):
+    async def get_conninfo():
+        return dsn
+
+    async with pool.AsyncConnectionPool(get_conninfo, min_size=1) as p:
+        conn = await p.dedicated_connection()
+        try:
+            res = await conn.execute("select 1")
+            assert (await res.fetchone()) == (1,)
+        finally:
+            await conn.close()
+
+
+async def test_dedicated_connection_pool_unaffected(dsn):
+    async with pool.AsyncConnectionPool(dsn, min_size=2) as p:
+        await p.wait(timeout=1.0)
+        stats_before = p.get_stats()
+
+        conn = await p.dedicated_connection()
+        try:
+            stats_after = p.get_stats()
+            assert stats_after["pool_available"] == stats_before["pool_available"]
+        finally:
+            await conn.close()
+
+
 @pytest.mark.slow
 async def test_get_config_raise_exception(dsn, caplog):
 

--- a/tests/pool/test_pool_null.py
+++ b/tests/pool/test_pool_null.py
@@ -453,3 +453,14 @@ def test_close_returns(dsn):
         assert not conn.closed
         conn.close()
         assert conn.closed
+
+
+def test_dedicated_connection(dsn):
+    with pool.NullConnectionPool(dsn) as p:
+        conn = p.dedicated_connection()
+        try:
+            res = conn.execute("select 1")
+            assert res.fetchone() == (1,)
+            assert getattr(conn, "_pool", None) is None
+        finally:
+            conn.close()

--- a/tests/pool/test_pool_null_async.py
+++ b/tests/pool/test_pool_null_async.py
@@ -510,3 +510,14 @@ async def test_close_returns(dsn):
         assert not conn.closed
         await conn.close()
         assert conn.closed
+
+
+async def test_dedicated_connection(dsn):
+    async with pool.AsyncNullConnectionPool(dsn) as p:
+        conn = await p.dedicated_connection()
+        try:
+            res = await conn.execute("select 1")
+            assert (await res.fetchone()) == (1,)
+            assert getattr(conn, "_pool", None) is None
+        finally:
+            await conn.close()


### PR DESCRIPTION
## Summary

- Adds `dedicated_connection()` to `ConnectionPool` and `AsyncConnectionPool`
- The method reuses the pool's `conninfo`, `connection_class`, and `configure` callback to open a new connection, but the pool does not track it — no stats, no expiry, no recycling
- The caller is fully responsible for closing it
- `NullConnectionPool` and `AsyncNullConnectionPool` inherit the method for free

## Motivation

Closes #1244

Users with a nicely configured pool (callable conninfo, custom `connection_class`, `configure` callback) currently have to duplicate that configuration to open a standalone long-lived connection (e.g. for `LISTEN`). This method lets the pool act as a config factory without taking ownership of the connection.

Mirrors the design of [`bb8::Pool::dedicated_connection`](https://docs.rs/bb8/latest/bb8/struct.Pool.html#method.dedicated_connection) in Rust.

## Usage

```python
# Sync
conn = pool.dedicated_connection()
try:
    for notify in conn.notifies():
        handle(notify)
finally:
    conn.close()

# Async
conn = await pool.dedicated_connection()
try:
    async for notify in conn.notifies():
        await handle(notify)
finally:
    await conn.close()
```

## Test plan

- Basic usability (`select 1`, verify `conn._pool is None`)
- Stats unaffected (`connections_num` unchanged)
- `configure` callback applied correctly
- `configure` bad state raises `ProgrammingError` and closes the connection cleanly (no resource leak)
- Callable `conninfo` resolved correctly
- Pool's own connections unaffected after call
- Connection survives pool close
- Null pool variants covered

🤖 Generated with [Claude Code](https://claude.ai/claude-code)