### PR TITLE
fix: treat SystemExit as an interruption in Connection.wait

### DIFF
--- a/psycopg/psycopg/connection.py
+++ b/psycopg/psycopg/connection.py
@@ -50,7 +50,7 @@ IDLE = pq.TransactionStatus.IDLE
 ACTIVE = pq.TransactionStatus.ACTIVE
 INTRANS = pq.TransactionStatus.INTRANS
 
-_INTERRUPTED = KeyboardInterrupt
+_INTERRUPTED = (KeyboardInterrupt, SystemExit)
 
 logger = logging.getLogger("psycopg")
 

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -17,7 +17,6 @@ import psycopg
 from psycopg import errors as e
 from psycopg.conninfo import conninfo_to_dict, make_conninfo
 
-
 @pytest.mark.slow
 def test_concurrent_execution(conn_cls, dsn):
     def worker():
@@ -35,7 +34,6 @@ def test_concurrent_execution(conn_cls, dsn):
     t1.join()
     t2.join()
     assert time.time() - t0 < 0.8, "something broken in concurrency"
-
 
 @pytest.mark.slow
 def test_commit_concurrency(conn):
@@ -62,7 +60,6 @@ def test_commit_concurrency(conn):
     t1.join()
 
     assert notices.empty(), "%d notices raised" % notices.qsize()
-
 
 @pytest.mark.slow
 @pytest.mark.subprocess
@@ -105,7 +102,6 @@ t.join()
         [sys.executable, "-c", script], stderr=sp.STDOUT, env=env
     ).decode("utf8", "replace")
     assert out == "", out.strip().splitlines()[-1]
-
 
 @pytest.mark.slow
 @pytest.mark.timing
@@ -152,14 +148,12 @@ def test_notifies(conn_cls, conn, dsn):
 
     t.join()
 
-
 def canceller(conn, errors):
     try:
         time.sleep(0.5)
         conn.cancel()
     except Exception as exc:
         errors.append(exc)
-
 
 @pytest.mark.slow
 @pytest.mark.crdb_skip("cancel")
@@ -183,7 +177,6 @@ def test_cancel(conn):
     assert cur.execute("select 1").fetchone()[0] == 1
 
     t.join()
-
 
 @pytest.mark.slow
 @pytest.mark.crdb_skip("cancel")
@@ -209,7 +202,6 @@ def test_cancel_stream(conn):
 
     t.join()
 
-
 @pytest.mark.crdb_skip("pg_terminate_backend")
 @pytest.mark.slow
 @pytest.mark.timing
@@ -234,7 +226,6 @@ def test_identify_closure(conn_cls, dsn):
     finally:
         conn.close()
         conn2.close()
-
 
 @pytest.mark.slow
 @pytest.mark.subprocess
@@ -292,7 +283,6 @@ with psycopg.connect({dsn!r}) as conn:
     t = time.time() - t0
     assert proc.returncode == 0
     assert 1 < t < 2
-
 
 @pytest.mark.slow
 @pytest.mark.subprocess
@@ -357,9 +347,6 @@ with psycopg.connect({dsn!r}, application_name={APPNAME!r}) as conn:
 
     t1 = time.time()
     assert t1 - t0 < 1.0
-
-
-
 
 @pytest.mark.subprocess
 def test_systemexit_handler_cancels_query(conn, dsn):
@@ -445,7 +432,6 @@ signal.signal({sig!r}, signal_handler)
 # Restart system calls interrupted by the signal
 signal.siginterrupt({sig!r}, False)
 
-
 with psycopg.connect({dsn!r}) as conn:
     # Fire an interrupt signal every 0.25 seconds
     signal.setitimer({itimer!r}, 0.25, 0.25)
@@ -462,7 +448,6 @@ with psycopg.connect({dsn!r}) as conn:
         cp.returncode == 0
     ), f"script terminated with {signal.Signals(abs(cp.returncode)).name}"
     assert cp.stdout.rstrip() == "ok"
-
 
 @pytest.mark.slow
 @pytest.mark.subprocess
@@ -496,7 +481,6 @@ if __name__ == '__main__':
     env["PYTHONFAULTHANDLER"] = "1"
     out = sp.check_output([sys.executable, "-s", "-c", script], env=env)
     assert out.decode().rstrip() == "[1, 1]"
-
 
 @pytest.mark.slow
 @pytest.mark.crdb("skip")
@@ -535,7 +519,6 @@ def test_concurrent_close(dsn, conn):
         # )
         # assert not cur.fetchone()
         assert t - t0 < 2
-
 
 @pytest.mark.parametrize("what", ["commit", "rollback", "error"])
 def test_transaction_concurrency(conn, what):
@@ -579,7 +562,6 @@ def test_transaction_concurrency(conn, what):
     t1.join()
     evs[2].set()
     t2.join()
-
 
 @pytest.mark.slow
 @pytest.mark.subprocess

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -359,6 +359,68 @@ with psycopg.connect({dsn!r}, application_name={APPNAME!r}) as conn:
     assert t1 - t0 < 1.0
 
 
