### PR TITLE
Fix connect generator

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -19,6 +19,8 @@ Psycopg 3.3.5 (unreleased)
   no `!NoneType` dumper registered in python implementation (:ticket:`#1325`).
 - Fix `!wait_selector` wait function to not raise `!KeyError`
   (:ticket:`#1327`).
+- Fix `Connection.connect()` sometimes hanging or raising
+  `errors.CancellationTimeout` when it should have succeeded (:ticket:`#1338`).
 
 
 Current release

--- a/psycopg/psycopg/generators.py
+++ b/psycopg/psycopg/generators.py
@@ -74,27 +74,28 @@ def _connect(conninfo: str, *, timeout: float = 0.0) -> PQGenConn[PGconn]:
 
     conn = pq.PGconn.connect_start(conninfo.encode())
     logger.debug("connection started: %s", conn)
+    if conn.status == BAD:
+        encoding = conninfo_encoding(conninfo)
+        raise e.OperationalError(
+            f"connection is bad: {conn.get_error_message(encoding)}", pgconn=conn
+        )
+    wait = WAIT_W
     while True:
-        if conn.status == BAD:
-            encoding = conninfo_encoding(conninfo)
-            raise e.OperationalError(
-                f"connection is bad: {conn.get_error_message(encoding)}", pgconn=conn
-            )
+        socket = conn.socket
+
+        while not (yield socket, wait):
+            if deadline and monotonic() > deadline:
+                raise e.ConnectionTimeout("connection timeout expired")
 
         status = conn.connect_poll()
         logger.debug("connection polled: %s", conn)
 
-        if status == POLL_READING or status == POLL_WRITING:
-            wait = WAIT_R if status == POLL_READING else WAIT_W
-            while True:
-                ready = yield conn.socket, wait
-                if deadline and monotonic() > deadline:
-                    raise e.ConnectionTimeout("connection timeout expired")
-                if ready:
-                    break
-
-        elif status == POLL_OK:
+        if status == POLL_OK:
             break
+        elif status == POLL_READING:
+            wait = WAIT_R
+        elif status == POLL_WRITING:
+            wait = WAIT_W
         elif status == POLL_FAILED:
             encoding = conninfo_encoding(conninfo)
             raise e.OperationalError(

--- a/psycopg_c/psycopg_c/_psycopg/generators.pyx
+++ b/psycopg_c/psycopg_c/_psycopg/generators.pyx
@@ -36,39 +36,40 @@ def connect(conninfo: str, *, timeout: float = 0.0) -> PQGenConn[abc.PGconn]:
     cdef libpq.PGconn *pgconn_ptr = conn._pgconn_ptr
     cdef int conn_status = libpq.PQstatus(pgconn_ptr)
     cdef int poll_status
-    cdef object wait, ready
+    cdef object wait
     cdef double deadline = 0.0
+    cdef int socket
+
+    logger.debug("connection started: %s", conn)
+
+    if conn_status == libpq.CONNECTION_BAD:
+        encoding = conninfo_encoding(conninfo)
+        raise e.OperationalError(
+            f"connection is bad: {conn.get_error_message(encoding)}",
+            pgconn=conn
+        )
 
     if timeout:
         deadline = monotonic() + timeout
 
-    logger.debug("connection started: %s", conn)
+    wait = WAIT_W
     while True:
-        if conn_status == libpq.CONNECTION_BAD:
-            encoding = conninfo_encoding(conninfo)
-            raise e.OperationalError(
-                f"connection is bad: {conn.get_error_message(encoding)}",
-                pgconn=conn
-            )
+        with nogil:
+            socket = libpq.PQsocket(pgconn_ptr)
+        while not (yield socket, wait):
+            if deadline and monotonic() > deadline:
+                raise e.ConnectionTimeout("connection timeout expired")
 
         with nogil:
             poll_status = libpq.PQconnectPoll(pgconn_ptr)
         logger.debug("connection polled: %s", conn)
 
-        if (
-            poll_status == libpq.PGRES_POLLING_READING
-            or poll_status == libpq.PGRES_POLLING_WRITING
-        ):
-            wait = WAIT_R if poll_status == libpq.PGRES_POLLING_READING else WAIT_W
-            while True:
-                ready = yield (libpq.PQsocket(pgconn_ptr), wait)
-                if deadline and monotonic() > deadline:
-                    raise e.ConnectionTimeout("connection timeout expired")
-                if ready:
-                    break
-
-        elif poll_status == libpq.PGRES_POLLING_OK:
+        if poll_status == libpq.PGRES_POLLING_OK:
             break
+        elif poll_status == libpq.PGRES_POLLING_READING:
+            wait = WAIT_R
+        elif poll_status == libpq.PGRES_POLLING_WRITING:
+            wait = WAIT_W
         elif poll_status == libpq.PGRES_POLLING_FAILED:
             encoding = conninfo_encoding(conninfo)
             raise e.OperationalError(

--- a/tests/fix_db.py
+++ b/tests/fix_db.py
@@ -200,7 +200,7 @@ def conn(conn_cls, dsn, request, tracefile):
     """Return a `Connection` connected to the ``--test-dsn`` database."""
     check_connection_version(request.node)
 
-    conn = conn_cls.connect(dsn)
+    conn = conn_cls.connect(dsn, connect_timeout=10)
     with maybe_trace(conn.pgconn, tracefile, request.function):
         yield conn
     conn.close()
@@ -223,7 +223,7 @@ async def aconn(dsn, aconn_cls, request, tracefile):
     """Return an `AsyncConnection` connected to the ``--test-dsn`` database."""
     check_connection_version(request.node)
 
-    conn = await aconn_cls.connect(dsn)
+    conn = await aconn_cls.connect(dsn, connect_timeout=10)
     with maybe_trace(conn.pgconn, tracefile, request.function):
         yield conn
     await conn.close()
@@ -268,7 +268,7 @@ def svcconn(conn_cls, session_dsn):
     """
     Return a session `Connection` connected to the ``--test-dsn`` database.
     """
-    conn = conn_cls.connect(session_dsn, autocommit=True)
+    conn = conn_cls.connect(session_dsn, autocommit=True, connect_timeout=10)
     yield conn
     conn.close()
 


### PR DESCRIPTION
Fixes #1338 

Also some minor performance boost:

1.  only get the socket after calling poll (not everytime the wait func sends a reply)
2.  don't double check the value of poll
3.  don't check the connection status in the loop (poll handles this)

for 3, see the [docs](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PQCONNECTSTARTPARAMS):

> At any time during connection, the status of the connection can be checked by calling [PQstatus](https://www.postgresql.org/docs/current/libpq-status.html#LIBPQ-PQSTATUS). If this call returns CONNECTION_BAD, then the connection procedure has failed; if the call returns CONNECTION_OK, then the connection is ready. Both of these states are equally detectable from the return value of PQconnectPoll, described above.
