### PR TITLE
Add Windows ARM64 build

### DIFF
--- a/.github/workflows/packages-bin.yml
+++ b/.github/workflows/packages-bin.yml
@@ -177,14 +177,20 @@ jobs:
 
   windows:  # {{{
     # TODO: move it back to windows-latest when the default runner switches.
-    runs-on: windows-2025
+    runs-on: ${{ matrix.arch == 'win_arm64' && 'windows-11-arm' || 'windows-2025' }}
     if: github.event_name != 'schedule' || github.repository == 'psycopg/psycopg'
 
     strategy:
       fail-fast: false
       matrix:
-        arch: [win_amd64]
+        arch: [win_amd64, win_arm64]
         pyver: [cp310, cp311, cp312, cp313, cp314]
+        exclude:
+          # Python 3.10 does not have an arm64 release
+          - {arch: win_arm64, pyver: cp310}
+
+    env:
+      VCPKG_TRIPLET: ${{ matrix.arch == 'win_arm64' && 'arm64-windows-release' || 'x64-windows-release' }}
 
     defaults:
       run:
@@ -196,11 +202,22 @@ jobs:
 
       - uses: actions/checkout@v6
 
+      - name: Install PostgreSQL (x64, under emulation)
+        # Currently, the arm64 runner image doesn't include PostgreSQL
+        if: ${{ matrix.arch == 'win_arm64' }}
+        run: |
+          choco install postgresql17 -y --no-progress --params '/Password:root'
+          "PGUSER=postgres" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "PGPASSWORD=root" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        shell: powershell
+
       - name: Start PostgreSQL service for test
         run: |
           $PgSvc = Get-Service "postgresql*"
           Set-Service $PgSvc.Name -StartupType manual
-          $PgSvc.Start()
+          if ($PgSvc.Status -ne 'Running') {
+            $PgSvc.Start()
+          }
         shell: powershell
 
       - name: Export GitHub Actions cache environment variables
@@ -208,10 +225,11 @@ jobs:
         with:
           script: |
             const path = require('path')
+            const triplet = process.env.VCPKG_TRIPLET;
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-            core.addPath(path.join(process.env.VCPKG_INSTALLATION_ROOT, 'installed/x64-windows-release/lib'));
-            core.addPath(path.join(process.env.VCPKG_INSTALLATION_ROOT, 'installed/x64-windows-release/bin'));
+            core.addPath(path.join(process.env.VCPKG_INSTALLATION_ROOT, `installed/${triplet}/lib`));
+            core.addPath(path.join(process.env.VCPKG_INSTALLATION_ROOT, `installed/${triplet}/bin`));
 
       - name: Create the binary package source tree
         run: python3 ./tools/ci/copy_to_binary.py
@@ -223,7 +241,7 @@ jobs:
         env:
           VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite" # cache vcpkg
           CIBW_BUILD: ${{matrix.pyver}}-${{matrix.arch}}
-          CIBW_ARCHS_WINDOWS: AMD64 x86
+          CIBW_ARCHS_WINDOWS: ${{ matrix.arch == 'win_arm64' && 'ARM64' || 'AMD64 x86' }}
           CIBW_BEFORE_BUILD_WINDOWS: '.\tools\ci\wheel_win32_before_build.bat'
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >-
             delvewheel repair -w {dest_dir}

--- a/.github/workflows/packages-bin.yml
+++ b/.github/workflows/packages-bin.yml
@@ -203,18 +203,16 @@ jobs:
 
       - uses: actions/checkout@v6
 
-      - name: Install PostgreSQL (x64, under emulation)
-        # Currently, the arm64 runner image doesn't include PostgreSQL
-        if: ${{ matrix.arch == 'win_arm64' }}
+      - name: Install and start PostgreSQL for test
+        # If the runner image doesn't ship PostgreSQL (currently the case on arm64), install it.
         run: |
