### PR TITLE
fix(rows): raise DataError on duplicate column names in namedtuple_row

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -22,6 +22,8 @@ Psycopg 3.3.5 (unreleased)
 - Fix `!DataError` messages leaking the literal ``{...}`` placeholder instead
   of the offending value when loading a pre-year-1 :sql:`timestamp` or a
   malformed binary :sql:`jsonb` value (:ticket:`#1372`).
+- Raise `!DataError` instead of `!ValueError` when `~psycopg.rows.namedtuple_row`
+  receives duplicate column names (:ticket:`#1348`).
 - Fix building C extension with Cython 3.3.
 
 

--- a/psycopg/psycopg/rows.py
+++ b/psycopg/psycopg/rows.py
@@ -142,7 +142,10 @@ def namedtuple_row(cursor: BaseCursor[Any, Any]) -> RowMaker[NamedTuple]:
 @functools.lru_cache(512)
 def _make_nt(enc: str, *names: bytes) -> type[NamedTuple]:
     snames = tuple(_as_python_identifier(n.decode(enc)) for n in names)
-    return namedtuple("Row", snames)  # type: ignore[return-value]
+    try:
+        return namedtuple("Row", snames)  # type: ignore[return-value]
+    except ValueError as ex:
+        raise e.DataError(f"can't create a namedtuple row: {ex}") from None
 
 
 def class_row(cls: type[T]) -> BaseRowFactory[T]:

--- a/tests/test_rows.py
+++ b/tests/test_rows.py
@@ -68,9 +68,10 @@ def test_namedtuple_row(conn):
     assert r3.f_eur == 5
 
 
-def test_make_nt_duplicate_names():
+def test_namedtuple_row_duplicate_names(conn):
+    cur = conn.cursor(row_factory=rows.namedtuple_row)
     with pytest.raises(psycopg.DataError):
-        rows._make_nt("utf-8", b"id", b"id")
+        cur.execute("select 1 as id, 2 as id").fetchall()
 
 
 def test_class_row(conn):

--- a/tests/test_rows.py
+++ b/tests/test_rows.py
@@ -68,6 +68,11 @@ def test_namedtuple_row(conn):
     assert r3.f_eur == 5
 
 
+def test_make_nt_duplicate_names():
+    with pytest.raises(psycopg.DataError):
+        rows._make_nt("utf-8", b"id", b"id")
+
+
 def test_class_row(conn):
     cur = conn.cursor(row_factory=rows.class_row(Person))
     cur.execute("select 'John' as first, 'Doe' as last")


### PR DESCRIPTION
Closes #1348

`namedtuple_row` let a raw `ValueError` from `collections.namedtuple` escape when a result set had two columns with the same name (e.g. `SELECT f.id, b.id` across a join). `_make_nt` now catches it and raises `DataError` instead, per your comment on the issue that converting the error is acceptable but allowing the duplicate is not.

Added `test_make_nt_duplicate_names` (fails with `ValueError` without the change, passes with it) and a news entry.
