### PR TITLE
fix: reject unterminated text copy rows

### DIFF
--- a/psycopg/psycopg/_copy_base.py
+++ b/psycopg/psycopg/_copy_base.py
@@ -350,6 +350,8 @@ def _format_row_binary(row: Sequence[Any], tx: Transformer, out: bytearray) -> N
 def _parse_row_text(data: Buffer, tx: Transformer) -> tuple[Any, ...]:
     if not isinstance(data, bytes):
         data = bytes(data)
+    if not data.endswith(b"\n"):
+        raise e.DataError("bad copy data: field delimiter not found")
     fields = data.split(b"\t")
     fields[-1] = fields[-1][:-1]  # drop \n
     row = [None if f == b"\\N" else _load_re.sub(_load_sub, f) for f in fields]


### PR DESCRIPTION
## Summary

- reject text COPY rows without the required newline terminator in the pure-Python parser
- raise the same `DataError` and message already used by the C implementation
- add a database-independent regression test and an unreleased news entry

The direct C parser requires result-backed field metadata, so constructing a standalone Transformer only with `set_loader_types()` fails before it can exercise row parsing. With normal COPY result metadata, the C implementation already reports `bad copy data: field delimiter not found` for this malformed input.

Fixes #1361.

## Verification

- focused parser regression: 1 passed
- Python implementation COPY suite against PostgreSQL 16 UTF-8: 225 passed
- C implementation COPY suite against PostgreSQL 16 UTF-8: 224 passed
- all changed-file pre-commit hooks
- complete async-to-sync regeneration check
- psycopg sdist and wheel build
- `git diff --check`
