### PR TITLE
namedtuple_row: rename duplicate column names instead of crashing (#1348)

### DIFF
--- a/psycopg/psycopg/rows.py
+++ b/psycopg/psycopg/rows.py
@@ -142,7 +142,9 @@ def namedtuple_row(cursor: BaseCursor[Any, Any]) -> RowMaker[NamedTuple]:
 @functools.lru_cache(512)
 def _make_nt(enc: str, *names: bytes) -> type[NamedTuple]:
     snames = tuple(_as_python_identifier(n.decode(enc)) for n in names)
-    return namedtuple("Row", snames)  # type: ignore[return-value]
+    # ``rename`` renames duplicate columns (e.g. ``SELECT a.*, b.*`` on a join)
+    # to positional ``_N`` names instead of raising ``ValueError``.
+    return namedtuple("Row", snames, rename=True)  # type: ignore[return-value]
 
 
 def class_row(cls: type[T]) -> BaseRowFactory[T]:

--- a/tests/test_rows.py
+++ b/tests/test_rows.py
@@ -68,6 +68,15 @@ def test_namedtuple_row(conn):
     assert r3.f_eur == 5
 
 
+def test_make_nt_duplicate_columns():
+    # gh-1348: duplicate column names (e.g. `SELECT a.*, b.*` on a join) must
+    # not raise; the duplicates are renamed to positional _N names.
+    rows._make_nt.cache_clear()
+    nt = rows._make_nt("utf-8", b"id", b"name", b"id")
+    assert nt._fields == ("id", "name", "_2")
+    assert tuple(nt("a", "b", "c")) == ("a", "b", "c")
+
+
 def test_class_row(conn):
     cur = conn.cursor(row_factory=rows.class_row(Person))
     cur.execute("select 'John' as first, 'Doe' as last")


### PR DESCRIPTION
## Summary

Fixes #1348. `namedtuple_row` raises `ValueError: Encountered duplicate field name` when a result has two columns sharing a name — a common, legitimate pattern such as `SELECT a.*, b.*` on a join where both sides have a same-named column:

```python
# with a cursor whose result has duplicate column names:
cur.row_factory = namedtuple_row
cur.execute("SELECT 1 AS id, 2 AS id")
cur.fetchone()   # ValueError: Encountered duplicate field name: 'id'
```

`dict_row`, `class_row`, and `kwargs_row` all handle the identical input gracefully; only `namedtuple_row` crashes.

## Fix

Pass `rename=True` to `namedtuple()` in `_make_nt`, so duplicate (and otherwise invalid) names are renamed to positional `_N` names — consistent with the docstring's note that field names are taken "with some mangling to deal with invalid names". All columns remain accessible (by position for the renamed ones).

`_make_nt("utf-8", b"id", b"name", b"id")._fields == ("id", "name", "_2")`.

## Verification

- Added `tests/test_rows.py::test_make_nt_duplicate_columns` (no DB needed; exercises `_make_nt` directly). It fails on `master` (`ValueError`) and passes here.
- Verified directly: on `master`, `_make_nt` with a duplicate name raises `ValueError`; with this change it returns fields `('id', 'name', '_2')`, and normal / invalid-identifier inputs are unchanged.
- `black` / `flake8` clean; `mypy` clean on `rows.py`.

*(The full suite needs a live PostgreSQL; the fix and its regression were verified via direct `_make_nt` calls, which require no connection.)*

---

*Disclosure: prepared with AI assistance; reviewed and verified locally.*
