### PR TITLE
feat(pool): add dedicated_connection() method

### DIFF
--- a/docs/api/pool.rst
+++ b/docs/api/pool.rst
@@ -263,6 +263,9 @@ The `!ConnectionPool` class
 
    .. automethod:: getconn
    .. automethod:: putconn
+   .. automethod:: dedicated_connection
+
+      .. versionadded:: 3.3.2
 
 
 Pool exceptions

--- a/docs/api/pool.rst
+++ b/docs/api/pool.rst
@@ -265,7 +265,7 @@ The `!ConnectionPool` class
    .. automethod:: putconn
    .. automethod:: dedicated_connection
 
-      .. versionadded:: 3.3.2
+      .. versionadded:: 3.4.0
 
 
 Pool exceptions

--- a/docs/news_pool.rst
+++ b/docs/news_pool.rst
@@ -10,6 +10,13 @@
 Current release
 ---------------
 
+psycopg_pool 3.3.2 (unreleased)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Add `~ConnectionPool.dedicated_connection()` method to obtain a connection
+  configured like the pool's but not managed by it (:ticket:`#1244`).
+
+
 psycopg_pool 3.3.1
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/news_pool.rst
+++ b/docs/news_pool.rst
@@ -7,15 +7,18 @@
 ``psycopg_pool`` release notes
 ==============================
 
-Current release
+Future releases
 ---------------
 
-psycopg_pool 3.3.2 (unreleased)
+psycopg_pool 3.4.0 (unreleased)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Add `~ConnectionPool.dedicated_connection()` method to obtain a connection
   configured like the pool's but not managed by it (:ticket:`#1244`).
 
+
+Current release
+---------------
 
 psycopg_pool 3.3.1
 ^^^^^^^^^^^^^^^^^^

--- a/psycopg_pool/psycopg_pool/pool.py
+++ b/psycopg_pool/psycopg_pool/pool.py
@@ -340,18 +340,20 @@ class ConnectionPool(Generic[CT], BasePool):
         returned to the pool on close. The caller is responsible for closing
         it. The pool's `!conninfo`, `!kwargs`, `!connection_class`, and
         `!configure` callback are applied as for any pool-managed connection.
+
+        The connection still contributes to the `!connections_num` and
+        `!connections_errors` stats counters.
         """
+        self._stats[self._CONNECTIONS_NUM] += 1
         conninfo = self._resolve_conninfo()
         kwargs = self._resolve_kwargs()
-        conn = self.connection_class.connect(conninfo, **kwargs)
         try:
-            if self._configure:
-                self._configure(conn)
-                if (status := conn.pgconn.transaction_status) != TransactionStatus.IDLE:
-                    sname = TransactionStatus(status).name
-                    raise e.ProgrammingError(
-                        f"connection left in status {sname} by configure function {self._configure}: discarded"
-                    )
+            conn = self.connection_class.connect(conninfo, **kwargs)
+        except CLIENT_EXCEPTIONS:
+            self._stats[self._CONNECTIONS_ERRORS] += 1
+            raise
+        try:
+            self._do_configure(conn)
         except BaseException:
             conn.close()
             raise
@@ -650,17 +652,23 @@ class ConnectionPool(Generic[CT], BasePool):
 
         conn._pool = self
 
-        if self._configure:
-            self._configure(conn)
-            if (status := conn.pgconn.transaction_status) != TransactionStatus.IDLE:
-                sname = TransactionStatus(status).name
-                raise e.ProgrammingError(
-                    f"connection left in status {sname} by configure function {self._configure}: discarded"
-                )
+        self._do_configure(conn)
 
         # Set an expiry date, with some randomness to avoid mass reconnection
         self._set_connection_expiry_date(conn)
         return conn
+
+    def _do_configure(self, conn: CT) -> None:
+        """Run the `!configure` callback on a new connection, if set."""
+        if not self._configure:
+            return
+
+        self._configure(conn)
+        if (status := conn.pgconn.transaction_status) != TransactionStatus.IDLE:
+            sname = TransactionStatus(status).name
+            raise e.ProgrammingError(
+                f"connection left in status {sname} by configure function {self._configure}: discarded"
+            )
 
     def _resolve_conninfo(self) -> str:
         """Resolve conninfo (static string, sync callable, or async callable)."""

--- a/psycopg_pool/psycopg_pool/pool.py
+++ b/psycopg_pool/psycopg_pool/pool.py
@@ -331,6 +331,32 @@ class ConnectionPool(Generic[CT], BasePool):
 
         self._putconn(conn, from_getconn=False)
 
+    def dedicated_connection(self) -> CT:
+        """Return a new connection configured like the pool's connections,
+        but not managed by the pool.
+
+        The pool does not track the returned connection: it is not counted in
+        the pool size, not subject to `!max_lifetime` or `!max_idle`, and not
+        returned to the pool on close. The caller is responsible for closing
+        it. The pool's `!conninfo`, `!kwargs`, `!connection_class`, and
+        `!configure` callback are applied as for any pool-managed connection.
+        """
+        conninfo = self._resolve_conninfo()
+        kwargs = self._resolve_kwargs()
+        conn = self.connection_class.connect(conninfo, **kwargs)
+        try:
+            if self._configure:
+                self._configure(conn)
+                if (status := conn.pgconn.transaction_status) != TransactionStatus.IDLE:
+                    sname = TransactionStatus(status).name
+                    raise e.ProgrammingError(
+                        f"connection left in status {sname} by configure function {self._configure}: discarded"
+                    )
+        except BaseException:
+            conn.close()
+            raise
+        return conn
+
     def drain(self) -> None:
         """
         Remove all the connections from the pool and create new ones.

