### PR TITLE
fix: cancel in-flight query on SystemExit in Connection.wait

### DIFF
--- a/psycopg/psycopg/connection.py
+++ b/psycopg/psycopg/connection.py
@@ -50,7 +50,7 @@ IDLE = pq.TransactionStatus.IDLE
 ACTIVE = pq.TransactionStatus.ACTIVE
 INTRANS = pq.TransactionStatus.INTRANS
 
-_INTERRUPTED = KeyboardInterrupt
+_INTERRUPTED = (KeyboardInterrupt, SystemExit)
 
 logger = logging.getLogger("psycopg")
 

--- a/psycopg/psycopg/connection_async.py
+++ b/psycopg/psycopg/connection_async.py
@@ -52,9 +52,9 @@ ACTIVE = pq.TransactionStatus.ACTIVE
 INTRANS = pq.TransactionStatus.INTRANS
 
 if True:  # ASYNC
-    _INTERRUPTED = (asyncio.CancelledError, KeyboardInterrupt)
+    _INTERRUPTED = (asyncio.CancelledError, KeyboardInterrupt, SystemExit)
 else:
-    _INTERRUPTED = KeyboardInterrupt
+    _INTERRUPTED = (KeyboardInterrupt, SystemExit)
 
 logger = logging.getLogger("psycopg")
 

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -565,3 +565,57 @@ def test_break_attempts(dsn, proxy):
     assert proc.returncode != 0
     assert "KeyboardInterrupt" in stderr
     assert stdout == ""
+
+
+def test_wait_systemexit_cancels_active(monkeypatch):
+    # SystemExit (e.g. Celery SIGTERM / sys.exit) must cancel like KeyboardInterrupt.
+    from unittest.mock import Mock
+
+    pgconn = Mock()
+    pgconn.transaction_status = psycopg.pq.TransactionStatus.ACTIVE
+    pgconn.socket = 1
+
+    conn = psycopg.Connection(pgconn)
+    conn._closed = True  # avoid ResourceWarning from an unfinished mock connection
+    cancelled = []
+
+    def fake_wait(*args, **kwargs):
+        raise SystemExit(15)
+
+    def fake_cancel(*, timeout=None):
+        cancelled.append(timeout)
+
+    monkeypatch.setattr(psycopg.waiting, "wait", fake_wait)
+    monkeypatch.setattr(conn, "_try_cancel", fake_cancel)
+
+    with pytest.raises(SystemExit) as ex:
+        conn.wait(iter(()))
+
+    assert ex.value.code == 15
+    assert cancelled == [5.0]
+
+
+def test_wait_systemexit_idle_does_not_cancel(monkeypatch):
+    from unittest.mock import Mock
+
+    pgconn = Mock()
+    pgconn.transaction_status = psycopg.pq.TransactionStatus.IDLE
+    pgconn.socket = 1
+
+    conn = psycopg.Connection(pgconn)
+    conn._closed = True
+    cancelled = []
+
+    def fake_wait(*args, **kwargs):
+        raise SystemExit(1)
+
+    def fake_cancel(*, timeout=None):
+        cancelled.append(timeout)
+
+    monkeypatch.setattr(psycopg.waiting, "wait", fake_wait)
+    monkeypatch.setattr(conn, "_try_cancel", fake_cancel)
+
+    with pytest.raises(SystemExit):
+        conn.wait(iter(()))
+
+    assert cancelled == []

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -573,10 +573,10 @@ def test_wait_systemexit_cancels_active(monkeypatch):
 
     pgconn = Mock()
     pgconn.transaction_status = psycopg.pq.TransactionStatus.ACTIVE
+    pgconn.status = psycopg.pq.ConnStatus.BAD
     pgconn.socket = 1
 
     conn = psycopg.Connection(pgconn)
-    conn._closed = True  # avoid ResourceWarning from an unfinished mock connection
     cancelled = []
 
     def fake_wait(*args, **kwargs):
@@ -600,10 +600,10 @@ def test_wait_systemexit_idle_does_not_cancel(monkeypatch):
 
     pgconn = Mock()
     pgconn.transaction_status = psycopg.pq.TransactionStatus.IDLE
+    pgconn.status = psycopg.pq.ConnStatus.BAD
     pgconn.socket = 1
 
     conn = psycopg.Connection(pgconn)
