### PR TITLE
fix: raise DataError when binary copy field length exceeds data

### DIFF
--- a/docs/news.rst
+++ b/docs/news.rst
@@ -24,6 +24,8 @@ Psycopg 3.3.5 (unreleased)
   malformed binary :sql:`jsonb` value (:ticket:`#1372`).
 - Raise `!DataError` instead of `!ValueError` when `~psycopg.rows.namedtuple_row`
   receives duplicate column names (:ticket:`#1348`).
+- Raise `!DataError` on inconsistent copy data length in pure Python,
+  consistently with the C implementation (:ticket:`#1360`).
 - Fix building C extension with Cython 3.3.
 
 

--- a/psycopg/psycopg/_copy_base.py
+++ b/psycopg/psycopg/_copy_base.py
@@ -366,6 +366,8 @@ def _parse_row_binary(data: Buffer, tx: Transformer) -> tuple[Any, ...]:
         length = _unpack_int4(data, pos)[0]
         pos += 4
         if length >= 0:
+            if pos + length > len(data):
+                raise e.DataError("bad copy data: length exceeding data")
             row.append(data[pos : pos + length])
             pos += length
         else:

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -30,6 +30,28 @@ from .test_adapt import StrNoneBinaryDumper, StrNoneDumper
 pytestmark = pytest.mark.crdb_skip("copy")
 
 
+def test_copy_binary_parse_length_exceeding_data():
+    from psycopg.adapt import Transformer
+    from psycopg._copy_base import _parse_row_binary
+
+    tx = Transformer()
+    # One field declaring length 10, but only two bytes ("ab") present.
+    data = bytes.fromhex("00010000000a6162")
+    with pytest.raises(e.DataError, match="length exceeding data"):
+        _parse_row_binary(data, tx)
+
+
+def test_copy_binary_parse_exact_length():
+    from psycopg.adapt import Transformer
+    from psycopg._copy_base import _parse_row_binary
+
+    tx = Transformer()
+    tx.set_loader_types([25], pq.Format.TEXT)  # oid 25 = text
+    # One field declaring length 2, with exactly two bytes ("ab") present.
+    data = bytes.fromhex("0001000000026162")
+    assert _parse_row_binary(data, tx) == ("ab",)
+
+
 @pytest.mark.parametrize("format", pq.Format)
 def test_copy_out_read(conn, format):
     if format == pq.Format.TEXT:

--- a/tests/test_copy_async.py
+++ b/tests/test_copy_async.py
@@ -27,6 +27,28 @@ from .test_adapt import StrNoneBinaryDumper, StrNoneDumper
 pytestmark = pytest.mark.crdb_skip("copy")
 
 
+def test_copy_binary_parse_length_exceeding_data():
+    from psycopg.adapt import Transformer
+    from psycopg._copy_base import _parse_row_binary
+
+    tx = Transformer()
+    # One field declaring length 10, but only two bytes ("ab") present.
+    data = bytes.fromhex("00010000000a6162")
+    with pytest.raises(e.DataError, match="length exceeding data"):
+        _parse_row_binary(data, tx)
+
+
+def test_copy_binary_parse_exact_length():
+    from psycopg.adapt import Transformer
+    from psycopg._copy_base import _parse_row_binary
+
+    tx = Transformer()
+    tx.set_loader_types([25], pq.Format.TEXT)  # oid 25 = text
+    # One field declaring length 2, with exactly two bytes ("ab") present.
+    data = bytes.fromhex("0001000000026162")
+    assert _parse_row_binary(data, tx) == ("ab",)
+
+
 @pytest.mark.parametrize("format", pq.Format)
 async def test_copy_out_read(aconn, format):
     if format == pq.Format.TEXT:


### PR DESCRIPTION
Closes #1360.

## Problem

The pure-Python `_parse_row_binary` slices `data[pos : pos + length]` without
checking that the declared `length` fits in the remaining buffer. Python slicing
doesn't raise for an out-of-range stop, so a field declaring more bytes than are
present is silently returned truncated instead of raising.

The C implementation already validates this and raises
`DataError("bad copy data: length exceeding data")`, so the two implementations
diverge on the same malformed input.

## Change

Add the same bounds check to `_parse_row_binary`, raising
`DataError("bad copy data: length exceeding data")` when `pos + length > len(data)`.

## Reproduction

```python
from psycopg._copy_base import _parse_row_binary
from psycopg.adapt import Transformer

tx = Transformer()
# One field declaring length 10, but only two bytes ("ab") present.
data = bytes.fromhex("00010000000a6162")
_parse_row_binary(data, tx)
# before: returned ('ab',) silently
# after:  psycopg.errors.DataError: bad copy data: length exceeding data
```

## Testing

Added `test_copy_binary_parse_length_exceeding_data` (in both the sync and async
test modules) covering the malformed case. I ran this unit test against the
pure-Python implementation and it passes; the full suite requires a running
PostgreSQL, which I did not have available, so the DB-backed copy tests were not
run locally.
