### PR TITLE
docs: fix grammar and punctuation in sql module docstrings

### DIFF
--- a/psycopg/psycopg/sql.py
+++ b/psycopg/psycopg/sql.py
@@ -1,5 +1,5 @@
 """
-SQL composition utility module
+SQL composition utility module.
 """
 
 # Copyright (C) 2020 The Psycopg Team
@@ -74,7 +74,7 @@ class Composable(ABC):
 
     def as_string(self, context: AdaptContext | None = None) -> str:
         """
-        Return the value of the object as string.
+        Return the value of the object as a string.
 
         :param context: the context to evaluate the string into.
         :type context: `connection` or `cursor`


### PR DESCRIPTION
### Summary
- Add missing trailing period in `psycopg.sql` module docstring.
- Add missing article 'a' in `Composable.as_string` docstring (`as string` -> `as a string`).