-    conn._closed = True
     cancelled = []
 
     def fake_wait(*args, **kwargs):

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -567,6 +567,11 @@ def test_break_attempts(dsn, proxy):
     assert stdout == ""
 
 
+def _empty_pqgen():
+    yield from ()
+    return
+
+
 def test_wait_systemexit_cancels_active(monkeypatch):
     # SystemExit (e.g. Celery SIGTERM / sys.exit) must cancel like KeyboardInterrupt.
     from unittest.mock import Mock
@@ -589,7 +594,7 @@ def test_wait_systemexit_cancels_active(monkeypatch):
     monkeypatch.setattr(conn, "_try_cancel", fake_cancel)
 
     with pytest.raises(SystemExit) as ex:
-        conn.wait(iter(()))
+        conn.wait(_empty_pqgen())
 
     assert ex.value.code == 15
     assert cancelled == [5.0]
@@ -616,6 +621,6 @@ def test_wait_systemexit_idle_does_not_cancel(monkeypatch):
     monkeypatch.setattr(conn, "_try_cancel", fake_cancel)
 
     with pytest.raises(SystemExit):
-        conn.wait(iter(()))
+        conn.wait(_empty_pqgen())
 
     assert cancelled == []

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -361,6 +361,77 @@ with psycopg.connect({dsn!r}, application_name={APPNAME!r}) as conn:
 
 @pytest.mark.slow
 @pytest.mark.subprocess
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="don't know how to Ctrl-C on Windows"
+)
+@pytest.mark.crdb("skip")
+def test_systemexit_cancels_query(conn, dsn):
+    # SIGINT mapped to SystemExit must still cancel the in-flight query (#1384).
+    conn.autocommit = True
+
+    APPNAME = "test_systemexit_cancels_query"
+    script = f"""\
+import signal
+import psycopg
+
+def handler(signum, frame):
+    raise SystemExit(3)
+
+signal.signal(signal.SIGINT, handler)
+with psycopg.connect({dsn!r}, application_name={APPNAME!r}) as conn:
+    conn.execute("select pg_sleep(60)")
+"""
+
+    if sys.platform == "win32":
+        creationflags = sp.CREATE_NEW_PROCESS_GROUP
+        sig = signal.CTRL_C_EVENT
+    else:
+        creationflags = 0
+        sig = signal.SIGINT
+
+    proc = None
+
+    def run_process():
+        nonlocal proc
+        proc = sp.Popen(
+            [sys.executable, "-s", "-c", script], creationflags=creationflags
+        )
+        proc.communicate()
+
+    t = threading.Thread(target=run_process)
+    t.start()
+
+    for i in range(20):
+        cur = conn.execute(
+            "select pid from pg_stat_activity where application_name = %s", (APPNAME,)
+        )
+
+        if rec := cur.fetchone():
+            pid = rec[0]
+            break
+        time.sleep(0.1)
+    else:
+        assert False, "process didn't start?"
+
+    t0 = time.time()
+    assert proc
+    proc.send_signal(sig)
+    proc.wait()
+
+    for i in range(20):
+        cur = conn.execute("select 1 from pg_stat_activity where pid = %s", (pid,))
+        if not cur.fetchone():
+            break
+        time.sleep(0.1)
+    else:
+        assert False, "process didn't stop?"
+
+    t1 = time.time()
+    assert t1 - t0 < 1.0
+
+
+@pytest.mark.slow
+@pytest.mark.subprocess
 @pytest.mark.parametrize("itimername, signame", [("ITIMER_REAL", "SIGALRM")])
 def test_eintr(dsn, itimername, signame):
     try:
@@ -565,62 +636,3 @@ def test_break_attempts(dsn, proxy):
     assert proc.returncode != 0
     assert "KeyboardInterrupt" in stderr
     assert stdout == ""