--- a/psycopg_pool/psycopg_pool/pool_async.py
+++ b/psycopg_pool/psycopg_pool/pool_async.py
@@ -378,19 +378,20 @@ class AsyncConnectionPool(Generic[ACT], BasePool):
         returned to the pool on close. The caller is responsible for closing
         it. The pool's `!conninfo`, `!kwargs`, `!connection_class`, and
         `!configure` callback are applied as for any pool-managed connection.
+
+        The connection still contributes to the `!connections_num` and
+        `!connections_errors` stats counters.
         """
+        self._stats[self._CONNECTIONS_NUM] += 1
         conninfo = await self._resolve_conninfo()
         kwargs = await self._resolve_kwargs()
-        conn = await self.connection_class.connect(conninfo, **kwargs)
         try:
-            if self._configure:
-                await self._configure(conn)
-                if (status := conn.pgconn.transaction_status) != TransactionStatus.IDLE:
-                    sname = TransactionStatus(status).name
-                    raise e.ProgrammingError(
-                        f"connection left in status {sname}"
-                        f" by configure function {self._configure}: discarded"
-                    )
+            conn = await self.connection_class.connect(conninfo, **kwargs)
+        except CLIENT_EXCEPTIONS:
+            self._stats[self._CONNECTIONS_ERRORS] += 1
+            raise
+        try:
+            await self._do_configure(conn)
         except BaseException:
             await conn.close()
             raise
@@ -726,18 +727,24 @@ class AsyncConnectionPool(Generic[ACT], BasePool):
 
         conn._pool = self
 
-        if self._configure:
-            await self._configure(conn)
-            if (status := conn.pgconn.transaction_status) != TransactionStatus.IDLE:
-                sname = TransactionStatus(status).name
-                raise e.ProgrammingError(
-                    f"connection left in status {sname} by configure function"
-                    f" {self._configure}: discarded"
-                )
+        await self._do_configure(conn)
 
         # Set an expiry date, with some randomness to avoid mass reconnection
         self._set_connection_expiry_date(conn)
         return conn
+
+    async def _do_configure(self, conn: ACT) -> None:
+        """Run the `!configure` callback on a new connection, if set."""
+        if not self._configure:
+            return
+
+        await self._configure(conn)
+        if (status := conn.pgconn.transaction_status) != TransactionStatus.IDLE:
+            sname = TransactionStatus(status).name
+            raise e.ProgrammingError(
+                f"connection left in status {sname} by configure function"
+                f" {self._configure}: discarded"
+            )
 
     async def _resolve_conninfo(self) -> str:
         """Resolve conninfo (static string, sync callable, or async callable)."""

--- a/psycopg_pool/psycopg_pool/pool_async.py
+++ b/psycopg_pool/psycopg_pool/pool_async.py
@@ -369,6 +369,33 @@ class AsyncConnectionPool(Generic[ACT], BasePool):
 
         await self._putconn(conn, from_getconn=False)
 
+    async def dedicated_connection(self) -> ACT:
+        """Return a new connection configured like the pool's connections,
+        but not managed by the pool.
+
+        The pool does not track the returned connection: it is not counted in
+        the pool size, not subject to `!max_lifetime` or `!max_idle`, and not
+        returned to the pool on close. The caller is responsible for closing
+        it. The pool's `!conninfo`, `!kwargs`, `!connection_class`, and
+        `!configure` callback are applied as for any pool-managed connection.
+        """
+        conninfo = await self._resolve_conninfo()
+        kwargs = await self._resolve_kwargs()
+        conn = await self.connection_class.connect(conninfo, **kwargs)
+        try:
+            if self._configure:
+                await self._configure(conn)
+                if (status := conn.pgconn.transaction_status) != TransactionStatus.IDLE:
+                    sname = TransactionStatus(status).name
+                    raise e.ProgrammingError(
+                        f"connection left in status {sname}"
+                        f" by configure function {self._configure}: discarded"
+                    )
+        except BaseException:
+            await conn.close()
+            raise
+        return conn
+
     async def drain(self) -> None:
         """
         Remove all the connections from the pool and create new ones.

