### PR TITLE
Make libpq paths configurable through environment variables

### DIFF
--- a/docs/basic/install.rst
+++ b/docs/basic/install.rst
@@ -176,7 +176,13 @@ In order to perform a local installation you need some prerequisites:
 - a C compiler,
 - Python development headers (e.g. the ``python3-dev`` package).
 - PostgreSQL client development headers (e.g. the ``libpq-dev`` package).
-- The :program:`pg_config` program available in the :envvar:`PATH`.
+
+The build will need access to the include folder and lib folder of libpq.
+On most systems this can be determined through the :program:`pg_config` if it
+is in the :envvar:`PATH`.
+Alternatively the path to :program:`pg_config` can be either configured via the
+:envvar:`PSYCOPG_PG_CONFIG` or the paths can directly be configured via
+:envvar:`PSYCOPG_PG_INCLUDEDIR` and :envvar:`PSYCOPG_PG_LIBDIR`.
 
 You **must be able** to troubleshoot an extension build, for instance you must
 be able to read your compiler's error message. If you are not, please don't

--- a/psycopg_c/build_backend/psycopg_build_ext.py
+++ b/psycopg_c/build_backend/psycopg_build_ext.py
@@ -17,12 +17,24 @@ log = logging.getLogger(__name__)
 
 
 def get_config(what: str) -> str:
-    pg_config = "pg_config"
+    env_map = {
+        "includedir": "PSYCOPG_PG_INCLUDEDIR",
+        "libdir": "PSYCOPG_PG_LIBDIR",
+    }
+    if envvar := env_map.get(what):
+        if value := os.environ.get(envvar):
+            return value
+
+    pg_config = os.environ.get("PSYCOPG_PG_CONFIG", "pg_config")
     try:
         out = sp.run([pg_config, f"--{what}"], stdout=sp.PIPE, check=True)
     except Exception as e:
-        log.error(f"couldn't run {pg_config!r} --{what}: %s", e)
-        raise
+        msg = (
+            f"couldn't determine PostgreSQL {what}: set {env_map.get(what, 'PSYCOPG_PG_CONFIG')} "
+            f"or make {pg_config!r} available"
+        )
+        log.error("%s: %s", msg, e)
+        raise RuntimeError(msg) from e
     else:
         return out.stdout.strip().decode()
 

--- a/psycopg_c/build_backend/psycopg_build_ext.py
+++ b/psycopg_c/build_backend/psycopg_build_ext.py
@@ -30,7 +30,8 @@ def get_config(what: str) -> str:
         out = sp.run([pg_config, f"--{what}"], stdout=sp.PIPE, check=True)
     except Exception as e:
         msg = (
-            f"couldn't determine PostgreSQL {what}: set {env_map.get(what, 'PSYCOPG_PG_CONFIG')} "
+            f"couldn't determine PostgreSQL {what}: "
+            f"set {env_map.get(what, 'PSYCOPG_PG_CONFIG')} "
             f"or make {pg_config!r} available"
         )
         log.error("%s: %s", msg, e)


### PR DESCRIPTION
I am a maintainer of [open-vcpkg/python-registry](https://github.com/open-vcpkg/python-registry). Recently, `vcpkg` moved to the meson build system for `libpq` and since, `pg_config` is no longer built as part of that port.
This pull request proposes to make it possible to build the psycopg c extension without `pg_config` and instead provide include and libdir via environment variables.

New variables:

`PSYCOPG_PG_INCLUDEDIR `: will have precedence for the includedir
`PSYCOPG_PG_LIBDIR `: will have precedence for the libdir
`PSYCOPG_PG_CONFIG`: path to `pg_config`, will have precedence over `pg_config` on `PATH`

Reference: https://github.com/open-vcpkg/python-registry/pull/240