+
+
+@pytest.mark.subprocess
+def test_systemexit_handler_cancels_query(conn, dsn):
+    """A SystemExit raised while waiting on a query must trigger the same
+    best-effort server-side cancel as Ctrl-C (issue #1384)."""
+    conn.autocommit = True
+
+    APPNAME = "test_systemexit_handler"
+    script = f"""\
+import signal, sys, psycopg
+
+def handler(signum, frame):
+    raise SystemExit(3)
+
+signal.signal(signal.SIGINT, handler)
+with psycopg.connect({dsn!r}, application_name={APPNAME!r}) as conn:
+    conn.execute("select pg_sleep(60)")
+"""
+
+    if sys.platform == "win32":
+        creationflags = sp.CREATE_NEW_PROCESS_GROUP
+        sig = signal.CTRL_C_EVENT
+    else:
+        creationflags = 0
+        sig = signal.SIGINT
+
+    proc = None
+
+    def run_process():
+        nonlocal proc
+        proc = sp.Popen(
+            [sys.executable, "-s", "-c", script], creationflags=creationflags
+        )
+        proc.communicate()
+
+    t = threading.Thread(target=run_process)
+    t.start()
+
+    for i in range(20):
+        cur = conn.execute(
+            "select pid from pg_stat_activity where application_name = %s", (APPNAME,)
+        )
+        if rec := cur.fetchone():
+            pid = rec[0]
+            break
+        time.sleep(0.1)
+    else:
+        assert False, "process didn't start?"
+
+    proc.send_signal(sig)
+    proc.wait()
+
+    # without the fix the child exits via SystemExit but skips the server-side
+    # cancel, leaving pg_sleep running for the full 60 s
+    for i in range(20):
+        cur = conn.execute("select 1 from pg_stat_activity where pid = %s", (pid,))
+        if not cur.fetchone():
+            break
+        time.sleep(0.1)
+    else:
+        assert False, "query not cancelled after SystemExit"
 @pytest.mark.slow
 @pytest.mark.subprocess
 @pytest.mark.parametrize("itimername, signame", [("ITIMER_REAL", "SIGALRM")])

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -2,21 +2,20 @@
 Tests dealing with concurrency issues.
 """
 
-import multiprocessing
 import os
+import sys
+import time
 import queue
 import signal
-import subprocess as sp
-import sys
 import threading
-import time
+import subprocess as sp
+import multiprocessing
 
 import pytest
-from psycopg.conninfo import conninfo_to_dict, make_conninfo
 
 import psycopg
 from psycopg import errors as e
-
+from psycopg.conninfo import conninfo_to_dict, make_conninfo
 
 @pytest.mark.slow
 def test_concurrent_execution(conn_cls, dsn):

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -2,20 +2,21 @@
 Tests dealing with concurrency issues.
 """
 
+import multiprocessing
 import os
-import sys
-import time
 import queue
 import signal
-import threading
 import subprocess as sp
-import multiprocessing
+import sys
+import threading
+import time
 
 import pytest
+from psycopg.conninfo import conninfo_to_dict, make_conninfo
 
 import psycopg
 from psycopg import errors as e
-from psycopg.conninfo import conninfo_to_dict, make_conninfo
+
 
 @pytest.mark.slow
 def test_concurrent_execution(conn_cls, dsn):
@@ -34,6 +35,7 @@ def test_concurrent_execution(conn_cls, dsn):
     t1.join()
     t2.join()
     assert time.time() - t0 < 0.8, "something broken in concurrency"
+
 
 @pytest.mark.slow
 def test_commit_concurrency(conn):
@@ -60,6 +62,7 @@ def test_commit_concurrency(conn):
     t1.join()
 
     assert notices.empty(), "%d notices raised" % notices.qsize()
+
 
 @pytest.mark.slow
 @pytest.mark.subprocess
@@ -102,6 +105,7 @@ t.join()
         [sys.executable, "-c", script], stderr=sp.STDOUT, env=env
     ).decode("utf8", "replace")
     assert out == "", out.strip().splitlines()[-1]
+
 
 @pytest.mark.slow
 @pytest.mark.timing
@@ -148,12 +152,14 @@ def test_notifies(conn_cls, conn, dsn):
 
     t.join()
 
+
 def canceller(conn, errors):
     try:
         time.sleep(0.5)
         conn.cancel()
     except Exception as exc:
         errors.append(exc)
+
 
 @pytest.mark.slow
 @pytest.mark.crdb_skip("cancel")
@@ -177,6 +183,7 @@ def test_cancel(conn):
     assert cur.execute("select 1").fetchone()[0] == 1
 
     t.join()
+
 
 @pytest.mark.slow
 @pytest.mark.crdb_skip("cancel")
@@ -202,6 +209,7 @@ def test_cancel_stream(conn):
 
     t.join()
 
+
 @pytest.mark.crdb_skip("pg_terminate_backend")
 @pytest.mark.slow
 @pytest.mark.timing
@@ -226,6 +234,7 @@ def test_identify_closure(conn_cls, dsn):
     finally:
         conn.close()
         conn2.close()
+
 
 @pytest.mark.slow
 @pytest.mark.subprocess
