### PR TITLE
Fix cancel generator

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -19,6 +19,8 @@ Psycopg 3.3.5 (unreleased)
   no `!NoneType` dumper registered in python implementation (:ticket:`#1325`).
 - Fix `!wait_selector` wait function to not raise `!KeyError`
   (:ticket:`#1327`).
+- Fix `Connection.cancel_safe()` sometimes hanging or raising
+  `errors.CancellationTimeout` when it should have succeeded (:ticket:`#1335`).
 
 
 Current release

--- a/psycopg/psycopg/generators.py
+++ b/psycopg/psycopg/generators.py
@@ -112,16 +112,20 @@ def _connect(conninfo: str, *, timeout: float = 0.0) -> PQGenConn[PGconn]:
 
 def _cancel(cancel_conn: PGcancelConn, *, timeout: float = 0.0) -> PQGenConn[None]:
     deadline = monotonic() + timeout if timeout else 0.0
+    wait = WAIT_W
+
     while True:
-        if deadline and monotonic() > deadline:
-            raise e.CancellationTimeout("cancellation timeout expired")
+        socket = cancel_conn.socket
+        while not (yield socket, wait):
+            if deadline and monotonic() > deadline:
+                raise e.CancellationTimeout("cancellation timeout expired")
 
         if (status := cancel_conn.poll()) == POLL_OK:
             break
         elif status == POLL_READING:
-            yield cancel_conn.socket, WAIT_R
+            wait = WAIT_R
         elif status == POLL_WRITING:
-            yield cancel_conn.socket, WAIT_W
+            wait = WAIT_W
         elif status == POLL_FAILED:
             raise e.OperationalError(
                 f"cancellation failed: {cancel_conn.get_error_message()}"

--- a/psycopg/psycopg/waiting.py
+++ b/psycopg/psycopg/waiting.py
@@ -292,13 +292,14 @@ def wait_select(gen: PQGen[RV], fileno: int, interval: float = 0.0) -> RV:
 
 
 if hasattr(selectors, "EpollSelector"):
-    _epoll_evmasks = {
-        WAIT_R: select.EPOLLONESHOT | select.EPOLLIN,
-        WAIT_W: select.EPOLLONESHOT | select.EPOLLOUT,
-        WAIT_RW: select.EPOLLONESHOT | select.EPOLLIN | select.EPOLLOUT,
-    }
+    _epoll_evmasks = [
+        0,  # unused
+        select.EPOLLONESHOT | select.EPOLLIN,  # WAIT_R
+        select.EPOLLONESHOT | select.EPOLLOUT,  # WAIT_W
+        select.EPOLLONESHOT | select.EPOLLIN | select.EPOLLOUT,  # WAIT_RW
+    ]
 else:
-    _epoll_evmasks = {}
+    _epoll_evmasks = []
 
 
 def wait_epoll(gen: PQGen[RV], fileno: int, interval: float = 0.0) -> RV:
@@ -349,14 +350,15 @@ def wait_epoll(gen: PQGen[RV], fileno: int, interval: float = 0.0) -> RV:
 
 
 if hasattr(selectors, "PollSelector"):
-    _poll_evmasks = {
-        WAIT_R: select.POLLIN,
-        WAIT_W: select.POLLOUT,
-        WAIT_RW: select.POLLIN | select.POLLOUT,
-    }
+    _poll_evmasks = [
+        0,  # unused
+        select.POLLIN,  # WAIT_R
+        select.POLLOUT,  # WAIT_W
+        select.POLLIN | select.POLLOUT,  # WAIT_RW
+    ]
     POLL_BAD = ~(select.POLLIN | select.POLLOUT)
 else:
-    _poll_evmasks = {}
+    _poll_evmasks = []
 
 
 def wait_poll(gen: PQGen[RV], fileno: int, interval: float = 0.0) -> RV:

--- a/psycopg_c/psycopg_c/_psycopg/generators.pyx
+++ b/psycopg_c/psycopg_c/_psycopg/generators.pyx
@@ -89,21 +89,27 @@ def cancel(pq.PGcancelConn cancel_conn, *, timeout: float = 0.0) -> PQGenConn[No
     cdef libpq.PGcancelConn *pgcancelconn_ptr = cancel_conn.pgcancelconn_ptr
     cdef int status
     cdef double deadline = 0.0
+    wait = WAIT_W
+    cdef int socket
 
     if timeout:
         deadline = monotonic() + timeout
 
     while True:
-        if deadline and monotonic() > deadline:
-            raise e.CancellationTimeout("cancellation timeout expired")
+        with nogil:
+            socket = libpq.PQcancelSocket(pgcancelconn_ptr)
+        while not (yield socket, wait):
+            if deadline and monotonic() > deadline:
+                raise e.CancellationTimeout("cancellation timeout expired")
         with nogil:
             status = libpq.PQcancelPoll(pgcancelconn_ptr)
+
         if status == libpq.PGRES_POLLING_OK:
             break
         elif status == libpq.PGRES_POLLING_READING:
-            yield libpq.PQcancelSocket(pgcancelconn_ptr), WAIT_R
+            wait = WAIT_R
         elif status == libpq.PGRES_POLLING_WRITING:
-            yield libpq.PQcancelSocket(pgcancelconn_ptr), WAIT_W
+            wait = WAIT_W
         elif status == libpq.PGRES_POLLING_FAILED:
             raise e.OperationalError(
                 f"cancellation failed: {cancel_conn.get_error_message()}"

--- a/tests/test_concurrency_async.py
+++ b/tests/test_concurrency_async.py
@@ -61,7 +61,7 @@ async def test_concurrent_execution(aconn_cls, dsn):
 async def canceller(aconn, errors):
     try:
         await asyncio.sleep(0.5)
-        await aconn.cancel_safe()
+        await aconn.cancel_safe(timeout=5)
     except Exception as exc:
         errors.append(exc)
 

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -55,7 +55,7 @@ def test_cancel(pgconn, conn, generators):
     cancel_conn = pgconn.cancel_conn()
     assert cancel_conn.status != pq.ConnStatus.BAD
     cancel_conn.start()
-    gen = generators.cancel(cancel_conn)
+    gen = generators.cancel(cancel_conn, timeout=5)
     waiting.wait_conn(gen)
     assert cancel_conn.status == pq.ConnStatus.OK
 


### PR DESCRIPTION
Fixes #1335.  Noticed that `test_cancel` sometimes hung.  It's because the cancel generator wasn't actually waiting on the correct state of the socket for two reasons:

1) it wasn't actually checking the ready value sent by wait
2) it wasn't waiting for write readiness before the first poll

See https://www.postgresql.org/docs/17/libpq-cancel.html#LIBPQ-PQCANCELSTART for (2)

Should probably be backported to all maintained major releases. 

This fixes both issues.  The existing cancel test covers it, but it's possible a test that more reliably fails could be written by wrapping the cancel generator and checking the values sent yielded (though I'm not 100%). 

I haven't filed an issue yet, but I'll try to do that tomorrow.   ~~The news item is kind of sparse.  Let me know what you'd like to see there.~~

EDIT: lint CI was complaining about an unrelated file and an unrelated part of generators.pyx, so I fixed that and in the process fixed another maybe-bug.  Interestingly, my local wasn't complaining, so maybe I need to update some of the linting tools. 