### PR TITLE
Minor performance, mypy upgrade, and other small fixes

### DIFF
--- a/.github/workflows/3rd-party-tests.yml
+++ b/.github/workflows/3rd-party-tests.yml
@@ -11,6 +11,8 @@ on:
     paths-ignore:
       - "docs/*"
       - "tools/*"
+    tags-ignore:
+      - "**"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,8 @@ on:
     branches:
       # This should match the DOC3_BRANCH value in the psycopg-website Makefile
       - master
+    tags-ignore:
+      - "**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,8 @@ on:
     # on.<push|pull_request>.<branches|tags> GitHub Actions docs.
     branches:
       - "**"
+    tags-ignore:
+      - "**"
   pull_request:
   schedule:
     - cron: '18 6 * * *'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,8 @@ on:
     # on.<push|pull_request>.<branches|tags> GitHub Actions docs.
     branches:
       - "**"
+    tags-ignore:
+      - "**"
     paths-ignore:
       - README.rst
       - "docs/*"

--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,12 @@ Now hack away! You can run the tests using::
     export PSYCOPG_TEST_DSN="dbname=psycopg_test"
     pytest
 
+If some of the tests fail on your local host, it may be helpful to exclude the
+`proxy`, `subprocess`, and/or `timing` tests to get a clean test run, for
+example::
+
+     pytest  -m 'not proxy and not timing'
+
 The project includes some `pre-commit`__ hooks to check that the code is valid
 according to the project coding convention. Please make sure to install them
 by running::

--- a/psycopg/psycopg/types/array.py
+++ b/psycopg/psycopg/types/array.py
@@ -172,8 +172,6 @@ class ListDumper(BaseListDumper):
                         tokens.append(b"NULL")
                     else:
                         if needs_quotes(ad):
-                            if not isinstance(ad, bytes):
-                                ad = bytes(ad)
                             ad = b'"' + self._re_esc.sub(rb"\\\1", ad) + b'"'
                         tokens.append(ad)
                 else:

--- a/psycopg/psycopg/types/net.py
+++ b/psycopg/psycopg/types/net.py
@@ -6,6 +6,7 @@ Adapters for network types.
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING, TypeAlias
 from collections.abc import Callable
 
@@ -36,6 +37,7 @@ PGSQL_AF_INET = 2
 PGSQL_AF_INET6 = 3
 IPV4_PREFIXLEN = 32
 IPV6_PREFIXLEN = 128
+_SLASH_RE = re.compile(b"/")
 
 
 class _LazyIpaddress:
@@ -126,13 +128,10 @@ class _LazyIpaddressLoader(Loader, _LazyIpaddress):
 
 class InetLoader(_LazyIpaddressLoader):
     def load(self, data: Buffer) -> Address | Interface:
-        if isinstance(data, memoryview):
-            data = bytes(data)
-
-        if b"/" in data:
-            return ip_interface(data.decode())
+        if _SLASH_RE.search(data):
+            return ip_interface(str(data, "utf-8"))
         else:
-            return ip_address(data.decode())
+            return ip_address(str(data, "utf-8"))
 
 
 class InetBinaryLoader(_LazyIpaddressLoader):
@@ -158,10 +157,7 @@ class InetBinaryLoader(_LazyIpaddressLoader):
 
 class CidrLoader(_LazyIpaddressLoader):
     def load(self, data: Buffer) -> Network:
-        if isinstance(data, memoryview):
-            data = bytes(data)
-
-        return ip_network(data.decode())
+        return ip_network(str(data, "utf-8"))
 
 
 class CidrBinaryLoader(_LazyIpaddressLoader):

--- a/psycopg/psycopg/types/net.py
+++ b/psycopg/psycopg/types/net.py
@@ -174,8 +174,6 @@ class CidrBinaryLoader(_LazyIpaddressLoader):
         else:
             return IPv6Network((packed, prefix))
 