--- a/tests/pool/test_pool.py
+++ b/tests/pool/test_pool.py
@@ -231,13 +231,10 @@ def test_dedicated_connection_configure(dsn):
     with pool.ConnectionPool(dsn, min_size=1, configure=configure) as p:
         p.wait(timeout=1.0)
         inits_before = inits
-        conn = p.dedicated_connection()
-        try:
+        with p.dedicated_connection() as conn:
             assert inits == inits_before + 1
             res = conn.execute("show default_transaction_read_only")
             assert res.fetchone()[0] == "on"
-        finally:
-            conn.close()
 
 
 def test_dedicated_connection_configure_badstate(dsn):

--- a/tests/pool/test_pool.py
+++ b/tests/pool/test_pool.py
@@ -244,6 +244,7 @@ def test_dedicated_connection_configure(dsn):
 
 
 def test_dedicated_connection_configure_badstate(dsn):
+
     def configure(conn):
         conn.execute("begin")
 

--- a/tests/pool/test_pool.py
+++ b/tests/pool/test_pool.py
@@ -246,7 +246,11 @@ def test_dedicated_connection_configure_badstate(dsn):
         conn.execute("begin")
 
     with pool.ConnectionPool(dsn, min_size=0, max_size=1, configure=configure) as p:
-        with pytest.raises(psycopg.ProgrammingError):
+        # PostgreSQL raises ProgrammingError from the transaction-status check;
+        # CockroachDB rejects the leftover transaction with ActiveSqlTransaction.
+        with pytest.raises(
+            (psycopg.ProgrammingError, psycopg.errors.ActiveSqlTransaction)
+        ):
             p.dedicated_connection()
 
 

--- a/tests/pool/test_pool.py
+++ b/tests/pool/test_pool.py
@@ -201,6 +201,57 @@ def test_configure(dsn):
             assert res.fetchone()[0] == "on"
 
 
