### PR TITLE
test: make async test_leak less flakey

### DIFF
--- a/tests/test_cursor_async.py
+++ b/tests/test_cursor_async.py
@@ -9,6 +9,9 @@ from psycopg import errors as e
 from psycopg import pq, rows
 from psycopg.adapt import PyFormat
 
+if True:  # ASYNC
+    from asyncio import sleep
+
 
 async def test_default_cursor(aconn):
     cur = aconn.cursor()
@@ -101,6 +104,9 @@ async def test_leak(aconn_cls, dsn, faker, fmt, fmt_out, fetch, row_factory, gc)
     gc.collect()
     for i in range(3):
         await work()
+        if True:  # ASYNC
+            # loop.remove_reader/writer needs to cancel the callback handle
+            await sleep(0)
         gc.collect()
         n.append(gc.count())
 

--- a/tests/test_cursor_client_async.py
+++ b/tests/test_cursor_client_async.py
@@ -7,6 +7,9 @@ from psycopg import rows
 
 from .fix_crdb import crdb_encoding
 
+if True:  # ASYNC
+    from asyncio import sleep
+
 
 @pytest.fixture
 async def aconn(aconn, anyio_backend):
@@ -111,6 +114,9 @@ async def test_leak(aconn_cls, dsn, faker, fetch, row_factory, gc):
     gc.collect()
     for i in range(3):
         await work()
+        if True:  # ASYNC
+            # loop.remove_reader/writer needs to cancel the callback handle
+            await sleep(0)
         gc.collect()
         n.append(gc.count())
 

--- a/tests/test_cursor_raw_async.py
+++ b/tests/test_cursor_raw_async.py
@@ -7,6 +7,9 @@ from psycopg.adapt import PyFormat
 
 from ._test_cursor import ph
 
+if True:  # ASYNC
+    from asyncio import sleep
+
 
 @pytest.fixture
 async def aconn(aconn, anyio_backend):
@@ -105,6 +108,9 @@ async def test_leak(aconn_cls, dsn, faker, fmt, fmt_out, fetch, row_factory, gc)
     gc.collect()
     for i in range(3):
         await work()
+        if True:  # ASYNC
+            # loop.remove_reader/writer needs to cancel the callback handle
+            await sleep(0)
         gc.collect()
         n.append(gc.count())
     assert n[0] == n[1] == n[2], f"objects leaked: {n[1] - n[0]}, {n[2] - n[1]}"


### PR DESCRIPTION
This one failed very occasionally, but with my new work on #1331 (which I'll get up tomorrow), it fails in CI quite a lot, especially on windows. 

This fixes the flakiness. 