-
-
-def _empty_pqgen():
-    yield from ()
-    return
-
-
-def test_wait_systemexit_cancels_active(monkeypatch):
-    # SystemExit (e.g. Celery SIGTERM / sys.exit) must cancel like KeyboardInterrupt.
-    from unittest.mock import Mock
-
-    pgconn = Mock()
-    pgconn.transaction_status = psycopg.pq.TransactionStatus.ACTIVE
-    pgconn.status = psycopg.pq.ConnStatus.BAD
-    pgconn.socket = 1
-
-    conn = psycopg.Connection(pgconn)
-    cancelled = []
-
-    def fake_wait(*args, **kwargs):
-        raise SystemExit(15)
-
-    def fake_cancel(*, timeout=None):
-        cancelled.append(timeout)
-
-    monkeypatch.setattr(psycopg.waiting, "wait", fake_wait)
-    monkeypatch.setattr(conn, "_try_cancel", fake_cancel)
-
-    with pytest.raises(SystemExit) as ex:
-        conn.wait(_empty_pqgen())
-
-    assert ex.value.code == 15
-    assert cancelled == [5.0]
-
-
-def test_wait_systemexit_idle_does_not_cancel(monkeypatch):
-    from unittest.mock import Mock
-
-    pgconn = Mock()
-    pgconn.transaction_status = psycopg.pq.TransactionStatus.IDLE
-    pgconn.status = psycopg.pq.ConnStatus.BAD
-    pgconn.socket = 1
-
-    conn = psycopg.Connection(pgconn)
-    cancelled = []
-
-    def fake_wait(*args, **kwargs):
-        raise SystemExit(1)
-
-    def fake_cancel(*, timeout=None):
-        cancelled.append(timeout)
-
-    monkeypatch.setattr(psycopg.waiting, "wait", fake_wait)
-    monkeypatch.setattr(conn, "_try_cancel", fake_cancel)
-
-    with pytest.raises(SystemExit):
-        conn.wait(_empty_pqgen())
-
-    assert cancelled == []

