### PR TITLE
Fix IndexError in _as_python_identifier on empty string

### DIFF
--- a/psycopg/psycopg/_encodings.py
+++ b/psycopg/psycopg/_encodings.py
@@ -138,7 +138,9 @@ def _as_python_identifier(s: str, prefix: str = "f") -> str:
     the first letter is an '_'.
     """
     if not s.isidentifier():
-        if s[0] in "1234567890":
+        if not s:
+            s = prefix
+        elif s[0] in "1234567890":
             s = prefix + s
         if not s.isidentifier():
             s = _re_clean.sub("_", s)

--- a/tests/test_encodings.py
+++ b/tests/test_encodings.py
@@ -56,3 +56,19 @@ def test_pg2py_missing(pgenc):
 )
 def test_conninfo_encoding(conninfo, pyenc):
     assert encodings.conninfo_encoding(conninfo) == pyenc
+
+
+@pytest.mark.parametrize(
+    "s, want",
+    [
+        ("", "f"),
+        ("foo", "foo"),
+        ("1foo", "f1foo"),
+        ("_foo", "f_foo"),
+        ("foo bar", "foo_bar"),
+    ],
+)
+def test_as_python_identifier(s, want):
+    got = encodings._as_python_identifier(s)
+    assert got == want
+    assert got.isidentifier()


### PR DESCRIPTION
Closes #1347

`_as_python_identifier("")` raised `IndexError`: `"".isidentifier()` is `False`, so the branch reading `s[0]` was entered on an empty string. An empty name now falls back to the `prefix`, matching how the function already handles names starting with a digit or an underscore.

The new parametrized case fails with the reported `IndexError` on `master` and passes with the fix.