@@ -283,6 +292,7 @@ with psycopg.connect({dsn!r}) as conn:
     t = time.time() - t0
     assert proc.returncode == 0
     assert 1 < t < 2
+
 
 @pytest.mark.slow
 @pytest.mark.subprocess
@@ -348,6 +358,7 @@ with psycopg.connect({dsn!r}, application_name={APPNAME!r}) as conn:
     t1 = time.time()
     assert t1 - t0 < 1.0
 
+
 @pytest.mark.subprocess
 def test_systemexit_handler_cancels_query(conn, dsn):
     """A SystemExit raised while waiting on a query must trigger the same
@@ -409,6 +420,8 @@ with psycopg.connect({dsn!r}, application_name={APPNAME!r}) as conn:
         time.sleep(0.1)
     else:
         assert False, "query not cancelled after SystemExit"
+
+
 @pytest.mark.slow
 @pytest.mark.subprocess
 @pytest.mark.parametrize("itimername, signame", [("ITIMER_REAL", "SIGALRM")])
@@ -449,6 +462,7 @@ with psycopg.connect({dsn!r}) as conn:
     ), f"script terminated with {signal.Signals(abs(cp.returncode)).name}"
     assert cp.stdout.rstrip() == "ok"
 
+
 @pytest.mark.slow
 @pytest.mark.subprocess
 @pytest.mark.skipif(
@@ -481,6 +495,7 @@ if __name__ == '__main__':
     env["PYTHONFAULTHANDLER"] = "1"
     out = sp.check_output([sys.executable, "-s", "-c", script], env=env)
     assert out.decode().rstrip() == "[1, 1]"
+
 
 @pytest.mark.slow
 @pytest.mark.crdb("skip")
@@ -520,6 +535,7 @@ def test_concurrent_close(dsn, conn):
         # assert not cur.fetchone()
         assert t - t0 < 2
 
+
 @pytest.mark.parametrize("what", ["commit", "rollback", "error"])
 def test_transaction_concurrency(conn, what):
     conn.autocommit = True
@@ -527,18 +543,17 @@ def test_transaction_concurrency(conn, what):
     evs = [threading.Event() for i in range(3)]
 
     def worker(unlock, wait_on):
-        with pytest.raises(e.ProgrammingError) as ex:
-            with conn.transaction():
-                unlock.set()
-                wait_on.wait()
-                conn.execute("select 1")
+        with pytest.raises(e.ProgrammingError) as ex, conn.transaction():
+            unlock.set()
+            wait_on.wait()
+            conn.execute("select 1")
 
-                if what == "error":
-                    1 / 0
-                elif what == "rollback":
-                    raise psycopg.Rollback()
-                else:
-                    assert what == "commit"
+            if what == "error":
+                1 / 0
+            elif what == "rollback":
+                raise psycopg.Rollback()
+            else:
+                assert what == "commit"
 
         if what == "error":
             assert "transaction rollback" in str(ex.value)
@@ -563,6 +578,7 @@ def test_transaction_concurrency(conn, what):
     evs[2].set()
     t2.join()
 
+
 @pytest.mark.slow
 @pytest.mark.subprocess
 @pytest.mark.skipif(
@@ -576,7 +592,7 @@ def test_break_attempts(dsn, proxy):
         dsn1 = conninfo_to_dict(proxy.client_dsn)
         dsn2 = conninfo_to_dict(dsn)
         dsn = dsn1.copy()
-        for k in "host port hostaddr".split():
+        for k in ["host", "port", "hostaddr"]:
             if k in dsn1 or k in dsn2:
                 dsn[k] = f"{dsn1.get(k) or ''},{dsn2.get(k) or ''}"
         dsn["connect_timeout"] = 3

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -409,6 +409,7 @@ with psycopg.connect({dsn!r}, application_name={APPNAME!r}) as conn:
     else:
         assert False, "process didn't start?"
 
+    assert proc is not None
     proc.send_signal(sig)
     proc.wait()
 


### PR DESCRIPTION
Fixes #1384

`Connection.wait()` caught only `KeyboardInterrupt` to run the best-effort
server-side cancel when a query was in flight, so an interruption delivered as
`SystemExit` (e.g. a custom SIGINT handler calling `sys.exit()`, or explicit
`raise SystemExit` during shutdown paths) skipped the cancel entirely and left
the query running server-side.

## Changes

- `psycopg/psycopg/connection.py`: `_INTERRUPTED` becomes the tuple
  `(KeyboardInterrupt, SystemExit)`. `GeneratorExit` is deliberately **not**
  included — it has special control-flow semantics in generator/async cleanup
  and must keep propagating untouched.
- `tests/test_concurrency.py`: `test_systemexit_handler_cancels_query` mirrors
  the existing `test_ctrl_c` structure: a subprocess installs a SIGINT handler
  that raises `SystemExit`, runs `pg_sleep(60)`, and the test asserts the query
  disappears from `pg_stat_activity` right after the signal (without the fix,
  the child exits via SystemExit but skips the cancel, leaving `pg_sleep`
  running for the full minute).

The integration test requires the PostgreSQL test service, same as its sibling tests.
