### PR TITLE
Fix Dumping non-None values with no NoneType dumper registered in Python implementation

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -15,6 +15,8 @@ Psycopg 3.3.5 (unreleased)
 
 - Discard prepared statements upon :sql:`ALTER *` or `DISCARD *`
   (:ticket:`#1307`).
+- Fix `!ProgrammingError` when dumping non-`!None` values with
+  no `!NoneType` dumper registered in python implementation (:ticket:`#1325`).
 - Fix `!wait_selector` wait function to not raise `!KeyError`
   (:ticket:`#1327`).
 

--- a/psycopg/psycopg/_py_transformer.py
+++ b/psycopg/psycopg/_py_transformer.py
@@ -65,6 +65,7 @@ class Transformer(AdaptContext):
 
     def __init__(self, context: AdaptContext | None = None):
         self._pgresult = self.types = self.formats = None
+        self._none_oid = -1
 
         # WARNING: don't store context, or you'll create a loop with the Cursor
         if context:
@@ -187,12 +188,16 @@ class Transformer(AdaptContext):
                     out[i] = self._row_dumpers[i].dump(param)
             return out
 
-        types = [self._get_none_oid()] * nparams
+        types = [-1] * nparams
         pqformats = [TEXT] * nparams
 
         for i in range(nparams):
             if (param := params[i]) is None:
+                if self._none_oid < 0:
+                    self._none_oid = self._get_none_oid()
+                types[i] = self._none_oid
                 continue
+
             dumper = self.get_dumper(param, formats[i])
             out[i] = dumper.dump(param)
             types[i] = dumper.oid
@@ -267,16 +272,9 @@ class Transformer(AdaptContext):
 
     def _get_none_oid(self) -> int:
         try:
-            return self._none_oid
-        except AttributeError:
-            pass
-
-        try:
-            rv = self._none_oid = self._adapters.get_dumper(NoneType, PY_TEXT).oid
+            return self._adapters.get_dumper(NoneType, PY_TEXT).oid
         except KeyError:
             raise e.InterfaceError("None dumper not found")
-
-        return rv
 
     def get_dumper_by_oid(self, oid: int, format: pq.Format) -> abc.Dumper:
         """

--- a/psycopg/psycopg/_py_transformer.py
+++ b/psycopg/psycopg/_py_transformer.py
@@ -193,9 +193,7 @@ class Transformer(AdaptContext):
 
         for i in range(nparams):
             if (param := params[i]) is None:
-                if self._none_oid < 0:
-                    self._none_oid = self._get_none_oid()
-                types[i] = self._none_oid
+                types[i] = self._get_none_oid()
                 continue
 
             dumper = self.get_dumper(param, formats[i])
@@ -271,10 +269,12 @@ class Transformer(AdaptContext):
             return dumper
 
     def _get_none_oid(self) -> int:
-        try:
-            return self._adapters.get_dumper(NoneType, PY_TEXT).oid
-        except KeyError:
-            raise e.InterfaceError("None dumper not found")
+        if self._none_oid < 0:
+            try:
+                self._none_oid = self._adapters.get_dumper(NoneType, PY_TEXT).oid
+            except KeyError:
+                raise e.InterfaceError("None dumper not found")
+        return self._none_oid
 
     def get_dumper_by_oid(self, oid: int, format: pq.Format) -> abc.Dumper:
         """

--- a/tests/test_adapt.py
+++ b/tests/test_adapt.py
@@ -59,6 +59,15 @@ def test_quote_none(data, result, global_adapters):
     assert dumper.quote(data) == result
 
 
+@pytest.mark.parametrize("fmt_in", PyFormat)
+def test_no_none_dumper_registered(dsn, fmt_in):
+    with psycopg.connect(dsn, context=make_str_map()) as conn:
+        with conn.cursor() as cur:
+            cur.execute(f"SELECT %{fmt_in.value}", ["not_none"])
+            with pytest.raises(e.ProgrammingError, match="NoneType"):
+                cur.execute(f"SELECT %{fmt_in.value}", [None])
+
+
 def test_register_dumper_by_class(conn):
     dumper = make_dumper("x")
     assert conn.adapters.get_dumper(MyStr, PyFormat.TEXT) is not dumper
@@ -561,3 +570,17 @@ def make_bin_loader(suffix):
     cls = make_loader(suffix)
     cls.format = pq.Format.BINARY
     return cls
+
+
+def make_str_map():
+    from psycopg._oids import INVALID_OID
+
+    # Construct a minimal AdaptersMap to no none dumper bug
+    str_map = psycopg.adapt.AdaptersMap()
+    invalid_oid_loader = psycopg.adapters.get_loader(INVALID_OID, pq.Format.TEXT)
+    assert invalid_oid_loader is not None
+    str_map.adapters.register_loader(INVALID_OID, invalid_oid_loader)
+    str_map.register_dumper(str, StrDumper)
+    str_map.register_dumper(str, StrBinaryDumper)
+
+    return str_map


### PR DESCRIPTION
Fixes #1325. 

Should ideally be merged before #1316.  Not sure how far back it should be backported, but I can check if you like.  If I should target a maintenance branch instead of master, let me know. 