### PR TITLE
fix(isort-psycopg): make psycosort compatible with isort >= 9

### DIFF
--- a/tools/isort-psycopg/isort_psycopg.py
+++ b/tools/isort-psycopg/isort_psycopg.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import re
-import inspect
 from typing import Any
 from collections.abc import Callable, Iterable
 
@@ -15,12 +14,10 @@ def psycosort(
     key: Callable[[str], Any] | None = None,
     reverse: bool = False,
 ) -> list[str]:
-    # Sniff whether we are sorting an import list (from module import a, b, c)
-    # or a list of modules.
-    # Tested with isort 6.0. It might break in the future!
-    is_from_import = any(
-        f for f in inspect.stack() if f.function == "_with_from_imports"
-    )
+    # isort feeds the objects of a `from module import a, b, c` list as a
+    # list, while the module lists (`import a`, `from a import`) are fed as
+    # dicts.
+    is_from_import = isinstance(to_sort, list)
 
     new_key: Callable[[str], Any] | None
     if is_from_import:

--- a/tools/isort-psycopg/pyproject.toml
+++ b/tools/isort-psycopg/pyproject.toml
@@ -8,7 +8,7 @@ description = "isort plug-in to sort imports by module length first"
 # Note: to release a new version:
 # python -m build -o dist --wheel .
 # twine upload dist/isort_psycopg-*-py3-none-any.whl
-version = "0.0.2"
+version = "0.0.3"
 
 [project.urls]
 Code = "https://github.com/psycopg/psycopg/tree/master/tools/isort-psycopg"


### PR DESCRIPTION
Split out from #1394 at @dvarrazzo's request, keeping attribution clean.

**Root cause.** `psycosort` used to tell `from module import a, b, c` object lists apart from `import module` module lists by walking `inspect.stack()` to find the caller frame. isort 9 is Cython-compiled and hides those intermediate frames, so the heuristic silently misclassified the two kinds of input and the psycopg import-style sort broke.

**Fix.** The two inputs are already distinguishable by type: isort feeds the object list as a `list` and the module lists as `dict`s, so we branch on `isinstance(to_sort, list)` instead of introspecting the call stack. This works on isort 6/8/9 (verified by @dvarrazzo) and removes the Cython-frames assumption entirely.

**Scope of this PR.** Only `isort_psycopg.py` + the version bump to `0.0.3` (so the revised plug-in can be released to PyPI). The repo-wide `pyproject.toml` note and the temporary `lint.yml` pin from #1394 are intentionally dropped here per review.

Closes the isort-9 breakage discussed in #1394.