--- a/tests/test_concurrency_async.py
+++ b/tests/test_concurrency_async.py
@@ -479,3 +479,57 @@ if __name__ == "__main__":
 """
 
     sp.run([sys.executable, "-s"], input=script, text=True, check=True)
+
+
+async def test_wait_systemexit_cancels_active(monkeypatch):
+    # SystemExit (e.g. Celery SIGTERM / sys.exit) must cancel like KeyboardInterrupt.
+    from unittest.mock import Mock
+
+    pgconn = Mock()
+    pgconn.transaction_status = psycopg.pq.TransactionStatus.ACTIVE
+    pgconn.socket = 1
+
+    conn = psycopg.AsyncConnection(pgconn)
+    conn._closed = True  # avoid ResourceWarning from an unfinished mock connection
+    cancelled = []
+
+    async def fake_wait(*args, **kwargs):
+        raise SystemExit(15)
+
+    async def fake_cancel(*, timeout=None):
+        cancelled.append(timeout)
+
+    monkeypatch.setattr(psycopg.waiting, "wait_async", fake_wait)
+    monkeypatch.setattr(conn, "_try_cancel", fake_cancel)
+
+    with pytest.raises(SystemExit) as ex:
+        await conn.wait(iter(()))
+
+    assert ex.value.code == 15
+    assert cancelled == [5.0]
+
+
+async def test_wait_systemexit_idle_does_not_cancel(monkeypatch):
+    from unittest.mock import Mock
+
+    pgconn = Mock()
+    pgconn.transaction_status = psycopg.pq.TransactionStatus.IDLE
+    pgconn.socket = 1
+
+    conn = psycopg.AsyncConnection(pgconn)
+    conn._closed = True
+    cancelled = []
+
+    async def fake_wait(*args, **kwargs):
+        raise SystemExit(1)
+
+    async def fake_cancel(*, timeout=None):
+        cancelled.append(timeout)
+
+    monkeypatch.setattr(psycopg.waiting, "wait_async", fake_wait)
+    monkeypatch.setattr(conn, "_try_cancel", fake_cancel)
+
+    with pytest.raises(SystemExit):
+        await conn.wait(iter(()))
+
+    assert cancelled == []

--- a/tests/test_concurrency_async.py
+++ b/tests/test_concurrency_async.py
@@ -481,16 +481,16 @@ if __name__ == "__main__":
     sp.run([sys.executable, "-s"], input=script, text=True, check=True)
 
 
-async def test_wait_systemexit_cancels_active(monkeypatch):
+async def test_wait_systemexit_cancels_active(monkeypatch, anyio_backend):
     # SystemExit (e.g. Celery SIGTERM / sys.exit) must cancel like KeyboardInterrupt.
     from unittest.mock import Mock
 
     pgconn = Mock()
     pgconn.transaction_status = psycopg.pq.TransactionStatus.ACTIVE
+    pgconn.status = psycopg.pq.ConnStatus.BAD
     pgconn.socket = 1
 
     conn = psycopg.AsyncConnection(pgconn)
-    conn._closed = True  # avoid ResourceWarning from an unfinished mock connection
     cancelled = []
 
     async def fake_wait(*args, **kwargs):
@@ -509,15 +509,15 @@ async def test_wait_systemexit_cancels_active(monkeypatch):
     assert cancelled == [5.0]
 
 
-async def test_wait_systemexit_idle_does_not_cancel(monkeypatch):
+async def test_wait_systemexit_idle_does_not_cancel(monkeypatch, anyio_backend):
     from unittest.mock import Mock
 
     pgconn = Mock()
     pgconn.transaction_status = psycopg.pq.TransactionStatus.IDLE
+    pgconn.status = psycopg.pq.ConnStatus.BAD
     pgconn.socket = 1
 
     conn = psycopg.AsyncConnection(pgconn)
-    conn._closed = True
     cancelled = []
 
     async def fake_wait(*args, **kwargs):

--- a/tests/test_concurrency_async.py
+++ b/tests/test_concurrency_async.py
@@ -274,6 +274,85 @@ asyncio.run(main())
 
 @pytest.mark.slow
 @pytest.mark.subprocess
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="don't know how to Ctrl-C on Windows"
+)
+@pytest.mark.crdb("skip")
+def test_systemexit_cancels_query(conn, dsn):
+    # SIGINT mapped to SystemExit must still cancel the in-flight query (#1384).
+    conn.autocommit = True
+
+    APPNAME = "test_systemexit_cancels_query_async"
+    script = f"""\
+import signal
+import asyncio
+import psycopg
+
+def handler(signum, frame):
+    raise SystemExit(3)
+
+signal.signal(signal.SIGINT, handler)
+
+async def main():
+    async with await psycopg.AsyncConnection.connect(
+        {dsn!r}, application_name={APPNAME!r}
+    ) as conn:
+        await conn.execute("select pg_sleep(60)")
+
+asyncio.run(main())
+"""
+    if sys.platform == "win32":
+        creationflags = sp.CREATE_NEW_PROCESS_GROUP
+        sig = signal.CTRL_C_EVENT
+    else:
+        creationflags = 0
+        sig = signal.SIGINT
+
+    proc = None
+
+    def run_process():
+        nonlocal proc
+        proc = sp.Popen(
+            [sys.executable, "-s", "-c", script],
+            creationflags=creationflags,
+            stderr=sp.PIPE,
+        )
+        proc.communicate()
+
+    t = threading.Thread(target=run_process)
+    t.start()
+
+    for i in range(20):
+        cur = conn.execute(
+            "select pid from pg_stat_activity where application_name = %s", (APPNAME,)
+        )
+
+        if rec := cur.fetchone():
+            pid = rec[0]
+            break
+        time.sleep(0.1)
+    else:
+        assert False, "process didn't start?"
+
+    t0 = time.time()
+    assert proc
+    proc.send_signal(sig)
+    proc.wait()
+
+    for i in range(20):
+        cur = conn.execute("select 1 from pg_stat_activity where pid = %s", (pid,))
+        if not cur.fetchone():
+            break
+        time.sleep(0.1)
+    else:
+        assert False, "process didn't stop?"
+
+    t1 = time.time()
+    assert t1 - t0 < 1.0
+
+
+@pytest.mark.slow
+@pytest.mark.subprocess
 @pytest.mark.parametrize("itimername, signame", [("ITIMER_REAL", "SIGALRM")])
 def test_eintr(dsn, itimername, signame):
     try:
@@ -479,62 +558,3 @@ if __name__ == "__main__":
 """
 
     sp.run([sys.executable, "-s"], input=script, text=True, check=True)
