### PR TITLE
fix(c): avoid a Cython 3.3 variable redeclaration

### DIFF
--- a/psycopg_c/psycopg_c/_psycopg/generators.pyx
+++ b/psycopg_c/psycopg_c/_psycopg/generators.pyx
@@ -299,7 +299,7 @@ def pipeline_communicate(
 
             _consume_notifies(pgconn)
 
-            res: list[PGresult] = []
+            res = []
             while True:
                 with nogil:
                     ibres = libpq.PQisBusy(pgconn_ptr)


### PR DESCRIPTION
## Summary

- avoid redeclaring `res` in `pipeline_communicate()` after its existing
  `cdef list res` declaration
- restore `psycopg_c` builds from a Git checkout with Cython 3.3

## Rationale

`psycopg_c/pyproject.toml` accepts `Cython >= 3.1.1` without an upper bound.
With Cython 3.3, the later annotated reset of `res` is interpreted as another
declaration and the build fails with:

```text
psycopg_c/psycopg_c/_psycopg/generators.pyx:302:12: 'res' redeclared
```

The function already declares `cdef list res = []` before the loop. Replacing
only the later `res: list[PGresult] = []` with `res = []` preserves the Cython
C type and the reset behavior.

I found this while retesting #1382. This PR is intentionally limited to the
current `master` build failure; it does not duplicate that PR's Python 3.15
metadata, test-matrix, or wheel changes.

## Validation

The unchanged source on #1382 (identical to `master` in this file and build
requirement) failed to build with Cython 3.3.0 as shown above. With this
one-line change, I ran the repository's Linux `impl=c` / PostgreSQL 18 workflow
locally with `act`:

- CPython 3.14.7 free-threaded: **5612 passed, 586 skipped, 39 xfailed**;
  completed without retries.
- CPython 3.15.0rc1: **5981 passed, 217 skipped, 39 xfailed**; completed
  without retries.
- CPython 3.15.0rc1 free-threaded: the first pass reported **5611 passed,
  586 skipped, 39 xfailed**, plus one timing-only failure in
  `test_stats_usage` (expected 850-950 ms, observed 702 ms). The workflow's
  existing last-failed retry passed, and the job completed successfully.

Additional checks on CPython 3.15t:

- built `psycopg_c-3.3.5.dev1-cp315-cp315t-linux_x86_64.whl`
- confirmed `pq.__impl__ == "c"`
- confirmed `sys._is_gil_enabled() == False`
- completed a query against PostgreSQL
- passed all 8 tests in `tests/test_free_threading.py`

`git diff --check` also passes.

## GitHub CI

All 48 test jobs passed, including the Linux, macOS, Windows, free-threaded
3.14, C-extension, CockroachDB, and pool jobs.

The separate lint job fails in unchanged
`psycopg_c/build_backend/psycopg_build_ext.py`: current mypy types
`ext.sources` as a non-indexable `Iterable`. The `cython-lint` hook and every
other lint hook pass. This is an existing `master` baseline failure: scheduled
lint runs on the same `c079c37c` commit have failed identically each day from
2026-08-16 through 2026-08-24. I have not mixed that unrelated change into
this PR.