-        return ip_network(data.decode())
-
 
 def register_default_adapters(context: AdaptContext) -> None:
     adapters = context.adapters

--- a/psycopg/psycopg/types/numeric.py
+++ b/psycopg/psycopg/types/numeric.py
@@ -267,9 +267,7 @@ class Float8BinaryLoader(Loader):
 
 class NumericLoader(Loader):
     def load(self, data: Buffer) -> Decimal:
-        if isinstance(data, memoryview):
-            data = bytes(data)
-        return Decimal(data.decode())
+        return Decimal(str(data, "utf-8"))
 
 
 DEC_DIGITS = 4  # decimal digits per Postgres "digit"

--- a/psycopg/psycopg/types/string.py
+++ b/psycopg/psycopg/types/string.py
@@ -112,9 +112,7 @@ class TextLoader(Loader):
 
     def load(self, data: Buffer) -> bytes | str:
         if self._encoding:
-            if isinstance(data, memoryview):
-                data = bytes(data)
-            return data.decode(self._encoding)
+            return str(data, self._encoding)
         else:
             # return bytes for SQL_ASCII db
             if not isinstance(data, bytes):

--- a/psycopg/psycopg/types/uuid.py
+++ b/psycopg/psycopg/types/uuid.py
@@ -43,7 +43,7 @@ class UUIDLoader(Loader):
             from uuid import UUID
 
     def load(self, data: Buffer) -> uuid.UUID:
-        return UUID((bytes(data) if isinstance(data, memoryview) else data).decode())
+        return UUID(str(data, "utf-8"))
 
 
 class UUIDBinaryLoader(UUIDLoader):

--- a/psycopg/pyproject.toml
+++ b/psycopg/pyproject.toml
@@ -71,7 +71,7 @@ pool = [
 test = [
     "anyio >= 4.0",
     # Mypy >= 1.19 depends on librt, not available for PyPy.
-    "mypy >= 1.19.0; implementation_name != \"pypy\"",
+    "mypy >= 2.1.0; implementation_name != \"pypy\"",
     "pproxy >= 2.7",
     "pytest >= 6.2.5",
     "pytest-cov >= 3.0",
@@ -86,7 +86,7 @@ dev = [
     "flake8 >= 4.0",
     "isort[colors] >= 6.0",
     "isort-psycopg",
-    "mypy >= 1.19.0",
+    "mypy >= 2.1.0",
     "pre-commit >= 4.0.1",
     "types-setuptools >= 57.4",
     "types-shapely >= 2.0",

--- a/psycopg_pool/pyproject.toml
+++ b/psycopg_pool/pyproject.toml
@@ -56,7 +56,7 @@ content-type = "text/x-rst"
 [project.optional-dependencies]
 test = [
     "anyio >= 4.0",
-    "mypy >= 1.14",
+    "mypy >= 2.1.0",
     "pproxy >= 2.7",
     "pytest >= 6.2.5",
     "pytest-cov >= 3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,6 @@ files = [
 ]
 warn_unused_ignores = true
 show_error_codes = true
-disable_bytearray_promotion = true
-disable_memoryview_promotion = true
 strict = true
 exclude = '''(?x)(
     ^ docs/lib/.*\.py

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -10,7 +10,7 @@ importlib-metadata == 1.4
 
 # From the 'test' extra
 anyio == 4.0
-mypy == 1.19.0
+mypy == 2.1.0
 pproxy == 2.7.0
 pytest == 6.2.5
 pytest-cov == 3.0.0


### PR DESCRIPTION
Branch includes the following:

- avoid copying memoryview to bytes where unnecessary
- update README.md HACKING section to suggest skipping tests that might fail locally (subprocess, proxy, timing)
- add explicit tags-ignore to workflows (may fix #1224: the docs still say it shouldn't be necessary, but it shouldn't hurt even if it doesn't help)
- upgrade mypy to version 2.1.0 (it's much faster and handles bytes properly by default; all typing tests and linting still pass locally)
- fixes one sometimes-failing test. 