### PR TITLE
Raise DataError instead of ValueError for an invalid enum label

### DIFF
--- a/psycopg/psycopg/types/enum.py
+++ b/psycopg/psycopg/types/enum.py
@@ -174,7 +174,12 @@ def register_enum(
 
 @cache
 def _make_enum(name: str, labels: tuple[str, ...]) -> Enum:
-    return Enum(name.title(), labels, module=__name__)
+    try:
+        return Enum(name.title(), labels, module=__name__)
+    except ValueError as ex:
+        raise e.DataError(
+            f"cannot create a Python enum for the {name!r} type: {ex}"
+        ) from ex
 
 
 @cache

--- a/tests/types/test_enum.py
+++ b/tests/types/test_enum.py
@@ -7,7 +7,7 @@ from psycopg import errors as e
 from psycopg import pq, sql
 from psycopg.adapt import PyFormat
 from psycopg.types import TypeInfo
-from psycopg.types.enum import EnumInfo, register_enum
+from psycopg.types.enum import EnumInfo, _make_enum, register_enum
 
 from ..fix_crdb import crdb_encoding
 
@@ -383,3 +383,8 @@ def test_remap_by_value(conn):
 
         cur = conn.execute(f"select '{label}'::puretestenum")
         assert cur.fetchone()[0] is enum[label.lower()]
+
+
+def test_make_enum_empty_label():
+    with pytest.raises(e.DataError):
+        _make_enum("EmptyLabel", ("",))


### PR DESCRIPTION
When `register_enum()` builds the Python enum itself, `_make_enum()` calls the stdlib `Enum` functional API, which raises a bare `ValueError` if a Postgres label is not a usable member name (e.g. an empty string). This propagates out with no indication it came from an enum label mismatch.

This catches that `ValueError` and re-raises it as a `DataError` naming the offending type, matching how the other type adapters report bad data. Closes #1357.