+def test_dedicated_connection(dsn):
+    with pool.ConnectionPool(dsn, min_size=1) as p:
+        p.wait(timeout=1.0)
+        stats_before = p.get_stats()
+        conn = p.dedicated_connection()
+        try:
+            assert getattr(conn, "_pool", None) is None
+            res = conn.execute("select 1")
+            assert res.fetchone() == (1,)
+        finally:
+            conn.close()
+        # Pool counters and size are unaffected.
+        stats_after = p.get_stats()
+        assert stats_after["connections_num"] == stats_before["connections_num"]
+        assert stats_after["pool_size"] == stats_before["pool_size"]
+        # Pool's own connections still work after a dedicated connection use.
+        with p.connection() as conn:
+            res = conn.execute("select 2")
+            assert res.fetchone() == (2,)
+
+
+def test_dedicated_connection_configure(dsn):
+    inits = 0
+
+    def configure(conn):
+        nonlocal inits
+        inits += 1
+        with conn.transaction():
+            conn.execute("set default_transaction_read_only to on")
+
+    with pool.ConnectionPool(dsn, min_size=1, configure=configure) as p:
+        p.wait(timeout=1.0)
+        inits_before = inits
+        conn = p.dedicated_connection()
+        try:
+            assert inits == inits_before + 1
+            res = conn.execute("show default_transaction_read_only")
+            assert res.fetchone()[0] == "on"
+        finally:
+            conn.close()
+
+
+def test_dedicated_connection_configure_badstate(dsn):
+    def configure(conn):
+        conn.execute("begin")
+
+    with pool.ConnectionPool(dsn, min_size=0, max_size=1, configure=configure) as p:
+        with pytest.raises(psycopg.ProgrammingError):
+            p.dedicated_connection()
+
+
 def test_reset(dsn):
     resets = 0
 

--- a/tests/pool/test_pool.py
+++ b/tests/pool/test_pool.py
@@ -205,16 +205,13 @@ def test_dedicated_connection(dsn):
     with pool.ConnectionPool(dsn, min_size=1) as p:
         p.wait(timeout=1.0)
         stats_before = p.get_stats()
-        conn = p.dedicated_connection()
-        try:
+        with p.dedicated_connection() as conn:
             assert getattr(conn, "_pool", None) is None
             res = conn.execute("select 1")
             assert res.fetchone() == (1,)
-        finally:
-            conn.close()
-        # Pool counters and size are unaffected.
+        # The connection is counted in the stats but not in the pool size.
         stats_after = p.get_stats()
-        assert stats_after["connections_num"] == stats_before["connections_num"]
+        assert stats_after["connections_num"] == stats_before["connections_num"] + 1
         assert stats_after["pool_size"] == stats_before["pool_size"]
         # Pool's own connections still work after a dedicated connection use.
         with p.connection() as conn:

--- a/tests/pool/test_pool_async.py
+++ b/tests/pool/test_pool_async.py
@@ -249,7 +249,9 @@ async def test_dedicated_connection_configure_badstate(dsn):
     ) as p:
         # PostgreSQL raises ProgrammingError from the transaction-status check;
         # CockroachDB rejects the leftover transaction with ActiveSqlTransaction.
-        with pytest.raises((psycopg.ProgrammingError, psycopg.errors.ActiveSqlTransaction)):
+        with pytest.raises(
+            (psycopg.ProgrammingError, psycopg.errors.ActiveSqlTransaction)
+        ):
             await p.dedicated_connection()
 
 

--- a/tests/pool/test_pool_async.py
+++ b/tests/pool/test_pool_async.py
@@ -205,16 +205,13 @@ async def test_dedicated_connection(dsn):
     async with pool.AsyncConnectionPool(dsn, min_size=1) as p:
         await p.wait(timeout=1.0)
         stats_before = p.get_stats()
-        conn = await p.dedicated_connection()
-        try:
+        async with await p.dedicated_connection() as conn:
             assert getattr(conn, "_pool", None) is None
             res = await conn.execute("select 1")
             assert (await res.fetchone()) == (1,)
-        finally:
-            await conn.close()
-        # Pool counters and size are unaffected.
+        # The connection is counted in the stats but not in the pool size.
         stats_after = p.get_stats()
-        assert stats_after["connections_num"] == stats_before["connections_num"]
+        assert stats_after["connections_num"] == stats_before["connections_num"] + 1
         assert stats_after["pool_size"] == stats_before["pool_size"]
         # Pool's own connections still work after a dedicated connection use.
         async with p.connection() as conn:

--- a/tests/pool/test_pool_async.py
+++ b/tests/pool/test_pool_async.py
@@ -201,6 +201,59 @@ async def test_configure(dsn):
             assert (await res.fetchone())[0] == "on"
 
 
+async def test_dedicated_connection(dsn):
+    async with pool.AsyncConnectionPool(dsn, min_size=1) as p:
+        await p.wait(timeout=1.0)
+        stats_before = p.get_stats()
+        conn = await p.dedicated_connection()
+        try:
+            assert getattr(conn, "_pool", None) is None
+            res = await conn.execute("select 1")
+            assert (await res.fetchone()) == (1,)
+        finally:
+            await conn.close()
+        # Pool counters and size are unaffected.
+        stats_after = p.get_stats()
+        assert stats_after["connections_num"] == stats_before["connections_num"]
+        assert stats_after["pool_size"] == stats_before["pool_size"]
+        # Pool's own connections still work after a dedicated connection use.
+        async with p.connection() as conn:
+            res = await conn.execute("select 2")
+            assert (await res.fetchone()) == (2,)
+
+
+async def test_dedicated_connection_configure(dsn):
+    inits = 0
+
+    async def configure(conn):
+        nonlocal inits
+        inits += 1
+        async with conn.transaction():
+            await conn.execute("set default_transaction_read_only to on")
+
+    async with pool.AsyncConnectionPool(dsn, min_size=1, configure=configure) as p:
+        await p.wait(timeout=1.0)
+        inits_before = inits
+        conn = await p.dedicated_connection()
+        try:
+            assert inits == inits_before + 1
+            res = await conn.execute("show default_transaction_read_only")
+            assert (await res.fetchone())[0] == "on"
+        finally:
+            await conn.close()
+
+
+async def test_dedicated_connection_configure_badstate(dsn):
+    async def configure(conn):
+        await conn.execute("begin")
+
+    async with pool.AsyncConnectionPool(
+        dsn, min_size=0, max_size=1, configure=configure
+    ) as p:
+        with pytest.raises(psycopg.ProgrammingError):
+            await p.dedicated_connection()
+
+
 async def test_reset(dsn):
     resets = 0
 

--- a/tests/pool/test_pool_async.py
+++ b/tests/pool/test_pool_async.py
@@ -231,13 +231,10 @@ async def test_dedicated_connection_configure(dsn):
     async with pool.AsyncConnectionPool(dsn, min_size=1, configure=configure) as p:
         await p.wait(timeout=1.0)
         inits_before = inits
-        conn = await p.dedicated_connection()
-        try:
+        async with await p.dedicated_connection() as conn:
             assert inits == inits_before + 1
             res = await conn.execute("show default_transaction_read_only")
             assert (await res.fetchone())[0] == "on"
-        finally:
-            await conn.close()
 
 
 async def test_dedicated_connection_configure_badstate(dsn):

--- a/tests/pool/test_pool_async.py
+++ b/tests/pool/test_pool_async.py
@@ -247,7 +247,9 @@ async def test_dedicated_connection_configure_badstate(dsn):
     async with pool.AsyncConnectionPool(
         dsn, min_size=0, max_size=1, configure=configure
     ) as p:
-        with pytest.raises(psycopg.ProgrammingError):
+        # PostgreSQL raises ProgrammingError from the transaction-status check;
+        # CockroachDB rejects the leftover transaction with ActiveSqlTransaction.
+        with pytest.raises((psycopg.ProgrammingError, psycopg.errors.ActiveSqlTransaction)):
             await p.dedicated_connection()
 
 


### PR DESCRIPTION
Adds `ConnectionPool.dedicated_connection()` / `AsyncConnectionPool.dedicated_connection()`, which returns a connection configured with the pool's `conninfo`, `kwargs`, `connection_class`, and `configure` callback, but not managed by the pool: it is not counted in the pool size, not subject to `max_lifetime` or `max_idle`, and not returned to the pool on close. The caller is responsible for closing it.

Closes #1244, addressing the maintainer comment that this is a not-bad use case from the initial pool design phase.