### PR TITLE
Upgrade Python version in 3rd party tests

### DIFF
--- a/.github/workflows/3rd-party-tests.yml
+++ b/.github/workflows/3rd-party-tests.yml
@@ -115,7 +115,8 @@ jobs:
         env:
           URL: postgresql+psycopg://postgres:password@127.0.0.1/test
         working-directory: sa_home/sa
-        run: pytest -n 2 -q --dburi $URL --backend-only --dropfirst --color=yes --dbdriver psycopg_async
+        run: pytest -n 8 -q --dburi $URL --dropfirst --color=yes
+          test/dialect/test_suite.py test/dialect/postgresql/ test/ext/asyncio
 
   django:
     # linux should be enough to test if everything works.

--- a/.github/workflows/3rd-party-tests.yml
+++ b/.github/workflows/3rd-party-tests.yml
@@ -29,11 +29,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.13"
-          - "3.10"
+          - "3.14"
+          - "3.11"
         sqlalchemy_label:
-          # what version of sqlalchemy to download is defined in the "include" section below,
-          # in the variable pip_sqlalchemy
+          # what version of sqlalchemy to download is defined in the "include"
+          # section below, in the variable pip_sqlalchemy
           - git_main
           - release
         impl:
@@ -51,10 +51,11 @@ jobs:
 
     services:
       postgresql:
-        image: postgres:15
+        image: postgres:18
         env:
           POSTGRES_PASSWORD: password
           POSTGRES_DB: test
+          POSTGRES_INITDB_ARGS: "-c max_prepared_transactions=10"
         ports:
           - 5432:5432
         # Wait until postgres has started
@@ -154,13 +155,13 @@ jobs:
             python-version: "3.10"
           - django_label: lts5
             impl: python
-            python-version: "3.13"
+            python-version: "3.14"
           - django_label: git_main
             impl: c
-            python-version: "3.13"
+            python-version: "3.14"
           - django_label: git_main
             impl: python
-            python-version: "3.12"
+            python-version: "3.13"
 
     env:
       DEPS: ./psycopg ./psycopg_pool

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -121,6 +121,9 @@ When a new Python major version is released
 - Add the new version to the relevant test matrices in
   ``.github/workflows/tests.yml`` and ``.github/workflows/packages-bin.yml``.
 
+- Move the upper bounds of the Python version to test in 3rd party tests, in
+  ``.github/workflows/3rd-party-tests.yml``.
+
 - Update ``docs/basic/install.rst`` with the correct range of supported Python
   versions.
 


### PR DESCRIPTION
The change was driven by SQLAlchemy dropping support for Python 3.10.

Something else is failing now: opening a MR to ask the SA devs.