### PR TITLE
dev: fix some linting issues

### DIFF
--- a/psycopg/psycopg/_compat.py
+++ b/psycopg/psycopg/_compat.py
@@ -33,24 +33,27 @@ else:
 if sys.version_info >= (3, 14):
     from string.templatelib import Interpolation, Template
 else:
+    from typing import Generic, Literal
     from dataclasses import dataclass
+
+    T = TypeVar("T")
 
     class Template:
         strings: tuple[str]
-        interpolations: tuple[Interpolation]
+        interpolations: tuple[Interpolation[Any]]
 
-        def __new__(cls, *args: str | Interpolation) -> Self:
+        def __new__(cls, *args: str | Interpolation[Any]) -> Self:
             return cls()
 
-        def __iter__(self) -> Iterator[str | Interpolation]:
+        def __iter__(self) -> Iterator[str | Interpolation[Any]]:
             return
             yield
 
     @dataclass
-    class Interpolation:
-        value: Any
+    class Interpolation(Generic[T]):
+        value: T
         expression: str
-        conversion: str | None
+        conversion: Literal["a", "r", "s"] | None
         format_spec: str
 
 

--- a/psycopg/psycopg/_tstrings.py
+++ b/psycopg/psycopg/_tstrings.py
@@ -40,7 +40,7 @@ class TemplateProcessor:
         self._process_template(self.template)
         self.query = b"".join(self._chunks)
 
-    def _check_template_format(self, item: Interpolation, want_fmt: str) -> None:
+    def _check_template_format(self, item: Interpolation[Any], want_fmt: str) -> None:
         if item.format_spec == want_fmt:
             return
         fmt = f":{item.format_spec}" if item.format_spec else ""
@@ -94,7 +94,7 @@ class TemplateProcessor:
                 else:
                     self._process_client_variable(item, fmt)
 
-    def _process_server_variable(self, item: Interpolation, fmt: str) -> None:
+    def _process_server_variable(self, item: Interpolation[Any], fmt: str) -> None:
         try:
             pyfmt = PyFormat(fmt)
         except ValueError:
@@ -107,7 +107,7 @@ class TemplateProcessor:
         self.params.append(item.value)
         self._chunks.append(b"$%d" % len(self.params))
 
-    def _process_client_variable(self, item: Interpolation, fmt: str) -> None:
+    def _process_client_variable(self, item: Interpolation[Any], fmt: str) -> None:
         try:
             PyFormat(fmt)
         except ValueError:
@@ -120,7 +120,7 @@ class TemplateProcessor:
         self._chunks.append(param)
         self.params.append(param)
 
-    def _process_composable(self, item: Interpolation) -> None:
+    def _process_composable(self, item: Interpolation[Any]) -> None:
         if isinstance(item.value, sql.Identifier):
             self._check_template_format(item, FMT_IDENT)
             self._chunks.append(item.value.as_bytes(self._tx))

--- a/psycopg_c/build_backend/psycopg_build_ext.py
+++ b/psycopg_c/build_backend/psycopg_build_ext.py
@@ -38,6 +38,7 @@ class psycopg_build_ext(build_ext):
         # MSVC requires an explicit "libpq"
         libpq = "pq" if sys.platform != "win32" else "libpq"
 
+        assert self.distribution.ext_modules is not None
         for ext in self.distribution.ext_modules:
             ext.libraries.append(libpq)
             ext.include_dirs.append(get_config("includedir"))


### PR DESCRIPTION
Caused by:
- mypy upgrade to version 2.2
- types-setuptools upgrade to 83

I opted to just add an assert to psycopg_c/build_backend/psycopg_build_ext.py because I assume you want it to fail hard if `self.distribution.ext_modules is None`