-          choco install postgresql17 -y --no-progress --params '/Password:root'
-          "PGUSER=postgres" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "PGPASSWORD=root" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-        shell: powershell
-
-      - name: Start PostgreSQL service for test
-        run: |
-          $PgSvc = Get-Service "postgresql*"
+          $PgSvc = Get-Service "postgresql*" -ErrorAction SilentlyContinue
+          if (-not $PgSvc) {
+            choco install postgresql17 -y --no-progress --params '/Password:root'
+            "PGUSER=postgres" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+            "PGPASSWORD=root" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+            $PgSvc = Get-Service "postgresql*"
+          }
           Set-Service $PgSvc.Name -StartupType manual
           if ($PgSvc.Status -ne 'Running') {
             $PgSvc.Start()

--- a/.github/workflows/packages-bin.yml
+++ b/.github/workflows/packages-bin.yml
@@ -190,7 +190,8 @@ jobs:
           - {arch: win_arm64, pyver: cp310}
 
     env:
-      VCPKG_TRIPLET: ${{ matrix.arch == 'win_arm64' && 'arm64-windows-release' || 'x64-windows-release' }}
+      # Note: there is no arm64-windows-release triplet in vcpkg.
+      VCPKG_TRIPLET: ${{ matrix.arch == 'win_arm64' && 'arm64-windows' || 'x64-windows-release' }}
 
     defaults:
       run:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -313,18 +313,16 @@ jobs:
           python-version: ${{ matrix.python }}
           allow-prereleases: true
 
-      - name: Install PostgreSQL (x64, under emulation)
-        # Currently, the arm64 runner image doesn't include PostgreSQL
-        if: ${{ matrix.runner == 'windows-11-arm' }}
+      - name: Install and start PostgreSQL
+        # If the runner image doesn't ship PostgreSQL (currently the case on arm64), install it.
         run: |
-          choco install postgresql17 -y --no-progress --params '/Password:root'
-          "PGUSER=postgres" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "PGPASSWORD=root" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-        shell: powershell
-
-      - name: Start PostgreSQL service
-        run: |
-          $PgSvc = Get-Service "postgresql*"
+          $PgSvc = Get-Service "postgresql*" -ErrorAction SilentlyContinue
+          if (-not $PgSvc) {
+            choco install postgresql17 -y --no-progress --params '/Password:root'
+            "PGUSER=postgres" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+            "PGPASSWORD=root" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+            $PgSvc = Get-Service "postgresql*"
+          }
           Set-Service $PgSvc.Name -StartupType manual
           if ($PgSvc.Status -ne 'Running') {
             $PgSvc.Start()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -258,8 +258,9 @@ jobs:
   # }}}
 
   windows:  # {{{
-    # TODO: move it back to windows-latest when the default runner switches.
-    runs-on: windows-2025
+    # TODO: move the default back to windows-latest when the default runner
+    # switches.
+    runs-on: ${{ matrix.runner || 'windows-2025' }}
     if: github.event_name != 'schedule' || github.repository == 'psycopg/psycopg'
 
     strategy:
@@ -277,12 +278,24 @@ jobs:
           - {impl: c, python: "3.13"}
           - {impl: c, python: "3.14"}
 
+          # Windows arm64. Note: setup-python has no arm64 build for
+          # Python 3.10, so start from 3.11.
+          - {impl: python, python: "3.11", runner: windows-11-arm}
+          - {impl: python, python: "3.12", runner: windows-11-arm}
+          - {impl: python, python: "3.13", runner: windows-11-arm}
+          - {impl: python, python: "3.14", runner: windows-11-arm}
+          - {impl: c, python: "3.11", runner: windows-11-arm}
+          - {impl: c, python: "3.12", runner: windows-11-arm}
+          - {impl: c, python: "3.13", runner: windows-11-arm}
+          - {impl: c, python: "3.14", runner: windows-11-arm}
+
     env:
       PSYCOPG_IMPL: ${{ matrix.impl }}
       DEPS: ./psycopg[test] ./psycopg_pool
       PSYCOPG_TEST_DSN: "host=127.0.0.1 dbname=postgres"
       # On windows pproxy doesn't seem very happy. Also a few timing test fail.
       NOT_MARKERS: "timing proxy mypy"
+      VCPKG_TRIPLET: ${{ matrix.runner == 'windows-11-arm' && 'arm64-windows-release' || 'x64-windows-release' }}
 
     defaults:
       run:
@@ -299,11 +312,22 @@ jobs:
           python-version: ${{ matrix.python }}
           allow-prereleases: true
 
+      - name: Install PostgreSQL (x64, under emulation)
+        # Currently, the arm64 runner image doesn't include PostgreSQL
+        if: ${{ matrix.runner == 'windows-11-arm' }}
+        run: |
+          choco install postgresql17 -y --no-progress --params '/Password:root'
+          "PGUSER=postgres" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "PGPASSWORD=root" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        shell: powershell
+
       - name: Start PostgreSQL service
         run: |
           $PgSvc = Get-Service "postgresql*"
           Set-Service $PgSvc.Name -StartupType manual
-          $PgSvc.Start()
+          if ($PgSvc.Status -ne 'Running') {
+            $PgSvc.Start()
+          }
         shell: powershell
 
       # Refcount tests are flakey on windows, often they fail with the likes of:
@@ -321,10 +345,11 @@ jobs:
         with:
           script: |
             const path = require('path')
+            const triplet = process.env.VCPKG_TRIPLET;
             core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-            core.addPath(path.join(process.env.VCPKG_INSTALLATION_ROOT, 'installed/x64-windows-release/lib'));
-            core.addPath(path.join(process.env.VCPKG_INSTALLATION_ROOT, 'installed/x64-windows-release/bin'));
+            core.addPath(path.join(process.env.VCPKG_INSTALLATION_ROOT, `installed/${triplet}/lib`));
+            core.addPath(path.join(process.env.VCPKG_INSTALLATION_ROOT, `installed/${triplet}/bin`));
 
       - name: Install libpq from vcpkg and install pg_config.exe stub
         run: .\tools\ci\wheel_win32_before_build.bat

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -295,7 +295,8 @@ jobs:
       PSYCOPG_TEST_DSN: "host=127.0.0.1 dbname=postgres"
       # On windows pproxy doesn't seem very happy. Also a few timing test fail.
       NOT_MARKERS: "timing proxy mypy"
-      VCPKG_TRIPLET: ${{ matrix.runner == 'windows-11-arm' && 'arm64-windows-release' || 'x64-windows-release' }}
+      # Note: there is no arm64-windows-release triplet in vcpkg.
+      VCPKG_TRIPLET: ${{ matrix.runner == 'windows-11-arm' && 'arm64-windows' || 'x64-windows-release' }}
 
     defaults:
       run:

--- a/tools/ci/pg_config_vcpkg_stub/pg_config_vcpkg_stub/__init__.py
+++ b/tools/ci/pg_config_vcpkg_stub/pg_config_vcpkg_stub/__init__.py
@@ -6,7 +6,8 @@ This is a stub to work as `pg_config --libdir` or `pg_config --includedir` to
 make it work with vcpkg.
 
 You will need install `vcpkg`, set `VCPKG_ROOT` env, and run `vcpkg install
-libpq:x64-windows-release` before using this script.
+libpq:$VCPKG_TRIPLET` (e.g. `libpq:x64-windows-release`) before using this
+script.
 """
 
 import os
@@ -21,16 +22,21 @@ class ScriptError(Exception):
 
 
 def _main() -> None:
-    # only x64-windows
-    if not (sys.platform == "win32" and platform.machine() == "AMD64"):
-        raise ScriptError("this script should only be used in x64-windows")
+    # only x64/arm64 windows
+    machines = {"AMD64": "x64", "ARM64": "arm64"}
+    if not (sys.platform == "win32" and platform.machine() in machines):
+        raise ScriptError("this script should only be used in x64/arm64 windows")
 
     vcpkg_root = os.environ.get(
         "VCPKG_ROOT", os.environ.get("VCPKG_INSTALLATION_ROOT", "")
     )
     if not vcpkg_root:
         raise ScriptError("VCPKG_ROOT/VCPKG_INSTALLATION_ROOT env var not specified")
-    vcpkg_platform_root = (Path(vcpkg_root) / "installed/x64-windows-release").resolve()
+    triplet = (
+        os.environ.get("VCPKG_TRIPLET")
+        or f"{machines[platform.machine()]}-windows-release"
+    )
+    vcpkg_platform_root = (Path(vcpkg_root) / "installed" / triplet).resolve()
 
     args = parse_cmdline()
 

--- a/tools/ci/pg_config_vcpkg_stub/pg_config_vcpkg_stub/__init__.py
+++ b/tools/ci/pg_config_vcpkg_stub/pg_config_vcpkg_stub/__init__.py
@@ -23,8 +23,9 @@ class ScriptError(Exception):
 
 def _main() -> None:
     # only x64/arm64 windows
-    machines = {"AMD64": "x64", "ARM64": "arm64"}
-    if not (sys.platform == "win32" and platform.machine() in machines):
+    # Note: there is no arm64-windows-release triplet in vcpkg.
+    triplets = {"AMD64": "x64-windows-release", "ARM64": "arm64-windows"}
+    if not (sys.platform == "win32" and platform.machine() in triplets):
         raise ScriptError("this script should only be used in x64/arm64 windows")
 
     vcpkg_root = os.environ.get(
@@ -32,10 +33,7 @@ def _main() -> None:
     )
     if not vcpkg_root:
         raise ScriptError("VCPKG_ROOT/VCPKG_INSTALLATION_ROOT env var not specified")
-    triplet = (
-        os.environ.get("VCPKG_TRIPLET")
-        or f"{machines[platform.machine()]}-windows-release"
-    )
+    triplet = os.environ.get("VCPKG_TRIPLET") or triplets[platform.machine()]
     vcpkg_platform_root = (Path(vcpkg_root) / "installed" / triplet).resolve()
 
     args = parse_cmdline()

--- a/tools/ci/wheel_win32_before_build.bat
+++ b/tools/ci/wheel_win32_before_build.bat
@@ -2,8 +2,17 @@
 
 pip install delvewheel wheel
 
+REM The workflows set VCPKG_TRIPLET; default to the native arch otherwise.
+if "%VCPKG_TRIPLET%"=="" (
+    if "%PROCESSOR_ARCHITECTURE%"=="ARM64" (
+        set VCPKG_TRIPLET=arm64-windows-release
+    ) else (
+        set VCPKG_TRIPLET=x64-windows-release
+    )
+)
+
 REM A specific version cannot be easily chosen.
 REM https://github.com/microsoft/vcpkg/discussions/25622
-vcpkg install libpq:x64-windows-release
+vcpkg install libpq:%VCPKG_TRIPLET%
 
 pipx install .\tools\ci\pg_config_vcpkg_stub\

--- a/tools/ci/wheel_win32_before_build.bat
+++ b/tools/ci/wheel_win32_before_build.bat
@@ -5,7 +5,7 @@ pip install delvewheel wheel
 REM The workflows set VCPKG_TRIPLET; default to the native arch otherwise.
 if "%VCPKG_TRIPLET%"=="" (
     if "%PROCESSOR_ARCHITECTURE%"=="ARM64" (
-        set VCPKG_TRIPLET=arm64-windows-release
+        set VCPKG_TRIPLET=arm64-windows
     ) else (
         set VCPKG_TRIPLET=x64-windows-release
     )


### PR DESCRIPTION
I got the impression from #1087 that libpq doesn't build cleanly for Windows ARM64. On testing it out though, it compiles fine.

So here's a PR that adds `win_arm64` wheels and runs tests on Windows ARM64 as well.

A few notes:
- I have skipped building and tests for Python 3.10 on WoA because there is no official binary release, and the setup-python GitHub Action cannot install it either. cibuildwheel does support this config though, let me know if you would like to add that config only in the packages-bin workflow.
- The `CIBW_ARCHS_WINDOWS` variable for cibuildwheel had an explicit value specified, so I have kept it that way with a conditional expression. However, setting this to `auto` will have the same effect. Let me know which one you prefer.
- There is no `arm64-windows-release` triplet in vcpkg. The `arm64-windows` 'triplet' will do both debug and release builds, although we'll pick up the release ones automatically because the debug builds are in their own subdirectory.

Closes #1087.