### PR TITLE
Fix missing f-string prefix in two DataError messages

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -19,6 +19,9 @@ Psycopg 3.3.5 (unreleased)
   no `!NoneType` dumper registered in python implementation (:ticket:`#1325`).
 - Fix `!wait_selector` wait function to not raise `!KeyError`
   (:ticket:`#1327`).
+- Fix `!DataError` messages leaking the literal ``{...}`` placeholder instead
+  of the offending value when loading a pre-year-1 :sql:`timestamp` or a
+  malformed binary :sql:`jsonb` value (:ticket:`#1372`).
 
 
 Current release

--- a/psycopg/psycopg/types/datetime.py
+++ b/psycopg/psycopg/types/datetime.py
@@ -689,7 +689,7 @@ def _get_timestamp_load_error(
             return len(s.split()[-1]) > 4  # year is last token
 
     if s == "-infinity" or s.endswith("BC"):
-        return DataError("timestamp too small (before year 1): {s!r}")
+        return DataError(f"timestamp too small (before year 1): {s!r}")
     elif s == "infinity" or is_overflow(s):
         return DataError(f"timestamp too large (after year 10K): {s!r}")
     else:

--- a/psycopg/psycopg/types/json.py
+++ b/psycopg/psycopg/types/json.py
@@ -277,7 +277,7 @@ class JsonbBinaryLoader(_JsonLoader):
 
     def load(self, data: Buffer) -> Any:
         if data and data[0] != 1:
-            raise DataError("unknown jsonb binary format: {data[0]}")
+            raise DataError(f"unknown jsonb binary format: {data[0]}")
         if not isinstance((data := data[1:]), bytes):
             data = bytes(data)
         return self.loads(data)


### PR DESCRIPTION
Two `DataError` messages were built from plain string literals containing `{...}` placeholders but missing the `f` prefix, so the literal placeholder text was shown to the user instead of the offending value.

- `psycopg/types/datetime.py` — `_get_timestamp_load_error()`:
  `"timestamp too small (before year 1): {s!r}"`
- `psycopg/types/json.py` — `JsonbBinaryLoader.load()`:
  `"unknown jsonb binary format: {data[0]}"`

The two sibling branches right next to the datetime message are already f-strings (`f"timestamp too large (after year 10K): {s!r}"`, `f"can't parse timestamp {s!r}: ..."`), which is what makes the omission stand out.

### Before

```
timestamp too small (before year 1): {s!r}
unknown jsonb binary format: {data[0]}
```

### After

```
timestamp too small (before year 1): '0001-01-01 00:00:00 BC'
unknown jsonb binary format: 2
```

A repo-wide grep confirms these are the only two occurrences of the pattern; every other `{...}`-in-a-plain-string case is an intentional `sql.SQL(...).format(...)` template.

Fixes #1372
