### PR TITLE
Detect recursive lists in the array dumpers' dump path (#1350)

### DIFF
--- a/psycopg/psycopg/types/array.py
+++ b/psycopg/psycopg/types/array.py
@@ -158,7 +158,11 @@ class ListDumper(BaseListDumper):
         tokens: list[Buffer] = []
         needs_quotes = _get_needs_quotes_regexp(self.delimiter).search
 
-        def dump_list(obj: list[Any]) -> None:
+        def dump_list(obj: list[Any], seen: set[int]) -> None:
+            if id(obj) in seen:
+                raise e.DataError("cannot dump a recursive list")
+            seen.add(id(obj))
+
             if not obj:
                 tokens.append(b"{}")
                 return
@@ -166,7 +170,7 @@ class ListDumper(BaseListDumper):
             tokens.append(b"{")
             for item in obj:
                 if isinstance(item, list):
-                    dump_list(item)
+                    dump_list(item, seen)
                 elif item is not None:
                     if (ad := self._dump_item(item)) is None:
                         tokens.append(b"NULL")
@@ -181,7 +185,7 @@ class ListDumper(BaseListDumper):
 
             tokens[-1] = b"}"
 
-        dump_list(obj)
+        dump_list(obj, set())
 
         return b"".join(tokens)
 
@@ -249,14 +253,17 @@ class ListBinaryDumper(BaseListDumper):
         dims: list[int] = []
         hasnull = 0
 
-        def calc_dims(L: list[Any]) -> None:
+        def calc_dims(L: list[Any], seen: set[int]) -> None:
             if isinstance(L, self.cls):
+                if id(L) in seen:
+                    raise e.DataError("cannot dump a recursive list")
+                seen.add(id(L))
                 if not L:
                     raise e.DataError("lists cannot contain empty lists")
                 dims.append(len(L))
-                calc_dims(L[0])
+                calc_dims(L[0], seen)
 
-        calc_dims(obj)
+        calc_dims(obj, set())
 
         def dump_list(L: list[Any], dim: int) -> None:
             nonlocal hasnull

--- a/tests/types/test_array.py
+++ b/tests/types/test_array.py
@@ -296,6 +296,29 @@ def test_dump_list_no_comma_separator(conn):
     assert got == "{(3,4),(1,2);(5,4),(3,2)}"
 
 
+@pytest.mark.parametrize("fmt_in", PyFormat)
+def test_dump_recursive_list_with_oid(fmt_in):
+    # gh-1350: a self-referential list must raise DataError (not RecursionError)
+    # even when the dumper's oid is already set - e.g. via COPY set_types(),
+    # which bypasses the get_key()/upgrade() step where cycle detection lives.
+    from psycopg.types.array import ListBinaryDumper, ListDumper
+    from psycopg.types.numeric import Int2BinaryDumper, Int2Dumper
+
+    tx = Transformer()
+    if fmt_in == PyFormat.BINARY:
+        dumper: Any = ListBinaryDumper(list, tx)
+        dumper.sub_dumper = Int2BinaryDumper(int, tx)
+    else:
+        dumper = ListDumper(list, tx)
+        dumper.sub_dumper = Int2Dumper(int, tx)
+    dumper.oid = builtins["int2"].array_oid
+
+    recursive: list[Any] = []
+    recursive.append(recursive)
+    with pytest.raises(psycopg.errors.DataError):
+        dumper.dump(recursive)
+
+
 @pytest.mark.crdb_skip("geometric types")
 def test_load_array_no_comma_separator(conn):
     cur = conn.execute("select '{(2,2),(1,1);(5,6),(3,4)}'::box[]")


### PR DESCRIPTION
## Summary

Fixes #1350. A self-referential list raises `RecursionError` (instead of the module's `DataError: cannot dump a recursive list`) when the list dumper's `oid` is already set:

```python
from psycopg.types.array import ListDumper
d = ListDumper(list)
d.oid = 1007          # e.g. reused via COPY set_types()
a = []; a.append(a)
d.dump(a)             # RecursionError
```

## Root cause

Cycle detection lives in `BaseListDumper._flatiter`, which is only reached through `get_key()`/`upgrade()` (the dumper-preparation step). When the dumper already has an `oid` — e.g. reused via `Transformer.set_dumper_types()` in a `COPY` block — that step is skipped, so `dump()` recurses directly over the list with no cycle check.

## Fix

Track visited list `id()`s in the recursive helpers of both list dumpers — `ListDumper.dump()`'s `dump_list()` and `ListBinaryDumper.dump()`'s `calc_dims()` — raising the same `DataError("cannot dump a recursive list")` as `_flatiter`. This keeps the pre-set-`oid` path consistent with the normal path (which already rejects recursive/shared lists).

## Verification

- Added `tests/types/test_array.py::test_dump_recursive_list_with_oid` (both `PyFormat`s, no DB needed).
- Verified directly: on `master`, both the text and binary dumpers raise `RecursionError`; with this change both raise `DataError`. Normal nested lists (`[[1],[2]]`, `[1,2,3]`, `[]`) still dump correctly.
- `black` / `flake8` / `mypy` clean on the changed files.

*(The full suite needs a live PostgreSQL; the fix and its regression were verified via direct dumper calls, which require no connection.)*

---

*Disclosure: prepared with AI assistance; reviewed and verified locally.*
