### PR TITLE
fix: allow binary dump of nested empty arrays

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -22,6 +22,8 @@ Psycopg 3.3.5 (unreleased)
 - Fix `!DataError` messages leaking the literal ``{...}`` placeholder instead
   of the offending value when loading a pre-year-1 :sql:`timestamp` or a
   malformed binary :sql:`jsonb` value (:ticket:`#1372`).
+- Allow binary array dumpers to handle nested empty lists consistently with
+  text array dumpers (:ticket:`#1349`).
 
 
 Current release

--- a/psycopg/psycopg/types/array.py
+++ b/psycopg/psycopg/types/array.py
@@ -251,10 +251,9 @@ class ListBinaryDumper(BaseListDumper):
 
         def calc_dims(L: list[Any]) -> None:
             if isinstance(L, self.cls):
-                if not L:
-                    raise e.DataError("lists cannot contain empty lists")
                 dims.append(len(L))
-                calc_dims(L[0])
+                if L:
+                    calc_dims(L[0])
 
         calc_dims(obj)
 
@@ -444,6 +443,15 @@ def _load_binary(data: Buffer, tx: Transformer) -> list[Any]:
     p = 12 + 8 * ndims
     dims = [_unpack_dim(data, i)[0] for i in range(12, p, 8)]
     nelems = prod(dims)
+
+    if not nelems:
+
+        def make_empty(dims: list[int]) -> list[Any]:
+            if len(dims) == 1:
+                return []
+            return [make_empty(dims[1:]) for _ in range(dims[0])]
+
+        return make_empty(dims)
 
     out: list[Any] = [None] * nelems
     for i in range(nelems):

--- a/tests/types/test_array.py
+++ b/tests/types/test_array.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import gc
+import struct
 from math import prod
 from typing import Any
 from decimal import Decimal
@@ -10,10 +11,11 @@ import pytest
 import psycopg
 import psycopg.types.numeric
 from psycopg import pq, sql
+from psycopg._oids import TEXT_OID
 from psycopg.adapt import Dumper, PyFormat, Transformer
 from psycopg.types import TypeInfo
 from psycopg.postgres import types as builtins
-from psycopg.types.array import register_array
+from psycopg.types.array import ListBinaryDumper, _load_binary, register_array
 
 from ..test_adapt import StrNoneBinaryDumper, StrNoneDumper
 
@@ -126,6 +128,19 @@ def test_bad_binary_array(input):
     tx = Transformer()
     with pytest.raises(psycopg.DataError):
         tx.get_dumper(input, PyFormat.BINARY).dump(input)
+
+
+def test_dump_binary_nested_empty_array():
+    got = ListBinaryDumper(list).dump([[], []])
+    want = b"".join(
+        [
+            struct.pack("!III", 2, 0, TEXT_OID),
+            struct.pack("!II", 2, 1),
+            struct.pack("!II", 0, 1),
+        ]
+    )
+    assert got == want
+    assert _load_binary(got, Transformer()) == [[], []]
 
 
 @pytest.mark.crdb_skip("nested array")


### PR DESCRIPTION
Fixes #1349.

## Reproduction
`ListDumper(list).dump([[], []])` returns `b'{{},{}}'`, but `ListBinaryDumper(list).dump([[], []])` raised `DataError: lists cannot contain empty lists` before this change. This is reproducible without a PostgreSQL server.

## Root cause
The binary array dumper calculated dimensions by descending into the first element of each nested list, but treated an empty nested list as invalid even when all sibling nested lists had the same empty shape. The binary array loader also assumed every dimension length was non-zero when re-nesting decoded items.

## Fix
Allow dimension calculation to stop at empty nested lists, producing a zero-length inner dimension for the binary array representation. Also teach the binary array loader to reconstruct nested empty arrays from zero-element dimensions, and add a regression test for the generated binary payload and round trip through the loader.

## Compatibility
Existing invalid ragged arrays, such as arrays mixing non-empty and empty nested lists, still raise `DataError` because their dimensions remain inconsistent. Top-level empty arrays are unchanged.

## Validation
- `python -m pytest ..\tests\types\test_array.py ..\tests\test_adapt.py -q` from the `psycopg` package directory with `PSYCOPG_IMPL=binary`: 48 passed, 173 skipped.
- `python -m black --check --diff --quiet psycopg\psycopg\types\array.py tests\types\test_array.py`
- `python -m flake8 psycopg\psycopg\types\array.py tests\types\test_array.py`
- `python -m isort --check --diff psycopg\psycopg\types\array.py tests\types\test_array.py`
- Skips are expected in this environment because no PostgreSQL server/`--test-dsn` is available; I did not run the server-dependent integration suite.
- Verified the new regression test fails on the previous implementation with `DataError: lists cannot contain empty lists`.