-
-
-def _empty_pqgen():
-    yield from ()
-    return
-
-
-async def test_wait_systemexit_cancels_active(monkeypatch, anyio_backend):
-    # SystemExit (e.g. Celery SIGTERM / sys.exit) must cancel like KeyboardInterrupt.
-    from unittest.mock import Mock
-
-    pgconn = Mock()
-    pgconn.transaction_status = psycopg.pq.TransactionStatus.ACTIVE
-    pgconn.status = psycopg.pq.ConnStatus.BAD
-    pgconn.socket = 1
-
-    conn = psycopg.AsyncConnection(pgconn)
-    cancelled = []
-
-    async def fake_wait(*args, **kwargs):
-        raise SystemExit(15)
-
-    async def fake_cancel(*, timeout=None):
-        cancelled.append(timeout)
-
-    monkeypatch.setattr(psycopg.waiting, "wait_async", fake_wait)
-    monkeypatch.setattr(conn, "_try_cancel", fake_cancel)
-
-    with pytest.raises(SystemExit) as ex:
-        await conn.wait(_empty_pqgen())
-
-    assert ex.value.code == 15
-    assert cancelled == [5.0]
-
-
-async def test_wait_systemexit_idle_does_not_cancel(monkeypatch, anyio_backend):
-    from unittest.mock import Mock
-
-    pgconn = Mock()
-    pgconn.transaction_status = psycopg.pq.TransactionStatus.IDLE
-    pgconn.status = psycopg.pq.ConnStatus.BAD
-    pgconn.socket = 1
-
-    conn = psycopg.AsyncConnection(pgconn)
-    cancelled = []
-
-    async def fake_wait(*args, **kwargs):
-        raise SystemExit(1)
-
-    async def fake_cancel(*, timeout=None):
-        cancelled.append(timeout)
-
-    monkeypatch.setattr(psycopg.waiting, "wait_async", fake_wait)
-    monkeypatch.setattr(conn, "_try_cancel", fake_cancel)
-
-    with pytest.raises(SystemExit):
-        await conn.wait(_empty_pqgen())
-
-    assert cancelled == []

--- a/tests/test_concurrency_async.py
+++ b/tests/test_concurrency_async.py
@@ -481,6 +481,11 @@ if __name__ == "__main__":
     sp.run([sys.executable, "-s"], input=script, text=True, check=True)
 
 
+def _empty_pqgen():
+    yield from ()
+    return
+
+
 async def test_wait_systemexit_cancels_active(monkeypatch, anyio_backend):
     # SystemExit (e.g. Celery SIGTERM / sys.exit) must cancel like KeyboardInterrupt.
     from unittest.mock import Mock
@@ -503,7 +508,7 @@ async def test_wait_systemexit_cancels_active(monkeypatch, anyio_backend):
     monkeypatch.setattr(conn, "_try_cancel", fake_cancel)
 
     with pytest.raises(SystemExit) as ex:
-        await conn.wait(iter(()))
+        await conn.wait(_empty_pqgen())
 
     assert ex.value.code == 15
     assert cancelled == [5.0]
@@ -530,6 +535,6 @@ async def test_wait_systemexit_idle_does_not_cancel(monkeypatch, anyio_backend):
     monkeypatch.setattr(conn, "_try_cancel", fake_cancel)
 
     with pytest.raises(SystemExit):
-        await conn.wait(iter(()))
+        await conn.wait(_empty_pqgen())
 
     assert cancelled == []


### PR DESCRIPTION
Connection.wait() only treated KeyboardInterrupt as an interruption. On Ctrl-C it best-effort cancels an in-flight query when the connection is ACTIVE, then re-raises. SystemExit (Celery SIGTERM, sys.exit(), process shutdown) skipped that path, so the server query could keep running and leave the connection stuck in ACTIVE.

This change widens _INTERRUPTED to (KeyboardInterrupt, SystemExit) on the sync connection, and adds SystemExit to the existing async tuple (CancelledError, KeyboardInterrupt). The handler is unchanged: cancel if ACTIVE, then re-raise. SystemExit is not swallowed. BaseException is not caught broadly. GeneratorExit is not included.

Regression tests raise SystemExit from the mocked wait path (no live Postgres): they assert _try_cancel is called when ACTIVE, is not called when IDLE, and that SystemExit still propagates. KeyboardInterrupt handling is unchanged.

Fixes #1384