### PR TITLE
fix: handle empty string in _as_python_identifier (#1347)

### DIFF
--- a/psycopg/psycopg/_encodings.py
+++ b/psycopg/psycopg/_encodings.py
@@ -135,15 +135,15 @@ def _as_python_identifier(s: str, prefix: str = "f") -> str:
     Reduce a string to a valid Python identifier.
 
     Replace all non-valid chars with '_' and prefix the value with `!prefix` if
-    the first letter is an '_'.
+    the string is empty or the first letter is an '_'.
     """
     if not s.isidentifier():
-        if s[0] in "1234567890":
+        if s and s[0] in "1234567890":
             s = prefix + s
         if not s.isidentifier():
             s = _re_clean.sub("_", s)
     # namedtuple fields cannot start with underscore. So...
-    if s[0] == "_":
+    if not s or s[0] == "_":
         s = prefix + s
     return s
 

--- a/tests/test_encodings.py
+++ b/tests/test_encodings.py
@@ -56,3 +56,26 @@ def test_pg2py_missing(pgenc):
 )
 def test_conninfo_encoding(conninfo, pyenc):
     assert encodings.conninfo_encoding(conninfo) == pyenc
+
+
+@pytest.mark.parametrize(
+    "s, expected",
+    [
+        ("", "f"),
+        ("123", "f123"),
+        ("_", "f_"),
+        ("a-b", "a_b"),
+        ("foo", "foo"),
+        ("?column?", "f_column_"),
+    ],
+)
+def test_as_python_identifier(s, expected):
+    got = encodings._as_python_identifier(s)
+    assert got == expected
+    assert got.isidentifier()
+
+
+def test_as_python_identifier_custom_prefix():
+    assert encodings._as_python_identifier("", prefix="x") == "x"
+    assert encodings._as_python_identifier("_", prefix="x") == "x_"
+    assert encodings._as_python_identifier("9a", prefix="x") == "x9a"


### PR DESCRIPTION
## Summary
- `_as_python_identifier("")` raised `IndexError` because it indexed `s[0]` after `"".isidentifier()` returned `False`.
- Guard the digit-prefix path with `s and ...`, and treat an empty result like other non-field-safe names so it becomes `prefix` (default `"f"`), consistent with existing sanitization (`"_" -> "f_"`, digit-leading names get `prefix`).
- Add regression tests in `tests/test_encodings.py`.

Empty input maps to `prefix` (not `f_`) because there is no character content to preserve; `"_"` still becomes `f_` by keeping the underscore.

Fixes #1347

## Test plan
- [x] `python -P -c "import psycopg; from psycopg._encodings import _as_python_identifier; r=_as_python_identifier(''); print(repr(r), r.isidentifier())"` → `'f' True`
- [x] encoding unit tests green (24 passed)
- [ ] CI on the PR