### PR TITLE
fix: raise ProgrammingError for infinite connect_timeout

### DIFF
--- a/psycopg/psycopg/conninfo.py
+++ b/psycopg/psycopg/conninfo.py
@@ -136,7 +136,7 @@ def timeout_from_conninfo(params: ConnDict) -> int:
         value = _DEFAULT_CONNECT_TIMEOUT
     try:
         timeout = int(float(value))
-    except (ValueError, OverflowError):
+    except Exception:
         raise e.ProgrammingError(f"bad value for connect_timeout: {value!r}") from None
 
     if timeout <= 0:

--- a/psycopg/psycopg/conninfo.py
+++ b/psycopg/psycopg/conninfo.py
@@ -136,7 +136,7 @@ def timeout_from_conninfo(params: ConnDict) -> int:
         value = _DEFAULT_CONNECT_TIMEOUT
     try:
         timeout = int(float(value))
-    except ValueError:
+    except (ValueError, OverflowError):
         raise e.ProgrammingError(f"bad value for connect_timeout: {value!r}") from None
 
     if timeout <= 0:

--- a/tests/test_conninfo.py
+++ b/tests/test_conninfo.py
@@ -105,3 +105,20 @@ def test_timeout(setpgenv, conninfo, want, env):
     params = conninfo_to_dict(conninfo)
     timeout = timeout_from_conninfo(params)
     assert timeout == want
+
+
+@pytest.mark.parametrize(
+    "conninfo",
+    [
+        "connect_timeout=notanumber",
+        "connect_timeout=nan",
+        "connect_timeout=inf",
+        "connect_timeout=-inf",
+        "connect_timeout=Infinity",
+    ],
+)
+def test_timeout_bad_value(setpgenv, conninfo):
+    setpgenv(None)
+    params = conninfo_to_dict(conninfo)
+    with pytest.raises(ProgrammingError, match="bad value for connect_timeout"):
+        timeout_from_conninfo(params)


### PR DESCRIPTION
Closes #1346

`timeout_from_conninfo()` wraps `int(float(value))` in a `try` that only catches `ValueError`, but `float("inf")` succeeds and `int(inf)` raises `OverflowError`, so `connect_timeout=inf` escaped as a raw `OverflowError` instead of the `ProgrammingError` every other invalid value (including the structurally identical `"nan"`) already raises. Catching `OverflowError` alongside `ValueError` routes it through the existing error path.

Regression test parametrizes the non-numeric, `nan` and infinite spellings; the three infinite cases fail with `OverflowError` without the source change and pass with it.
