### PR TITLE
fix: Fix  to return a timezone-aware datetime

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -22,6 +22,9 @@ Psycopg 3.3.5 (unreleased)
 - Fix `!DataError` messages leaking the literal ``{...}`` placeholder instead
   of the offending value when loading a pre-year-1 :sql:`timestamp` or a
   malformed binary :sql:`jsonb` value (:ticket:`#1372`).
+- Fix `Timestamp` to return a timezone-aware datetime (in UTC), consistent with
+  `TimestampFromTicks`, so that both constructors are adapted to the same
+  PostgreSQL type (:ticket:`#1058`).
 
 
 Current release

--- a/psycopg/psycopg/dbapi20.py
+++ b/psycopg/psycopg/dbapi20.py
@@ -112,7 +112,7 @@ def TimeFromTicks(ticks: float) -> dt.time:
 def Timestamp(
     year: int, month: int, day: int, hour: int, minute: int, second: int
 ) -> dt.datetime:
-    return dt.datetime(year, month, day, hour, minute, second)
+    return dt.datetime(year, month, day, hour, minute, second, tzinfo=dt.timezone.utc)
 
 
 def TimestampFromTicks(ticks: float) -> dt.datetime:

--- a/tests/test_psycopg_dbapi20.py
+++ b/tests/test_psycopg_dbapi20.py
@@ -90,6 +90,30 @@ def test_timestamp_from_ticks(ticks, want):
 
 
 @pytest.mark.parametrize(
+    "args, want",
+    [
+        ((2024, 1, 1, 12, 0, 0), "2024-01-01T12:00:00.000000+0000"),
+        ((2001, 9, 9, 1, 46, 40), "2001-09-09T01:46:40.000000+0000"),
+    ],
+)
+def test_timestamp(args, want):
+    s = psycopg.Timestamp(*args)
+    want = dt.datetime.strptime(want, "%Y-%m-%dT%H:%M:%S.%f%z")
+    assert s == want
+
+
+def test_timestamp_tz_consistency():
+    # Timestamp() and TimestampFromTicks() must produce datetime objects with
+    # the same timezone-awareness, otherwise they would be adapted to different
+    # PostgreSQL types (timestamp vs timestamptz).
+    ts1 = psycopg.Timestamp(2024, 1, 1, 12, 0, 0)
+    ts2 = psycopg.TimestampFromTicks(1704110400.0)
+    assert ts1.tzinfo is not None
+    assert ts2.tzinfo is not None
+    assert ts1.utcoffset() == ts2.utcoffset()
+
+
+@pytest.mark.parametrize(
     "ticks, want",
     [
         (0, "1970-01-01"),


### PR DESCRIPTION

Fixes : 
- `Timestamp` to return a timezone-aware datetime (in UTC), consistent with `TimestampFromTicks`, so that both constructors are adapted to the same ( issue #1351  )


@dvarrazzo please take a look at this and review.