### PR TITLE
Bump OpenSSL version to 3.5.7 for vuln remediation

### DIFF
--- a/.github/workflows/build-and-cache-libpq.yml
+++ b/.github/workflows/build-and-cache-libpq.yml
@@ -50,7 +50,7 @@ env:
   # https://github.com/microsoft/vcpkg/discussions/25622
 
   # Latest release: https://www.openssl.org/source/
-  OPENSSL_VERSION: "3.5.6"
+  OPENSSL_VERSION: "3.5.7"
 
   # A string to differentiate build cacke keys to allow building different
   # flavours of libpq in different branches without mixups. Currently used to

--- a/.github/workflows/packages-bin.yml
+++ b/.github/workflows/packages-bin.yml
@@ -25,7 +25,7 @@ env:
   # https://github.com/microsoft/vcpkg/discussions/25622
 
   # Latest release: https://www.openssl.org/source/
-  OPENSSL_VERSION: "3.5.4"
+  OPENSSL_VERSION: "3.5.7"
 
   # A string to differentiate build cacke keys to allow building different
   # flavours of libpq in different branches without mixups. Currently used to


### PR DESCRIPTION
3.5.7
https://github.com/openssl/openssl/releases/tag/openssl-3.5.7


> Major changes between OpenSSL 3.5.6 and OpenSSL 3.5.7 [9 Jun 2026]
> OpenSSL 3.5.7 is a security patch release. The most severe CVE fixed in this release is High.
> 
> This release incorporates the following bug fixes and mitigations:
> 
> Fixed heap use-after-free in PKCS7_verify(). ([CVE-2026-45447](https://openssl-library.org/news/vulnerabilities/#CVE-2026-45447))
> 
> Fixed CMS AuthEnvelopedData processing may accept forged messages. ([CVE-2026-34182](https://openssl-library.org/news/vulnerabilities/#CVE-2026-34182))
> 
> Fixed unbounded memory growth in the QUIC PATH_CHALLENGE handler. ([CVE-2026-34183](https://openssl-library.org/news/vulnerabilities/#CVE-2026-34183))
> 
> Fixed NULL pointer dereference in QUIC server initial packet handling. ([CVE-2026-42764](https://openssl-library.org/news/vulnerabilities/#CVE-2026-42764))
> 
> Fixed AES-OCB IV ignored on EVP_Cipher() path. ([CVE-2026-45445](https://openssl-library.org/news/vulnerabilities/#CVE-2026-45445))
> 
> Fixed possible heap buffer overflow in ASN.1 multibyte string conversion. ([CVE-2026-7383](https://openssl-library.org/news/vulnerabilities/#CVE-2026-7383))
> 
> Fixed out-of-bounds read in CMS password-based decryption. ([CVE-2026-9076](https://openssl-library.org/news/vulnerabilities/#CVE-2026-9076))
> 
> Fixed heap buffer over-read in ASN.1 content parsing. ([CVE-2026-34180](https://openssl-library.org/news/vulnerabilities/#CVE-2026-34180))
> 
> Fixed PKCS#12 files with PBMAC1 are accepted with short HMAC keys. ([CVE-2026-34181](https://openssl-library.org/news/vulnerabilities/#CVE-2026-34181))
> 
> Fixed possible NULL dereference in password-dased CMS decryption. ([CVE-2026-42766](https://openssl-library.org/news/vulnerabilities/#CVE-2026-42766))
> 
> Fixed NULL pointer dereference in CRMF EncryptedValue decryption. ([CVE-2026-42767](https://openssl-library.org/news/vulnerabilities/#CVE-2026-42767))
> 
> Fixed multi-RecipientInfo Bleichenbacher Oracle in CMS_decrypt() and PKCS7_decrypt(). ([CVE-2026-42768](https://openssl-library.org/news/vulnerabilities/#CVE-2026-42768))
> 
> Fixed trust anchor substitution via cert/issuer typo in CMP rootCaKeyUpdate. ([CVE-2026-42769](https://openssl-library.org/news/vulnerabilities/#CVE-2026-42769))
> 
> Fixed FFC-DH peer validation uses attacker-supplied q. ([CVE-2026-42770](https://openssl-library.org/news/vulnerabilities/#CVE-2026-42770))
> 
> Fixed incorrect tag processing for empty messages in AES-GCM-SIV and AES-SIV modes. ([CVE-2026-45446](https://openssl-library.org/news/vulnerabilities/#CVE-2026-45446))
> 
> Major changes between OpenSSL 3.5.5 and OpenSSL 3.5.6 [7 Apr 2026]
> OpenSSL 3.5.6 is a security patch release. The most severe CVE fixed in this release is Moderate.
> 
> This release incorporates the following bug fixes and mitigations:
> 
> Fixed incorrect failure handling in RSA KEM RSASVE encapsulation. ([CVE-2026-31790](https://openssl-library.org/news/vulnerabilities/#CVE-2026-31790))
> 
> Fixed loss of key agreement group tuple structure when the DEFAULT keyword is used in the server-side configuration of the key-agreement group list. ([CVE-2026-2673](https://openssl-library.org/news/vulnerabilities/#CVE-2026-2673))
> 
> Fixed potential use-after-free in DANE client code. ([CVE-2026-28387](https://openssl-library.org/news/vulnerabilities/#CVE-2026-28387))
> 
> Fixed NULL pointer dereference when processing a delta CRL. ([CVE-2026-28388](https://openssl-library.org/news/vulnerabilities/#CVE-2026-28388))
> 
> Fixed possible NULL dereference when processing CMS KeyAgreeRecipientInfo. ([CVE-2026-28389](https://openssl-library.org/news/vulnerabilities/#CVE-2026-28389))
> 
> Fixed possible NULL dereference when processing CMS KeyTransportRecipientInfo. ([CVE-2026-28390](https://openssl-library.org/news/vulnerabilities/#CVE-2026-28390))
> 
> Fixed heap buffer overflow in hexadecimal conversion. ([CVE-2026-31789](https://openssl-library.org/news/vulnerabilities/#CVE-2026-31789))